### PR TITLE
修改所有发送到微信的api

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1882,7 +1882,7 @@ def viewActivity(request, aid=None):
         ):
             return redirect(f"/addActivities/?edit=True&aid={aid}")
         if activity.status == activity.Status.WAITING:
-            if start + timedelta(hours=1) > datetime.now():
+            if start_time + timedelta(hours=1) > datetime.now():
                 html_display["warn_code"] = 1
                 html_display["warn_message"] = f"活动即将开始, 不能修改活动。"
                 return render(request, "activity_info.html", locals())
@@ -2062,9 +2062,9 @@ def getActivityInfo(request):
         else:
             # get participants
             # are you sure it's 'Paticipant' not 'Participant' ??
-            paticipants = Paticipant.objects.filter(activity_id=activity_id)
-            paticipants = paticipants.filter(
-                status=Paticipant.AttendStatus.APLLYSUCCESS
+            participants = Participant.objects.filter(activity_id=activity_id)
+            participants = participants.filter(
+                status=Participant.AttendStatus.APLLYSUCCESS
             )
 
             # get required fields
@@ -2082,7 +2082,7 @@ def getActivityInfo(request):
             filename = f"{activity_id}-{info_type}-{output}"
             content = map(
                 lambda paticipant: map(
-                    lambda key: paticipant[key], fields), paticipants
+                    lambda key: paticipant[key], fields), participants
             )
 
             format = request.GET.get("format", "csv")

--- a/app/views.py
+++ b/app/views.py
@@ -2452,7 +2452,7 @@ def apply_position(request, oid=None):
         Notification.Type.NEEDREAD,
         Notification.Title.POSITION_INFORM,
         contents[0],
-        URL=None,
+        "/personnelMobilization/",
 
         publish_to_wechat=True, # 不要复制这个参数，先去看函数说明
     )

--- a/app/wechat_send.py
+++ b/app/wechat_send.py
@@ -37,7 +37,7 @@ if USE_SCHEDULER:
 
 # 全局变量 用来发送和确认默认的导航网址
 default_url = settings.LOGIN_URL
-this_url = local_dict["url"].get("this_url", '')    # 增加默认url前缀
+this_url = settings.LOGIN_URL                       # 增加默认url前缀
 if this_url[-1:] == '/' and this_url[-2:] != '//':
     this_url = this_url[:-1]                        # 去除尾部的/
 wechat_url = local_dict["url"]["wechat_url"]

--- a/app/wechat_send.py
+++ b/app/wechat_send.py
@@ -1,4 +1,3 @@
-from django.dispatch.dispatcher import receiver
 import requests
 import json
 
@@ -8,16 +7,17 @@ from boottest import local_dict
 
 # 模型与加密模型
 from app.models import NaturalPerson, Activity, Notification
+from app.views import get_person_or_org     # 获取名称
 from boottest.hasher import MyMD5PasswordHasher, MySHA256Hasher
 
 # 日期与定时任务
 from datetime import datetime, timedelta
-from apscheduler.schedulers.background import BackgroundScheduler
-#from django_apscheduler.jobstores import DjangoJobStore
 
 # 全局设置
 # 是否启用定时任务，请最好仅在服务器启用，如果不启用，后面的多个设置也会随之变化
-USE_SCHEDULER = False
+USE_SCHEDULER = True
+try:USE_SCHEDULER = bool(local_dict['config']['wechat_send']['use_scheduler'])
+except:pass
 # 是否多线程发送，必须启用scheduler，如果启用则发送时无需等待
 USE_MULTITHREAD = True if USE_SCHEDULER else False
 # 决定单次连接的超时时间，响应时间一般为1s或12s（偶尔），建议考虑前端等待时间放弃12s
@@ -27,11 +27,19 @@ TIMEOUT = 15 if USE_MULTITHREAD else 5 or 3.05 or 12 or 15
 RETRY = False
 
 if USE_SCHEDULER:
-    scheduler = BackgroundScheduler()
-    scheduler.add_jobstore(DjangoJobStore(), "default")
+    try:
+        from app.scheduler_func import scheduler
+    except:
+        from apscheduler.schedulers.background import BackgroundScheduler
+        from django_apscheduler.jobstores import DjangoJobStore
+        scheduler = BackgroundScheduler()
+        scheduler.add_jobstore(DjangoJobStore(), "default")
 
 # 全局变量 用来发送和确认默认的导航网址
 default_url = settings.LOGIN_URL
+this_url = local_dict["url"].get("this_url", '')    # 增加默认url前缀
+if this_url[-1:] == '/' and this_url[-2:] != '//':
+    this_url = this_url[:-1]                        # 去除尾部的/
 wechat_url = local_dict["url"]["wechat_url"]
 wechat_coder = MySHA256Hasher(local_dict["hash"]["wechat"])
 
@@ -51,6 +59,8 @@ def base_send_wechat(users, message, card=True, url=None, btntxt=None, default=T
             post_data["btntxt"] = btntxt if btntxt is not None else "详情"
         else:
             if url is not None:
+                if url[:1] in ['', '/']:    # 空或者相对路径，变为绝对路径
+                    url = this_url + url
                 post_data["url"] = url
             if btntxt is not None:
                 post_data["btntxt"] = btntxt
@@ -78,19 +88,25 @@ def base_send_wechat(users, message, card=True, url=None, btntxt=None, default=T
         print(f"向企业微信发送失败：失败用户：{failed[:3]}等{len(failed)}人，主要失败原因：{errmsg}")
 
 
-def publish_notification(notification_id):
-    '''根据通知id（实际是主键）向通知的receiver发送'''
+def publish_notification(notification_or_id):
+    '''
+    根据单个通知或id（实际是主键）向通知的receiver发送
+    别创建了好多通知然后循环调用这个，之后会出批量发送的
+    '''
     try:
-        notification = Notification.objects.get(pk=notification_id)
+        if isinstance(notification_or_id, Notification):
+            notification = notification_or_id
+        else:
+            notification = Notification.objects.get(pk=notification_or_id)
     except:
-        print(f"未找到id为{notification_id}的通知")
+        print(f"未找到id为{notification_or_id}的通知")
         return False
-    sender = NaturalPerson.objects.get(person_id=notification.sender)
+    sender = get_person_or_org(notification.sender) # 也可能是组织
     send_time = notification.start_time
     timeformat = "%Y年%m月%d日 %H:%M"   
     send_time = send_time.strftime(timeformat)
 
-    if len(notification.content) < 120:         # 卡片类型消息最多显示256字（512字节）
+    if len(notification.content) < 120:         # 卡片类型消息最多显示256字节
         kws = {"card": True}                    # 因留白等原因，内容120字左右就超出了
         message = "\n".join((
             notification.get_title_display(),
@@ -116,20 +132,32 @@ def publish_notification(notification_id):
             notification.content
         ))
         if notification.URL:
-            message += f"\n<a href=\"{notification.URL}\">阅读原文</a>"
+            message += f"\n\n<a href=\"{notification.URL}\">阅读原文</a>"
         else:
-            message += f"\n<a href=\"{default_url}\">点击查看详情</a>"
-    base_send_wechat([notification.receiver.username],
-                     message, **kws)  # 不使用定时任务请改为这句
+            message += f"\n\n<a href=\"{default_url}\">点击查看详情</a>"
+    if USE_MULTITHREAD:
+        # 多线程
+        scheduler.add_job(base_send_wechat, 'date',
+                            args=([notification.receiver.username], message),
+                            kwargs=kws,
+                            next_run_time=datetime.now() + timedelta(seconds=5)
+                            )
+    else:
+        base_send_wechat([notification.receiver.username],
+                            message, **kws) # 不使用定时任务请改为这句
     return True
+publish_notification.ENABLE_INSTANCE = True # 标识接收的参数类型
 
 
-def publish_activity(aid, only_activated=False):
-    '''根据活动id（实际是主键）向所有订阅该组织信息的学生发送，可以只发给在校学生'''
+def publish_activity(activity_or_id, only_activated=False):
+    '''根据活动或id（实际是主键）向所有订阅该组织信息的学生发送，可以只发给在校学生'''
     try:
-        activity = Activity.objects.get(pk=aid)
+        if isinstance(activity_or_id, Activity):
+            activity = activity_or_id
+        else:
+            activity = Activity.objects.get(pk=activity_or_id)
     except:
-        print(f"未找到id为{aid}的活动")
+        print(f"未找到id为{activity_or_id}的活动")
         return False
     org = activity.organization_id
     subcribers = NaturalPerson.objects.difference(
@@ -146,14 +174,16 @@ def publish_activity(aid, only_activated=False):
         timeformat = "%Y年%m月%d日 %H:%M"   # 显示具体年份
     start = start.strftime(timeformat)
     finish = finish.strftime(timeformat)
-    if len(activity.content) < 120:         # 卡片类型消息最多显示256字（512字节）
+    content = activity.introduction if not hasattr(
+        activity, 'content') else activity.content      # 模型发生了改变
+    if len(content) < 120:                  # 卡片类型消息最多显示256字节
         kws = {"card": True}                # 因留白等原因，内容120字左右就超出了
         message = "\n".join((
             activity.title,
             f"组织者：{activity.organization_id.oname}",
             f"活动时间：{start}-{finish}",
             "活动内容：",
-            activity.content,
+            content,
             "点击查看详情"
         ))
         if activity.URL:
@@ -169,12 +199,12 @@ def publish_activity(aid, only_activated=False):
             "活动时间：",
             f"{start}-{finish}",
             "活动简介：",
-            activity.content
+            content
         ))
         if activity.URL:
-            message += f"\n<a href=\"{activity.URL}\">阅读原文</a>"
+            message += f"\n\n<a href=\"{activity.URL}\">阅读原文</a>"
         else:
-            message += f"\n<a href=\"{default_url}\">点击查看详情</a>"
+            message += f"\n\n<a href=\"{default_url}\">点击查看详情</a>"
     for i in range(0, num, 500):
         userids = subcribers[i:i+500]   # 一次最多接受1000个，方便传送只发500个
         if USE_MULTITHREAD:
@@ -187,3 +217,4 @@ def publish_activity(aid, only_activated=False):
         else:
             base_send_wechat(userids, message, **kws)  # 不使用定时任务请改为这句
     return True
+publish_activity.ENABLE_INSTANCE = True     # 标识接收的参数类型


### PR DESCRIPTION
1.默认多线程定时任务，不堵塞（但仍可能修改设置）
2.解耦创建单个通知与单个发送到微信的逻辑（之后的批量创建和发送时会有相关）
3.增加容错，用于将错误的相对路径转化为绝对路径
4.新增notification发送者或接受者为组织时的逻辑
5.限制单次发送量，并加入json设置中
6.新增可选local_json项，路径：`config/wechat_send/[receivers,blacklist,use_scheduler]`，`thresholds/[wechat_budget, activity_budget]`