### PR TITLE
bug修复

### DIFF
--- a/app/activity_utils.py
+++ b/app/activity_utils.py
@@ -169,7 +169,7 @@ def activity_base_check(request, edit=False):
     announcephoto = request.FILES.getlist("images")
     if len(announcephoto) > 0:
         pic = announcephoto[0]
-        if if_image(pic) == False:
+        if if_image(pic)!=2:
             raise ActivityException("上传的附件只支持图片格式。")
     else:
         if request.POST.get("picture1"):

--- a/app/models.py
+++ b/app/models.py
@@ -572,7 +572,7 @@ class Activity(CommentBase):
     need_checkin = models.BooleanField("是否需要签到", default=False)
 
     examine_teacher = models.ForeignKey(NaturalPerson, on_delete=models.CASCADE)
-    # recorded 其实是冗余，但用着方便，存了吧
+    # recorded 其实是冗余，但用着方便，存了吧,activity_show.html用到了
     recorded = models.BooleanField("是否预报备", default=False)
     valid = models.BooleanField("是否已审核", default=False)
 

--- a/app/reimbursement_utils.py
+++ b/app/reimbursement_utils.py
@@ -117,7 +117,7 @@ def update_reimb_application(application, me, user_type, request,auditor_name):
                     images = request.FILES.getlist('images')
                     if len(images) > 0:
                         for image in images:
-                            if utils.if_image(image) == False:
+                            if utils.if_image(image) !=2:
                                 return wrong("上传的材料只支持图片格式。")
 
                     transaction_msg = f'活动“{reimb_act.title}”的报销申请'  # TODO:报销信息的补充

--- a/app/views.py
+++ b/app/views.py
@@ -1980,7 +1980,7 @@ def viewActivity(request, aid=None):
             except:
                 html_display['warn_code'] = 1
                 html_display['warn_message'] = "上传活动照片不能为空"
-            if utils.if_image(photo) == False:
+            if utils.if_image(photo) !=2:
                 html_display['warn_code'] = 1
                 html_display['warn_message'] = "上传的附件只支持图片格式"
             elif summary_photo_exists:
@@ -2893,7 +2893,7 @@ def addComment(request, comment_base, receiver=None):
             return context
         if len(comment_images) > 0:
             for comment_image in comment_images:
-                if utils.if_image(comment_image) == False:
+                if utils.if_image(comment_image)!=2:
                     context["warn_code"] = 1
                     context["warn_message"] = "评论中上传的附件只支持图片格式。"
                     return context
@@ -3258,7 +3258,7 @@ def showActivity(request):
     """
     valid, user_type, html_display = utils.check_user_type(request.user)
     me = utils.get_person_or_org(request.user)  # 获取自身
-    is_teacher = False
+    is_teacher = False #该变量同时用于前端
     if user_type == "Person":
         try:
             person = utils.get_person_or_org(request.user, user_type)

--- a/templates/activity_info.html
+++ b/templates/activity_info.html
@@ -176,10 +176,13 @@
                             <div>
 
                                 {% if examine %}
-                                <button class="btn btn-primary btn-block mb-4 mr-2" data-toggle="collapse"
-                                    data-target="#extend-area" onclick="location='/examineActivity/{{aid}}'">
-                                    审批活动
-                                </button>
+                                    {%if status == "审核中" or not activity.valid%}
+                                    <button class="btn btn-primary btn-block mb-4 mr-2" data-toggle="collapse"
+                                        data-target="#extend-area" onclick="location='/examineActivity/{{aid}}'">
+                                        审批活动
+                                    </button>
+                                    {% endif %}
+
                                 {% endif %}
 
                                 {% if person %}

--- a/templates/activity_info.html
+++ b/templates/activity_info.html
@@ -181,6 +181,11 @@
                                         data-target="#extend-area" onclick="location='/examineActivity/{{aid}}'">
                                         审批活动
                                     </button>
+                                    {%elif activity.valid%}
+                                    <button class="btn btn-primary btn-block mb-4 mr-2" data-toggle="collapse"
+                                        data-target="#extend-area" disabled>
+                                        已经审核
+                                    </button>
                                     {% endif %}
 
                                 {% endif %}

--- a/templates/activity_show.html
+++ b/templates/activity_show.html
@@ -94,7 +94,7 @@
                                                             {% elif status == 'Canceled' %}
                                                                 <h5 class="text-muted">已取消</h5>
                                                             {% elif instance.recorded and not instance.valid %}
-                                                                <h5 class="text-info">预报备</h5>
+                                                                <h5 class="text-info">预报备+审核中</h5>
                                                             {% else %}
                                                                 <h5 class="text-success">已通过</h5>
 

--- a/templates/activity_show.html
+++ b/templates/activity_show.html
@@ -17,7 +17,7 @@
 
 {% block mainpage %}
 
-{% with title='活动管理' link='/viewActivity/' new_link='' query_field='aid' new_btn_name='' btn_name='详情' empty_info='没有相关活动哦～' %}
+{% with title='活动管理' link='/viewActivity/' audit_link='/examineActivity/' new_link='' query_field='aid' new_btn_name='' btn_name='详情' empty_info='没有相关活动哦～' %}
 
 <!--  BEGIN CONTENT AREA  -->
 <div id="content" class="main-content">
@@ -77,7 +77,7 @@
                                                     <div class="d-flex justify-content-between">
                                                         <div>
                                                             <h5>
-                                                                <a href="{{link}}{% if query_field %}{{instance.id}}{% endif %}">
+                                                                <a href="{%if is_teacher%}{{audit_link}}{%else%}{{link}}{% endif %}{% if query_field %}{{instance.id}}{% endif %}">
                                                                     <u>{{instance.get_instance}}</u>
                                                                 </a>
                                                                 <br />
@@ -91,7 +91,9 @@
                                                                 <h5 class="text-danger">未过审</h5>
                                                             {% elif status == 'Abort' %}
                                                                 <h5 class="text-muted">已撤销</h5>
-                                                            {% elif status == '预报备' %}
+                                                            {% elif status == 'Canceled' %}
+                                                                <h5 class="text-muted">已取消</h5>
+                                                            {% elif instance.recorded and not instance.valid %}
                                                                 <h5 class="text-info">预报备</h5>
                                                             {% else %}
                                                                 <h5 class="text-success">已通过</h5>
@@ -113,17 +115,15 @@
                                                             {% endfor %}
                                                         </div>
                                                         {% endif %}
-                                                        {% if instance.get_poster_name %}
-                                                        <div>
-                                                            <p style="color: rgb(66, 67, 68);">
-                                                                <i class="fa fa-address-book"></i>
-                                                                {{instance.get_poster_name}}
-                                                            </p>
-                                                        </div>
-                                                        {% endif %}
                                                     </div>
                                                     <div class="d-flex justify-content-between">
                                                         <div>
+                                                            {%if is_teacher%}
+                                                            <p style="color: rgb(66, 67, 68);">
+                                                                 <i class="fa fa-address-book"></i>
+                                                                 {{instance.organization_id.oname}}
+                                                            </p>
+                                                            {% endif %}
                                                             <p style="color: rgb(66, 67, 68);">
                                                                 <i class="fa fa-calendar-plus-o"></i>
                                                                 创建时间：{{instance.time|date:'m/d H:i'}}
@@ -137,11 +137,12 @@
                                                             <h5>
                                                                 <a href="#" class="btn btn-primary my-3 my-sm-2" tabindex="-1"
                                                                     role="button"
-                                                                    onclick="window.location='{{link}}{% if query_field %}{{instance.id}}{% endif %}'">
+                                                                    onclick="window.location='{%if is_teacher %}{{audit_link}}{%else%}{{link}}{% endif %}{% if query_field %}{{instance.id}}{% endif %}'">
                                                                     {{btn_name}}
                                                                 </a>
                                                             </h5>
                                                         </div>
+
                                                     </div>
                                                 </div>
                                             </div>

--- a/templates/comment.html
+++ b/templates/comment.html
@@ -56,8 +56,8 @@ img {
                 
                     <div class="custom-file" lang="zh">
                         <input onchange="showFilename(this.files)" type="file" 
-                               class="custom-file-input" id="customFile" name="comment_images" 
-                               accept="image/*"  multiple>
+                               class="custom-file-input" id="customFile" name="comment_images"
+                               accept="image/*"  multiple/>
                         <label id="uploadfile" class="custom-file-label" 
                                for="customFile">相关图片</label>
                     </div>
@@ -117,12 +117,14 @@ function showFilename(files){
             var name = images[i].name.toLowerCase();
             var format = name.substring(name.lastIndexOf('.') + 1);
             var flag = false;
+            var fileMaxSize = 3072
             for (var j = 0; j < formats.length; j++) {
                 if (formats[j] == format) {
                     flag = true;
                     break;
                 }
             }
+
             if (!flag) {
                 document.getElementById("warn_msg").style.display = "";
                 document.getElementById("warn_msg").innerHTML = "仅支持图片类型文件。";

--- a/templates/comment.html
+++ b/templates/comment.html
@@ -101,7 +101,6 @@ function showFilename(files){
     content: "上传";}
 </style>
 <script type="text/javascript">
-    {% if front_check %}
     function check_comment_inputs() {
         var images = document.getElementById("customFile").files;
         var comments = document.getElementById("comment").value;
@@ -124,7 +123,13 @@ function showFilename(files){
                     break;
                 }
             }
-
+            //检查图片大小
+            if ((images[i].size/1024)>fileMaxSize){
+                    document.getElementById("warn_msg").style.display = "";
+                    document.getElementById("warn_msg").innerHTML = "图片大小不应该超过3M";
+                    document.body.scrollTop = document.documentElement.scrollTop = 0;
+                    return false
+                }
             if (!flag) {
                 document.getElementById("warn_msg").style.display = "";
                 document.getElementById("warn_msg").innerHTML = "仅支持图片类型文件。";
@@ -134,10 +139,5 @@ function showFilename(files){
         }
         return true;
     }
-    {% else %}
-    function check_comment_inputs() {
-        return true;
-    }
-    {% endif %}
 </script>
 {%endblock%}


### PR DESCRIPTION
逻辑修改：
（1）活动管理页面，对于老师来讲，点击详情，跳转到审核页面；
（2）增加评论区图片大小限制，限制在3M
bug修复
（1）活动管理页面，对于老师来讲，修复申请组织称号未显示的bug;
（2）活动管理页面，修复卡片右侧活动状态显示不准确（缺少预报备+审核中的状态和已取消的状态）
（3）activity_info页面，若活动已审批通过，对于审核老师来讲，显示“已经审核”的按钮
