### PR TITLE
学时查询_v2

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -19,6 +19,8 @@ from app.models import (
     Wishes,
     QandA,
     ReimbursementPhoto,
+    Course,
+    CourseRecord,
 )
 from app.utils import (
     url_check,
@@ -57,7 +59,7 @@ from boottest import local_dict
 from django.contrib import auth, messages
 from django.contrib.auth.hashers import make_password, check_password
 from django.db import transaction
-from django.db.models import Q, F
+from django.db.models import Q, F, Sum
 from django.contrib.auth.password_validation import CommonPasswordValidator, NumericPasswordValidator
 from django.core.exceptions import ValidationError
 
@@ -437,6 +439,77 @@ def stuinfo(request, name=None):
 
         # ----------------------------------- 活动卡片 ----------------------------------- #
 
+        #学生学时查询
+        if user_type == "Person":
+            course_me = CourseRecord.objects.filter(person_id=oneself)
+            course_me_past = (
+                course_me.exclude(
+                    year=int(local_dict["semester_data"]["year"]), 
+                    semester=local_dict["semester_data"]["semester"])
+            ) # 把当前学期的活动去除
+            total_hours_me = course_me_past.aggregate(hours_me=Sum('total_hours'))
+            course_me_past = course_me_past.order_by('year','semester')
+            total_hours_sum = total_hours_me['hours_me']
+            if total_hours_sum == None:
+                total_hours_sum = 0
+
+            hour_MORAL = course_me_past.filter(course__type = Course.CourseType.MORAL).aggregate(hours_me=Sum('total_hours'))
+            if hour_MORAL['hours_me'] == None:
+                hour_MORAL['hours_me'] = 0
+            total_hours_MORAL = hour_MORAL['hours_me']
+
+            hour_INTELLECTUAL = course_me_past.filter(course__type = Course.CourseType.INTELLECTUAL).aggregate(hours_me=Sum('total_hours'))
+            if hour_INTELLECTUAL['hours_me'] == None:
+                hour_INTELLECTUAL['hours_me'] = 0
+            total_hours_INTELLECTUAL = hour_INTELLECTUAL['hours_me']
+
+            hour_PHYSICAL = course_me_past.filter(course__type = Course.CourseType.PHYSICAL).aggregate(hours_me=Sum('total_hours'))
+            if hour_PHYSICAL['hours_me'] == None:
+                hour_PHYSICAL['hours_me'] = 0
+            total_hours_PHYSICAL = hour_PHYSICAL['hours_me']
+
+            hour_AESTHETICS = course_me_past.filter(course__type = Course.CourseType.AESTHETICS).aggregate(hours_me=Sum('total_hours'))
+            if hour_AESTHETICS['hours_me'] == None:
+                hour_AESTHETICS['hours_me'] = 0
+            total_hours_AESTHETICS = hour_AESTHETICS['hours_me']
+
+            hour_LABOUR = course_me_past.filter(course__type = Course.CourseType.LABOUR).aggregate(hours_me=Sum('total_hours'))
+            if hour_LABOUR['hours_me'] == None:
+                hour_LABOUR['hours_me'] = 0
+            total_hours_LABOUR = hour_LABOUR['hours_me']
+
+            if int(oneself.stu_grade) == 2019: # 每个人的规定学时，按年级讨论
+                ruled_hours = 32
+            elif int(oneself.stu_grade) <= 2018:
+                ruled_hours = 0
+            else:
+                ruled_hours = 64
+
+            actual_total_hours = total_hours_sum
+            if actual_total_hours < ruled_hours:
+                actual_total_hours = ruled_hours # 用于算百分比的实际总学时（考虑到可能会超学时）
+            # 如果actual_total_hours=0，说明一个课程也没有参加
+
+            if actual_total_hours == 0:
+                progress_MORAL = 0
+                progress_INTELLECTUAL = 0
+                progress_PHYSICAL = 0
+                progress_AESTHETICS = 0
+                progress_LABOUR = 0
+            else:
+                progress_MORAL = total_hours_MORAL / actual_total_hours
+                progress_INTELLECTUAL = total_hours_INTELLECTUAL / actual_total_hours
+                progress_PHYSICAL = total_hours_PHYSICAL / actual_total_hours
+                progress_AESTHETICS = total_hours_AESTHETICS / actual_total_hours
+                progress_LABOUR = total_hours_LABOUR / actual_total_hours
+            
+            progress_MORAL = progress_MORAL * 100
+            progress_INTELLECTUAL = progress_INTELLECTUAL * 100
+            progress_PHYSICAL = progress_PHYSICAL * 100
+            progress_AESTHETICS = progress_AESTHETICS * 100
+            progress_LABOUR = progress_LABOUR * 100
+        
+        
         participants = Participant.objects.activated().filter(person_id=person)
         activities = Activity.objects.activated().filter(
             Q(id__in=participants.values("activity_id")),

--- a/app/views.py
+++ b/app/views.py
@@ -442,43 +442,95 @@ def stuinfo(request, name=None):
         #学生学时查询
         if user_type == "Person":
             course_me = CourseRecord.objects.filter(person_id=oneself)
+            # 把当前学期的活动去除
             course_me_past = (
                 course_me.exclude(
                     year=int(local_dict["semester_data"]["year"]), 
                     semester=local_dict["semester_data"]["semester"])
-            ) # 把当前学期的活动去除
+            )
+
+            # 无效学时，在前端呈现
+            course_no_use = (
+                course_me_past
+                .filter(total_hours__lt = 8)
+                .exclude(year = 20, semester = "Fall", total_hours__gte = 6)
+                .exclude(year = 21, semester = "Spring", total_hours__gte = 6)
+            )
+            
+            # 特判，需要一定时长才能计入总学时
+            course_me_past = (
+                course_me_past
+                .exclude(year = 20, semester = "Fall", total_hours__lt = 6)
+                .exclude(year = 21, semester = "Spring", total_hours__lt = 6)
+                .exclude(year = 21, semester = "Fall", total_hours__lt = 8) # 21秋开始，需要至少8学时
+                .exclude(year__gt = 21, total_hours__lt = 8)
+            )
+
+            # 计算总学时
             total_hours_me = course_me_past.aggregate(hours_me=Sum('total_hours'))
             course_me_past = course_me_past.order_by('year','semester')
             total_hours_sum = total_hours_me['hours_me']
             if total_hours_sum == None:
                 total_hours_sum = 0
 
-            hour_MORAL = course_me_past.filter(course__type = Course.CourseType.MORAL).aggregate(hours_me=Sum('total_hours'))
+            # 计算没有对应Course的学时
+            hour_NOTYPE = (
+                course_me_past
+                .filter(course__isnull = True)
+                .aggregate(hours_me=Sum('total_hours'))
+            )
+            if hour_NOTYPE['hours_me'] == None:
+                hour_NOTYPE['hours_me'] = 0
+            total_hours_NOTYPE = hour_NOTYPE['hours_me']
+
+            # 分别计算德智体美劳每个类型的学时
+            hour_MORAL = (
+                course_me_past
+                .filter(course__type = Course.CourseType.MORAL)
+                .aggregate(hours_me=Sum('total_hours'))
+            )
             if hour_MORAL['hours_me'] == None:
                 hour_MORAL['hours_me'] = 0
             total_hours_MORAL = hour_MORAL['hours_me']
 
-            hour_INTELLECTUAL = course_me_past.filter(course__type = Course.CourseType.INTELLECTUAL).aggregate(hours_me=Sum('total_hours'))
+            hour_INTELLECTUAL = (
+                course_me_past
+                .filter(course__type = Course.CourseType.INTELLECTUAL)
+                .aggregate(hours_me=Sum('total_hours'))
+            )
             if hour_INTELLECTUAL['hours_me'] == None:
                 hour_INTELLECTUAL['hours_me'] = 0
             total_hours_INTELLECTUAL = hour_INTELLECTUAL['hours_me']
 
-            hour_PHYSICAL = course_me_past.filter(course__type = Course.CourseType.PHYSICAL).aggregate(hours_me=Sum('total_hours'))
+            hour_PHYSICAL = (
+                course_me_past
+                .filter(course__type = Course.CourseType.PHYSICAL)
+                .aggregate(hours_me=Sum('total_hours'))
+            )
             if hour_PHYSICAL['hours_me'] == None:
                 hour_PHYSICAL['hours_me'] = 0
             total_hours_PHYSICAL = hour_PHYSICAL['hours_me']
 
-            hour_AESTHETICS = course_me_past.filter(course__type = Course.CourseType.AESTHETICS).aggregate(hours_me=Sum('total_hours'))
+            hour_AESTHETICS = (
+                course_me_past
+                .filter(course__type = Course.CourseType.AESTHETICS)
+                .aggregate(hours_me=Sum('total_hours'))
+            )
             if hour_AESTHETICS['hours_me'] == None:
                 hour_AESTHETICS['hours_me'] = 0
             total_hours_AESTHETICS = hour_AESTHETICS['hours_me']
 
-            hour_LABOUR = course_me_past.filter(course__type = Course.CourseType.LABOUR).aggregate(hours_me=Sum('total_hours'))
+            hour_LABOUR = (
+                course_me_past
+                .filter(course__type = Course.CourseType.LABOUR)
+                .aggregate(hours_me=Sum('total_hours'))
+            )
             if hour_LABOUR['hours_me'] == None:
                 hour_LABOUR['hours_me'] = 0
             total_hours_LABOUR = hour_LABOUR['hours_me']
 
-            if int(oneself.stu_grade) == 2019: # 每个人的规定学时，按年级讨论
+            # 每个人的规定学时，按年级讨论
+            if int(oneself.stu_grade) == 2019:
                 ruled_hours = 32
             elif int(oneself.stu_grade) <= 2018:
                 ruled_hours = 0
@@ -490,24 +542,28 @@ def stuinfo(request, name=None):
                 actual_total_hours = ruled_hours # 用于算百分比的实际总学时（考虑到可能会超学时）
             # 如果actual_total_hours=0，说明一个课程也没有参加
 
-            if actual_total_hours == 0:
+            if actual_total_hours == 0: # 防止除零出现
                 progress_MORAL = 0
                 progress_INTELLECTUAL = 0
                 progress_PHYSICAL = 0
                 progress_AESTHETICS = 0
                 progress_LABOUR = 0
-            else:
+                progress_NOTYPE = 0
+            else: # 计算进度
                 progress_MORAL = total_hours_MORAL / actual_total_hours
                 progress_INTELLECTUAL = total_hours_INTELLECTUAL / actual_total_hours
                 progress_PHYSICAL = total_hours_PHYSICAL / actual_total_hours
                 progress_AESTHETICS = total_hours_AESTHETICS / actual_total_hours
                 progress_LABOUR = total_hours_LABOUR / actual_total_hours
+                progress_NOTYPE = total_hours_NOTYPE / actual_total_hours
             
+            # 换成百分比
             progress_MORAL = progress_MORAL * 100
             progress_INTELLECTUAL = progress_INTELLECTUAL * 100
             progress_PHYSICAL = progress_PHYSICAL * 100
             progress_AESTHETICS = progress_AESTHETICS * 100
             progress_LABOUR = progress_LABOUR * 100
+            progress_NOTYPE = progress_NOTYPE * 100
         
         
         participants = Participant.objects.activated().filter(person_id=person)

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -502,7 +502,107 @@
             <div class="container-fluid layout-px-spacing layout-top-spacing">
                 <div class="bio education layout-spacing ">
                     <div class="widget-content widget-content-area">
-
+                        
+                        {% if user_type == 'Person' %}
+                        <div class="row">
+                            <h3 class="col mb-0">我的学时
+                            <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="仅统计过往学期。如果学时统计有误，请通过相关途径联系管理员">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor"
+                                    class="bi bi-question-circle-fill" viewBox="0 0 22 22">
+                                    <path
+                                        d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z" />
+                                </svg>
+                            </a>
+                        </h3>
+                        </div>
+                        <br>
+                        <div class="progress">
+                            <div class="progress-bar progress-bar-info" role="progressbar"
+                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                 style="width: {{progress_MORAL}}%; border-radius:0; background-color:#0092c7;">
+                            </div>
+                            <div class="progress-bar progress-bar-info" role="progressbar"
+                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                 style="width: {{progress_INTELLECTUAL}}%; border-radius:0; background-color:#22c3aa;">
+                            </div>
+                            <div class="progress-bar progress-bar-info" role="progressbar"
+                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                 style="width: {{progress_PHYSICAL}}%; border-radius:0; background-color:#AD8976;">
+                            </div>
+                            <div class="progress-bar progress-bar-info" role="progressbar"
+                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                 style="width: {{progress_AESTHETICS}}%; border-radius:0; background-color:#f3b59b;">
+                            </div>
+                            <div class="progress-bar progress-bar-info" role="progressbar"
+                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                 style="width: {{progress_LABOUR}}%; border-radius:0; background-color:#f29c9c;">
+                            </div>
+                        </div>
+                        <!-- <div class="progress">
+                            <div class="progress-bar" role="progressbar" aria-valuenow="60" 
+                                aria-valuemin="0" aria-valuemax="100" style="width: {{progress_me}}%;">
+                                <span class="sr-only">{{progress_me}}% 完成</span>
+                            </div>
+                        </div> -->
+                        {% if course_me_past %}
+                            <script src="https://cdn.staticfile.org/jquery/1.10.2/jquery.min.js">
+                            </script>
+                            <script>
+                            $(document).ready(function(){
+                                $("button").click(function(){
+                                    $("table").toggle();
+                                });
+                            });
+                            </script>
+                            <p class="text-left">
+                                已有学时 / 规定学时 ： {{total_hours_sum}} / {{ruled_hours}} 
+                            </p>
+                            <p class="text-right">
+                                <button type="button" class="btn btn-info mb-4 mr-2">隐藏/显示详细学时</button>
+                            </p>
+                            <table class="table">
+                                <thead>
+                                    <th style='text-align: center;'>课程名称</th>
+                                    <th style='text-align: center;'>学年</th>
+                                    <th style='text-align: center;'>学期</th>
+                                    <th style='text-align: center;'>获得学时</th>
+                                    <th style='text-align: center;'>课程类型</th>
+                                </thead>
+                                <tbody>
+                                    {% for c in course_me_past %}
+                                        <tr>
+                                            <td style='text-align: center;'>{{c.course.name}}</td>
+                                            <td style='text-align: center;'>{{c.year}}</td>
+                                            <td style='text-align: center;'>{{c.semester}}</td>
+                                            <td style='text-align: center;'>{{c.total_hours}}</td>
+                                            {% if c.course.type == 0 %}
+                                                <td style="text-align: center; color:#0092c7;">{{c.course.get_type_display}}</td>
+                                            {% endif %}
+                                            {% if c.course.type == 1 %}
+                                                <td style="text-align: center; color:#22c3aa;">{{c.course.get_type_display}}</td>
+                                            {% endif %}
+                                            {% if c.course.type == 2 %}
+                                                <td style="text-align: center; color:#AD8976;">{{c.course.get_type_display}}</td>
+                                            {% endif %}
+                                            {% if c.course.type == 3 %}
+                                                <td style="text-align: center; color:#f3b59b;">{{c.course.get_type_display}}</td>
+                                            {% endif %}
+                                            {% if c.course.type == 4 %}
+                                                <td style="text-align: center; color:#f29c9c;">{{c.course.get_type_display}}</td>
+                                            {% endif %}
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                            <br>
+                        {% else %}
+                            <p class="text-left"> 已有学时 / 规定学时 ： {{total_hours_sum}} / {{ruled_hours}} </p>
+                            <br>
+                            <p class="text-center">没有参与的书院课程</p>
+                            <br>
+                        {% endif %}
+                        {% endif %}
+                        
                         <div class="row">
                             <h3 class="col mb-0">参与的活动</h3>
                             {% if html_display.is_myself == False %}

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -537,6 +537,10 @@
                                  aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
                                  style="width: {{progress_LABOUR}}%; border-radius:0; background-color:#f29c9c;">
                             </div>
+                            <div class="progress-bar progress-bar-info" role="progressbar"
+                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                 style="width: {{progress_NOTYPE}}%; border-radius:0; background-color:#9E9EA3;">
+                            </div>
                         </div>
                         <!-- <div class="progress">
                             <div class="progress-bar" role="progressbar" aria-valuenow="60" 
@@ -544,7 +548,7 @@
                                 <span class="sr-only">{{progress_me}}% 完成</span>
                             </div>
                         </div> -->
-                        {% if course_me_past %}
+                        {% if course_me_past or course_no_use %}
                             <script src="https://cdn.staticfile.org/jquery/1.10.2/jquery.min.js">
                             </script>
                             <script>
@@ -555,7 +559,7 @@
                             });
                             </script>
                             <p class="text-left">
-                                已有学时 / 规定学时 ： {{total_hours_sum}} / {{ruled_hours}} 
+                                已有学时 / 规定学时 ： {{total_hours_sum|floatformat:-1}} / {{ruled_hours}} 
                             </p>
                             <p class="text-right">
                                 <button type="button" class="btn btn-info mb-4 mr-2">隐藏/显示详细学时</button>
@@ -565,16 +569,26 @@
                                     <th style='text-align: center;'>课程名称</th>
                                     <th style='text-align: center;'>学年</th>
                                     <th style='text-align: center;'>学期</th>
+                                    <th style='text-align: center;'>参与次数</th>
                                     <th style='text-align: center;'>获得学时</th>
                                     <th style='text-align: center;'>课程类型</th>
                                 </thead>
                                 <tbody>
                                     {% for c in course_me_past %}
                                         <tr>
-                                            <td style='text-align: center;'>{{c.course.name}}</td>
+                                            {% if c.course == null %}
+                                                <td style='text-align: center;'>{{c.extra_name}}</td>
+                                            {% else %}
+                                                <td style='text-align: center;'>{{c.course.name}}</td>
+                                            {% endif %}
                                             <td style='text-align: center;'>{{c.year}}</td>
-                                            <td style='text-align: center;'>{{c.semester}}</td>
-                                            <td style='text-align: center;'>{{c.total_hours}}</td>
+                                            {% if c.semester == "Spring" %}
+                                                <td style='text-align: center;'>春季</td>
+                                            {% else %}
+                                                <td style='text-align: center;'>秋季</td>
+                                            {% endif %}
+                                            <td style='text-align: center;'>{{c.attend_times}}</td>
+                                            <td style='text-align: center;'>{{c.total_hours|floatformat:-1}}</td>
                                             {% if c.course.type == 0 %}
                                                 <td style="text-align: center; color:#0092c7;">{{c.course.get_type_display}}</td>
                                             {% endif %}
@@ -590,10 +604,32 @@
                                             {% if c.course.type == 4 %}
                                                 <td style="text-align: center; color:#f29c9c;">{{c.course.get_type_display}}</td>
                                             {% endif %}
+                                            {% if c.course == null %}
+                                                <td style="text-align: center; color:#9E9EA3;">未分类</td>
+                                            {% endif %}
                                         </tr>
+                                    {% endfor %}
+                                    {% for c in course_no_use %}
+                                    <tr bgcolor = "#F1F3F4">
+                                        {% if c.course == null %}
+                                                <td style='text-align: center; color:grey;'>{{c.extra_name}}</td>
+                                            {% else %}
+                                            <td style='text-align: center; color:grey;'>{{c.course.name}}</td>
+                                        {% endif %}
+                                        <td style='text-align: center; color:grey;'>{{c.year}}</td>
+                                        {% if c.semester == "Spring" %}
+                                                <td style='text-align: center; color:grey;'>春季</td>
+                                        {% else %}
+                                                <td style='text-align: center; color:grey;'>秋季</td>
+                                        {% endif %}
+                                        <td style='text-align: center;color:grey;'>{{c.attend_times}}</td>
+                                        <td style='text-align: center; color:grey;'>{{c.total_hours|floatformat:-1}}</td>
+                                        <td style='text-align: center; color:grey;'>无效学时</td>
+                                    </tr>
                                     {% endfor %}
                                 </tbody>
                             </table>
+                            <p>注：根据学院规定，同一门书院课程须完成8学时及以上，才可以认定时长（20秋及21春为6学时及以上）。</p>
                             <br>
                         {% else %}
                             <p class="text-left"> 已有学时 / 规定学时 ： {{total_hours_sum}} / {{ruled_hours}} </p>

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -504,139 +504,133 @@
                     <div class="widget-content widget-content-area">
                         
                         {% if user_type == 'Person' %}
-                        <div class="row">
-                            <h3 class="col mb-0">我的学时
-                            <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="仅统计过往学期。如果学时统计有误，请通过相关途径联系管理员">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor"
-                                    class="bi bi-question-circle-fill" viewBox="0 0 22 22">
-                                    <path
-                                        d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z" />
-                                </svg>
-                            </a>
-                        </h3>
-                        </div>
-                        <br>
-                        <div class="progress">
-                            <div class="progress-bar progress-bar-info" role="progressbar"
-                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
-                                 style="width: {{progress_MORAL}}%; border-radius:0; background-color:#0092c7;">
+                            <div class="row">
+                                <h3 class="col mb-0">我的学时
+                                    <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="仅统计过往学期。如果学时统计有误，请通过相关途径联系管理员">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor"
+                                            class="bi bi-question-circle-fill" viewBox="0 0 22 22">
+                                            <path
+                                                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z" />
+                                        </svg>
+                                    </a>
+                                </h3>
                             </div>
-                            <div class="progress-bar progress-bar-info" role="progressbar"
-                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
-                                 style="width: {{progress_INTELLECTUAL}}%; border-radius:0; background-color:#22c3aa;">
-                            </div>
-                            <div class="progress-bar progress-bar-info" role="progressbar"
-                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
-                                 style="width: {{progress_PHYSICAL}}%; border-radius:0; background-color:#AD8976;">
-                            </div>
-                            <div class="progress-bar progress-bar-info" role="progressbar"
-                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
-                                 style="width: {{progress_AESTHETICS}}%; border-radius:0; background-color:#f3b59b;">
-                            </div>
-                            <div class="progress-bar progress-bar-info" role="progressbar"
-                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
-                                 style="width: {{progress_LABOUR}}%; border-radius:0; background-color:#f29c9c;">
-                            </div>
-                            <div class="progress-bar progress-bar-info" role="progressbar"
-                                 aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
-                                 style="width: {{progress_NOTYPE}}%; border-radius:0; background-color:#9E9EA3;">
-                            </div>
-                        </div>
-                        <!-- <div class="progress">
-                            <div class="progress-bar" role="progressbar" aria-valuenow="60" 
-                                aria-valuemin="0" aria-valuemax="100" style="width: {{progress_me}}%;">
-                                <span class="sr-only">{{progress_me}}% 完成</span>
-                            </div>
-                        </div> -->
-                        {% if course_me_past or course_no_use %}
-                            <script src="https://cdn.staticfile.org/jquery/1.10.2/jquery.min.js">
-                            </script>
-                            <script>
-                            $(document).ready(function(){
-                                $("button").click(function(){
-                                    $("table").toggle();
-                                });
-                            });
-                            </script>
-                            <p class="text-left">
-                                已有学时 / 规定学时 ： {{total_hours_sum|floatformat:-1}} / {{ruled_hours}} 
-                            </p>
-                            <p class="text-right">
-                                <button type="button" class="btn btn-info mb-4 mr-2">隐藏/显示详细学时</button>
-                            </p>
-                            <table class="table">
-                                <thead>
-                                    <th style='text-align: center;'>课程名称</th>
-                                    <th style='text-align: center;'>学年</th>
-                                    <th style='text-align: center;'>学期</th>
-                                    <th style='text-align: center;'>参与次数</th>
-                                    <th style='text-align: center;'>获得学时</th>
-                                    <th style='text-align: center;'>课程类型</th>
-                                </thead>
-                                <tbody>
-                                    {% for c in course_me_past %}
-                                        <tr>
-                                            {% if c.course == null %}
-                                                <td style='text-align: center;'>{{c.extra_name}}</td>
-                                            {% else %}
-                                                <td style='text-align: center;'>{{c.course.name}}</td>
-                                            {% endif %}
-                                            <td style='text-align: center;'>{{c.year}}</td>
-                                            {% if c.semester == "Spring" %}
-                                                <td style='text-align: center;'>春季</td>
-                                            {% else %}
-                                                <td style='text-align: center;'>秋季</td>
-                                            {% endif %}
-                                            <td style='text-align: center;'>{{c.attend_times}}</td>
-                                            <td style='text-align: center;'>{{c.total_hours|floatformat:-1}}</td>
-                                            {% if c.course.type == 0 %}
-                                                <td style="text-align: center; color:#0092c7;">{{c.course.get_type_display}}</td>
-                                            {% endif %}
-                                            {% if c.course.type == 1 %}
-                                                <td style="text-align: center; color:#22c3aa;">{{c.course.get_type_display}}</td>
-                                            {% endif %}
-                                            {% if c.course.type == 2 %}
-                                                <td style="text-align: center; color:#AD8976;">{{c.course.get_type_display}}</td>
-                                            {% endif %}
-                                            {% if c.course.type == 3 %}
-                                                <td style="text-align: center; color:#f3b59b;">{{c.course.get_type_display}}</td>
-                                            {% endif %}
-                                            {% if c.course.type == 4 %}
-                                                <td style="text-align: center; color:#f29c9c;">{{c.course.get_type_display}}</td>
-                                            {% endif %}
-                                            {% if c.course == null %}
-                                                <td style="text-align: center; color:#9E9EA3;">未分类</td>
-                                            {% endif %}
-                                        </tr>
-                                    {% endfor %}
-                                    {% for c in course_no_use %}
-                                    <tr bgcolor = "#F1F3F4">
-                                        {% if c.course == null %}
-                                                <td style='text-align: center; color:grey;'>{{c.extra_name}}</td>
-                                            {% else %}
-                                            <td style='text-align: center; color:grey;'>{{c.course.name}}</td>
-                                        {% endif %}
-                                        <td style='text-align: center; color:grey;'>{{c.year}}</td>
-                                        {% if c.semester == "Spring" %}
-                                                <td style='text-align: center; color:grey;'>春季</td>
-                                        {% else %}
-                                                <td style='text-align: center; color:grey;'>秋季</td>
-                                        {% endif %}
-                                        <td style='text-align: center;color:grey;'>{{c.attend_times}}</td>
-                                        <td style='text-align: center; color:grey;'>{{c.total_hours|floatformat:-1}}</td>
-                                        <td style='text-align: center; color:grey;'>无效学时</td>
-                                    </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                            <p>注：根据学院规定，同一门书院课程须完成8学时及以上，才可以认定时长（20秋及21春为6学时及以上）。</p>
                             <br>
-                        {% else %}
-                            <p class="text-left"> 已有学时 / 规定学时 ： {{total_hours_sum}} / {{ruled_hours}} </p>
-                            <br>
-                            <p class="text-center">没有参与的书院课程</p>
-                            <br>
-                        {% endif %}
+                            <div class="progress">
+                                <div class="progress-bar progress-bar-info" role="progressbar"
+                                    aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: {{progress_list.0}}%; border-radius:0; background-color:#0092c7;">
+                                </div>
+                                <div class="progress-bar progress-bar-info" role="progressbar"
+                                    aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: {{progress_list.1}}%; border-radius:0; background-color:#22c3aa;">
+                                </div>
+                                <div class="progress-bar progress-bar-info" role="progressbar"
+                                    aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: {{progress_list.2}}%; border-radius:0; background-color:#AD8976;">
+                                </div>
+                                <div class="progress-bar progress-bar-info" role="progressbar"
+                                    aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: {{progress_list.3}}%; border-radius:0; background-color:#f3b59b;">
+                                </div>
+                                <div class="progress-bar progress-bar-info" role="progressbar"
+                                    aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: {{progress_list.4}}%; border-radius:0; background-color:#f29c9c;">
+                                </div>
+                                <div class="progress-bar progress-bar-info" role="progressbar"
+                                    aria-valuenow="60" aria-valuemin="0" aria-valuemax="100"
+                                    style="width: {{progress_NOTYPE}}%; border-radius:0; background-color:#9E9EA3;">
+                                </div>
+                            </div>
+                            {% if course_me_past or course_no_use %}
+                                <script src="https://cdn.staticfile.org/jquery/1.10.2/jquery.min.js">
+                                </script>
+                                <script>
+                                    $(document).ready(function(){
+                                        $("button").click(function(){
+                                            $("table").toggle();
+                                        });
+                                    });
+                                </script>
+                                <p class="text-left">
+                                    已有学时 / 规定学时 ： {{total_hours_sum|floatformat:-1}} / {{ruled_hours}} 
+                                </p>
+                                <p class="text-right">
+                                    <button type="button" class="btn btn-info mb-4 mr-2">隐藏/显示详细学时</button>
+                                </p>
+                                <table class="table">
+                                    <thead>
+                                        <th style='text-align: center;'>课程名称</th>
+                                        <th style='text-align: center;'>学年</th>
+                                        <th style='text-align: center;'>学期</th>
+                                        <th style='text-align: center;'>参与次数</th>
+                                        <th style='text-align: center;'>获得学时</th>
+                                        <th style='text-align: center;'>课程类型</th>
+                                    </thead>
+                                    <tbody>
+                                        {% for c in course_me_past %}
+                                            <tr>
+                                                {% if c.course == null %}
+                                                    <td style='text-align: center;'>{{c.extra_name}}</td>
+                                                {% else %}
+                                                    <td style='text-align: center;'>{{c.course.name}}</td>
+                                                {% endif %}
+                                                <td style='text-align: center;'>{{c.year}}</td>
+                                                {% if c.semester == "Spring" %}
+                                                    <td style='text-align: center;'>春季</td>
+                                                {% else %}
+                                                    <td style='text-align: center;'>秋季</td>
+                                                {% endif %}
+                                                <td style='text-align: center;'>{{c.attend_times}}</td>
+                                                <td style='text-align: center;'>{{c.total_hours|floatformat:-1}}</td>
+                                                {% if c.course.type == 0 %}
+                                                    <td style="text-align: center; color:#0092c7;">{{c.course.get_type_display}}</td>
+                                                {% endif %}
+                                                {% if c.course.type == 1 %}
+                                                    <td style="text-align: center; color:#22c3aa;">{{c.course.get_type_display}}</td>
+                                                {% endif %}
+                                                {% if c.course.type == 2 %}
+                                                    <td style="text-align: center; color:#AD8976;">{{c.course.get_type_display}}</td>
+                                                {% endif %}
+                                                {% if c.course.type == 3 %}
+                                                    <td style="text-align: center; color:#f3b59b;">{{c.course.get_type_display}}</td>
+                                                {% endif %}
+                                                {% if c.course.type == 4 %}
+                                                    <td style="text-align: center; color:#f29c9c;">{{c.course.get_type_display}}</td>
+                                                {% endif %}
+                                                {% if c.course == null %}
+                                                    <td style="text-align: center; color:#9E9EA3;">未分类</td>
+                                                {% endif %}
+                                            </tr>
+                                        {% endfor %}
+                                        {% for c in course_no_use %}
+                                            <tr bgcolor = "#F1F3F4">
+                                                {% if c.course == null %}
+                                                        <td style='text-align: center; color:grey;'>{{c.extra_name}}</td>
+                                                    {% else %}
+                                                    <td style='text-align: center; color:grey;'>{{c.course.name}}</td>
+                                                {% endif %}
+                                                <td style='text-align: center; color:grey;'>{{c.year}}</td>
+                                                {% if c.semester == "Spring" %}
+                                                        <td style='text-align: center; color:grey;'>春季</td>
+                                                {% else %}
+                                                        <td style='text-align: center; color:grey;'>秋季</td>
+                                                {% endif %}
+                                                <td style='text-align: center;color:grey;'>{{c.attend_times}}</td>
+                                                <td style='text-align: center; color:grey;'>{{c.total_hours|floatformat:-1}}</td>
+                                                <td style='text-align: center; color:grey;'>无效学时</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                                <p>注：根据学院规定，同一门书院课程须完成8学时及以上，才可以认定时长（20秋及21春为6学时及以上）。</p>
+                                <br>
+                            {% else %}
+                                <p class="text-left"> 已有学时 / 规定学时 ： {{total_hours_sum}} / {{ruled_hours}} </p>
+                                <br>
+                                <p class="text-center">没有参与的书院课程</p>
+                                <br>
+                            {% endif %}
                         {% endif %}
                         
                         <div class="row">


### PR DESCRIPTION
<img width="588" alt="截屏2022-02-09 上午12 00 19" src="https://user-images.githubusercontent.com/87112442/153026515-a77577af-a2b1-4cfc-9014-0c098cd5c17f.png">

- 为个人账号提供学时查询
- 位置：个人主页-活动卡片，在原“参与的活动”上方
- 进度条中不同颜色对应不同课程类型，有相应详细学时表中字体颜色对应
- 提供隐藏/显示详细学时信息按钮
- 根据学院要求，去掉无效学时。无效学时也呈现在前端
- 考虑到了会有未分类（德，智...）的课程
- 学期改成了中文（春季/秋季），学时为整数