### PR TITLE
更新聚合页面前端并添加链接

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -21,7 +21,7 @@ __all__ = [
     'get_setting', 'get_config',
     'DEBUG', 'MEDIA_URL', 'LOGIN_URL',
     'WRONG', 'SUCCEED', 'SYSTEM_LOG',
-    'YQP_ONAME',
+    'YQP_ONAME', 'COURSE_TYPENAME',
 ]
 
 PREFIX = ''
@@ -62,3 +62,5 @@ def get_config(path: str='', default=None, trans_func=None,
     '''
     return base_get_setting(
         PREFIX + path, default, trans_func, fuzzy_lookup, raise_exception)
+
+COURSE_TYPENAME = get_config('course/type_name', '书院课程')

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -104,7 +104,7 @@ def addSingleCourseActivity(request):
         valid, user_type, html_display = utils.check_user_type(request.user)
         # assert valid  已经在check_user_access检查过了
         me = utils.get_person_or_org(request.user, user_type)  # 这里的me应该为小组账户
-        if user_type != "Organization":
+        if user_type != "Organization" or me.otype.otype_name != COURSE_TYPENAME:
             return redirect(message_url(wrong('书院课程小组账号才能开设课程活动!')))
         if me.oname == YQP_ONAME:
             return redirect("/showActivity")  # TODO: 可以重定向到书院课程聚合页面
@@ -149,7 +149,7 @@ def showCourseActivity(request):
     me = get_person_or_org(request.user, user_type)  # 获取自身
 
     
-    if user_type != "Organization" or me.otype.otype_name != "书院课程":
+    if user_type != "Organization" or me.otype.otype_name != COURSE_TYPENAME:
         return redirect(message_url(wrong('只有书院课程组织才能查看此页面!')))
 
     all_activity_list = (

--- a/app/urls.py
+++ b/app/urls.py
@@ -76,6 +76,7 @@ urlpatterns = [
     # 书院课程相关内容
     path("addSingleCourseActivity/", course_views.addSingleCourseActivity, name="addSingleCourseActivity"),
     path("editCourseActivity/<str:aid>", course_views.editCourseActivity, name="editCourseActivity"),
+    path("showCourseActivity/", course_views.showCourseActivity, name="showCourseActivity"),
 ] + [
     # 组织相关操作
     path("saveShowPositionStatus", org_views.saveShowPositionStatus, name="saveShowPositionStatus"),

--- a/app/utils.py
+++ b/app/utils.py
@@ -214,7 +214,7 @@ def get_sidebar_and_navbar(user, navbar_name="", title_name="", bar_display=None
     else:
         bar_display["profile_name"] = "小组主页"
         bar_display["profile_url"] = "/orginfo/"
-        bar_display["org_type"] = me.otype.otype_name
+        bar_display["is_course"] = me.otype.otype_name == COURSE_TYPENAME
 
     bar_display["navbar_name"] = navbar_name
     # title_name默认与navbar_name相同

--- a/app/utils.py
+++ b/app/utils.py
@@ -214,6 +214,7 @@ def get_sidebar_and_navbar(user, navbar_name="", title_name="", bar_display=None
     else:
         bar_display["profile_name"] = "小组主页"
         bar_display["profile_url"] = "/orginfo/"
+        bar_display["org_type"] = me.otype.otype_name
 
     bar_display["navbar_name"] = navbar_name
     # title_name默认与navbar_name相同

--- a/local_json_template.json
+++ b/local_json_template.json
@@ -87,6 +87,7 @@
         "活动信息": "将其在微信中打开，就可以在聊天/朋友圈中分享你自己啦"
     },
     "course": {
+        "type_name": "书院课程",
         "audit_teacher": "YPadmin"
     },
     "audit_teacher": {

--- a/templates/org_left_navbar.html
+++ b/templates/org_left_navbar.html
@@ -63,6 +63,28 @@
                         </a>
                     </li>
                     -->
+                    {% if bar_display.org_type == "书院课程" %}
+                    <li class="menu">
+                        <a href="/showCourseActivity/" aria-expanded="false" class="dropdown-toggle">
+                            <div class="">
+                                <svg xmlns="http://www.w3.org/2000/svg"
+                                width="24"
+                                height="24"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round">
+                                <path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z" />
+                                <line x1="16" y1="8" x2="2" y2="22" />
+                                <line x1="17.5" y1="15" x2="9" y2="15" />
+                                </svg>
+                                <span>我的课程</span>
+                            </div>
+                        </a>
+                    </li>
+                    {% else %}
                     <li class="menu">
                         <a href="/showActivity/" aria-expanded="false" class="dropdown-toggle">
                             <div class="">
@@ -103,6 +125,7 @@
                             </div>
                         </a>
                     </li>
+                    {% endif %}
                     <!-- <li class="menu">
                         <a href="/personnelMobilization/" aria-expanded="false" class="dropdown-toggle">
                             <div class="">

--- a/templates/org_left_navbar.html
+++ b/templates/org_left_navbar.html
@@ -63,7 +63,7 @@
                         </a>
                     </li>
                     -->
-                    {% if bar_display.org_type == "书院课程" %}
+                    {% if bar_display.is_course %}
                     <li class="menu">
                         <a href="/showCourseActivity/" aria-expanded="false" class="dropdown-toggle">
                             <div class="">

--- a/templates/org_show_course_activity.html
+++ b/templates/org_show_course_activity.html
@@ -77,77 +77,76 @@
                                             {% endif %}
                                             <div class="row w-100 m-0">
                                                 {% for act in future_activity_list %}
-                                                    <!-- BEGIN ACTIVITY DISPLAY -->
-                                                    <div class="col-xm-12 col-md-6 mb-xl-5 mb-5 ">
-                                                        <div class="dropdown">
-                                                        <div class="d-flex b-skills" role="button" data-toggle="dropdown">
-                                                            <div class="text-nowrap mw-100">
-                                                                <div class="d-flex justify-content-between">
-                                                                    <h5
-                                                                        style="max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                        {% if act.status == "等待中" %}
-                                                                        <span class="badge badge-pill badge-warning">
-                                                                            等待开始
-                                                                            {% else %}
-                                                                            {% if act.status == "审核中" %}
-                                                                            <span
-                                                                                class="flex badge badge-pill badge-secondary">
-                                                                                {% elif act.status == "未过审" or act.status == "已取消" or act.status == "已撤销" or act.status == "已结束" %}
+                                                <!-- BEGIN ACTIVITY DISPLAY -->
+                                                <div class="col-12 col-xl-6 col-lg-12 mb-xl-4 mb-4 ">
+                                                    <div class=" b-skills">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div>
+                                                                <h5
+                                                                    style="max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    {% if act.status == "等待中" %}
+                                                                    <span class="badge badge-pill badge-warning">
+                                                                        等待开始
+                                                                        {% else %}
+                                                                        {% if act.status == "审核中" %}
+                                                                        <span
+                                                                            class="flex badge badge-pill badge-secondary">
+                                                                            {% elif act.status == "未过审" or act.status == "已取消" or act.status == "已撤销" or act.status == "已结束" %}
+                                                                            <span class="badge badge-pill badge-danger">
+                                                                                {% elif act.status == "报名中" %}
                                                                                 <span
-                                                                                    class="badge badge-pill badge-danger">
-                                                                                    {% elif act.status == "报名中" %}
+                                                                                    class="badge badge-pill badge-info">
+                                                                                    {% elif act.status == "进行中" %}
                                                                                     <span
-                                                                                        class="badge badge-pill badge-info">
-                                                                                        {% elif act.status == "进行中" %}
-                                                                                        <span
-                                                                                            class="badge badge-pill badge-success">
-                                                                                            {% endif %}
-                                                                                            {{ act.status }}
-                                                                                            {% endif %}
-                                                                                        </span>
-                                                                                        {{ act.title }}
-                                                                    </h5>
+                                                                                        class="badge badge-pill badge-success">
+                                                                                        {% endif %}
+                                                                                        {{ act.status }}
+                                                                                        {% endif %}
+                                                                                    </span>
+                                                                                    {{ act.title }}
+                                                                </h5>
+                                                            </div>
+                                                            <div>
+                                                                <div class="dropdown">
+                                                                    <button type="button"
+                                                                        class="btn btn-primary dropdown-toggle"
+                                                                        data-toggle="dropdown">
+                                                                        管理活动
+                                                                    </button>
+                                                                    <div class="dropdown-menu">
+                                                                        <a class="dropdown-item" href="/editCourseActivity/{{act.id}}">修改活动</a>
+                                                                        <a class="dropdown-item" href="#">取消活动</a>
+                                                                    </div>
                                                                 </div>
-
-                                                                <p
-                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                    <i class="fa fa-info-circle"
-                                                                        style="width: 20px;"></i>
-                                                                    <span class="ml-1">{{ act.introduction }}</span>
-                                                                </p>
-
-                                                                <p
-                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                    <i class="fa fa-clock" style="width: 20px;"></i>
-                                                                    <span class="ml-1">活动开始时间：{{ act.start }}&nbsp;</span>
-                                                                </p>
-
-                                                                <p
-                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                    <i class="fa fa-location-arrow"
-                                                                        style="width: 20px;"></i>
-                                                                    <span class="ml-1">{{ act.location }}&nbsp;</span>
-                                                                </p>
-
                                                             </div>
 
                                                         </div>
-                                                        
-                                                        <!-- BEGIN DROPDOWN MENU -->
-                                                        <!-- TODO: modify href -->
-                                                        <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                                                            <a class="dropdown-item" href="/editCourseActivity/act.id">修改活动</a>
-                                                            <a class="dropdown-item" href="#">取消活动</a>
-                                                        </div>
-                                                        <!-- END DROPDOWN MENU -->
 
+                                                        <p
+                                                            style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                            <i class="fa fa-info-circle" style="width: 20px;"></i>
+                                                            <span class="ml-1">{{ act.introduction }}</span>
+                                                        </p>
+
+                                                        <p
+                                                            style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                            <i class="fa fa-clock" style="width: 20px;"></i>
+                                                            <span class="ml-1">开始时间：{{ act.start }}&nbsp;</span>
+                                                        </p>
+
+                                                        <p
+                                                            style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                            <i class="fa fa-location-arrow" style="width: 20px;"></i>
+                                                            <span class="ml-1">{{ act.location }}&nbsp;</span>
+                                                        </p>
                                                     </div>
-                                                    <!-- END ACTIVITY DISPLAY -->
                                                 </div>
-                                                {% endfor %}
-                                            </div>
 
+                                                <!-- END ACTIVITY DISPLAY -->
+                                            </div>
+                                            {% endfor %}
                                         </div>
+
                                     </div>
 
                                     <div id="finishedActivity" class="tab-pane fade">
@@ -158,93 +157,90 @@
                                             {% endif %}
                                             <div class="row w-100 m-0">
                                                 {% for act in finished_activity_list %}
-                                                    <!-- BEGIN ACTIVITY DISPLAY -->
-                                                    <div class="col-xm-12 col-md-6 mb-xl-5 mb-5 ">
-                                                        <div class="dropdown">
-                                                        <div class="d-flex b-skills" role="button" data-toggle="dropdown">
-                                                            <div class="text-nowrap mw-100">
-                                                                <div class="d-flex justify-content-between">
-                                                                    <h5
-                                                                        style="max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                        {% if act.status == "等待中" %}
-                                                                        <span class="badge badge-pill badge-warning">
-                                                                            等待开始
-                                                                            {% else %}
-                                                                            {% if act.status == "审核中" %}
-                                                                            <span
-                                                                                class="flex badge badge-pill badge-secondary">
-                                                                                {% elif act.status == "未过审" or act.status == "已取消" or act.status == "已撤销" or act.status == "已结束" %}
+                                                <!-- BEGIN ACTIVITY DISPLAY -->
+                                                <div class="col-12 col-xl-6 col-lg-12 mb-xl-4 mb-4 ">
+
+                                                    <div class=" b-skills">
+
+
+                                                        <div class="d-flex justify-content-between">
+                                                            <div>
+                                                                <h5
+                                                                    style="max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    {% if act.status == "等待中" %}
+                                                                    <span class="badge badge-pill badge-warning">
+                                                                        等待开始
+                                                                        {% else %}
+                                                                        {% if act.status == "审核中" %}
+                                                                        <span
+                                                                            class="flex badge badge-pill badge-secondary">
+                                                                            {% elif act.status == "未过审" or act.status == "已取消" or act.status == "已撤销" or act.status == "已结束" %}
+                                                                            <span class="badge badge-pill badge-danger">
+                                                                                {% elif act.status == "报名中" %}
                                                                                 <span
-                                                                                    class="badge badge-pill badge-danger">
-                                                                                    {% elif act.status == "报名中" %}
+                                                                                    class="badge badge-pill badge-info">
+                                                                                    {% elif act.status == "进行中" %}
                                                                                     <span
-                                                                                        class="badge badge-pill badge-info">
-                                                                                        {% elif act.status == "进行中" %}
-                                                                                        <span
-                                                                                            class="badge badge-pill badge-success">
-                                                                                            {% endif %}
-                                                                                            {{ act.status }}
-                                                                                            {% endif %}
-                                                                                        </span>
-                                                                                        {{ act.title }}
-                                                                    </h5>
+                                                                                        class="badge badge-pill badge-success">
+                                                                                        {% endif %}
+                                                                                        {{ act.status }}
+                                                                                        {% endif %}
+                                                                                    </span>
+                                                                                    {{ act.title }}
+                                                                </h5>
+                                                            </div>
+                                                            <div>
+                                                                <div class="dropdown">
+                                                                    <button type="button"
+                                                                        class="btn btn-primary dropdown-toggle"
+                                                                        data-toggle="dropdown">
+                                                                        管理活动
+                                                                    </button>
+                                                                    <div class="dropdown-menu">
+                                                                        <a class="dropdown-item" href="#">手工签到</a>
+                                                                    </div>
                                                                 </div>
-
-                                                                <p
-                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                    <i class="fa fa-info-circle"
-                                                                        style="width: 20px;"></i>
-                                                                    <span class="ml-1">{{ act.introduction }}</span>
-                                                                </p>
-
-                                                                <p
-                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                    <i class="fa fa-clock" style="width: 20px;"></i>
-                                                                    <span class="ml-1">结束时间：{{ act.end }}&nbsp;</span>
-                                                                </p>
-
-                                                                <p
-                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                                                                    <i class="fa fa-location-arrow"
-                                                                        style="width: 20px;"></i>
-                                                                    <span class="ml-1">{{ act.location }}&nbsp;</span>
-                                                                </p>
-
                                                             </div>
 
                                                         </div>
-                                                    
-                                                        <!-- BEGIN DROPDOWN MENU -->
-                                                        <!-- TODO: modify href -->
-                                                        <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-                                                            <a class="dropdown-item" href="#">手工签到</a>
-                                                        </div>
-                                                        <!-- END DROPDOWN MENU -->
 
+                                                        <p
+                                                            style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                            <i class="fa fa-info-circle" style="width: 20px;"></i>
+                                                            <span class="ml-1">{{ act.introduction }}</span>
+                                                        </p>
+
+                                                        <p
+                                                            style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                            <i class="fa fa-clock" style="width: 20px;"></i>
+                                                            <span class="ml-1">结束时间：{{ act.end }}&nbsp;</span>
+                                                        </p>
+
+                                                        <p
+                                                            style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                            <i class="fa fa-location-arrow" style="width: 20px;"></i>
+                                                            <span class="ml-1">{{ act.location }}&nbsp;</span>
+                                                        </p>
                                                     </div>
-                                                    <!-- END ACTIVITY DISPLAY -->
                                                 </div>
-                                                {% endfor %}
+                                                <!-- END ACTIVITY DISPLAY -->
                                             </div>
+                                            {% endfor %}
                                         </div>
                                     </div>
-
                                 </div>
 
                             </div>
-                        </div>
 
-                        <!-- END ACTIVITY LIST -->
+                        </div>
                     </div>
+                    <!-- END ACTIVITY LIST -->
+
                 </div>
             </div>
         </div>
     </div>
     <!-- END BOOTSTRAP GRID-->
-
-
-
-
 </div>
 <!--  END CONTENT AREA  -->
 

--- a/templates/org_show_course_activity.html
+++ b/templates/org_show_course_activity.html
@@ -1,0 +1,253 @@
+{% extends "base.html" %}
+
+{% block mainpage %}
+
+<!-- TODO: Link to related pages -->
+{% with title='我的课程' link1='/addSingleCourseActivity' btn_name1='增加课时' link2='' btn_name2='发起选课' %}
+
+<!--  BEGIN CONTENT AREA  -->
+<div id="content" class="main-content">
+    {% if html_display.warn_code == 1 %}
+    <div class="alert alert-warning  text-center">{{ html_display.warn_message }}</div>
+    {% elif html_display.warn_code == 2 %}
+    <div class="alert alert-success  text-center">{{ html_display.warn_message }}</div>
+    {% endif %}
+
+    <!-- BEGIN BOOTSTRAP GRID -->
+    <div class="container">
+        <div class="row layout-top-spacing">
+            <div class="col-lg-12 col-12 layout-top-spacing">
+                <div class="bio layout-spacing ">
+                    <div class="widget-content widget-content-area">
+                        <!-- BEGIN HEADER -->
+                        <div class="d-flex justify-content-between">
+                            <h3 class="">{{title}}</h3>
+                            <div class="row justify-content-end">
+                                <button type="button" class="btn btn-info mb-4 mr-2 "
+                                    onclick="location.href = '{{link1}}';">{{btn_name1}}
+                                </button>
+                                <button type="button" class="btn btn-info mb-4 mr-2 "
+                                    onclick="location.href = '{{link2}}';">{{btn_name2}}
+                                </button>
+                            </div>
+                        </div>
+                        <!-- END HEADER -->
+
+                        <!-- BEGIN ACTIVITY LIST -->
+                        <div class="row">
+                            <div class="col-12 layout-top-spacing bio">
+                                <ul id="Tab" class="nav nav-tabs nav-tabs-solid nav-justified">
+                                    <!-- BEGIN NAV HEADER -->
+                                    <li class="nav-item">
+                                        <b class="nav-link active" data-toggle="tab" role="tab" href="#futureActivity">
+                                            未开始的活动
+                                            <a data-toggle="tooltip" data-placement="bottom" title="本学期还未开始的课程活动">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                    fill="currentColor" class="bi bi-question-circle-fill"
+                                                    viewBox="0 0 22 22">
+                                                    <path
+                                                        d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z" />
+                                                </svg>
+                                            </a>
+                                        </b>
+                                    </li>
+
+                                    <li class="nav-item">
+                                        <b class="nav-link" data-toggle="tab" role="tab" href="#finishedActivity">
+                                            已结束的活动
+                                            <a data-toggle="tooltip" data-placement="bottom" title="本学期已结束的课程活动">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                    fill="currentColor" class="bi bi-question-circle-fill"
+                                                    viewBox="0 0 22 22">
+                                                    <path
+                                                        d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z" />
+                                                </svg>
+                                            </a>
+                                        </b>
+                                    </li>
+                                    <!-- END NAV HEADER -->
+                                </ul>
+
+                                <div class="tab-content" id="activityTabContent">
+                                    <div id="futureActivity" class="tab-pane active">
+                                        <div class="bio-skill-box layout-top-spacing"
+                                            style="max-height: 75vh; overflow: scroll;">
+                                            {% if future_activity_list|length == 0 %}
+                                            <p style="text-align: center;">没有未开始的课程活动！</p>
+                                            {% endif %}
+                                            <div class="row w-100 m-0">
+                                                {% for act in future_activity_list %}
+                                                    <!-- BEGIN ACTIVITY DISPLAY -->
+                                                    <div class="col-xm-12 col-md-6 mb-xl-5 mb-5 ">
+                                                        <div class="dropdown">
+                                                        <div class="d-flex b-skills" role="button" data-toggle="dropdown">
+                                                            <div class="text-nowrap mw-100">
+                                                                <div class="d-flex justify-content-between">
+                                                                    <h5
+                                                                        style="max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                        {% if act.status == "等待中" %}
+                                                                        <span class="badge badge-pill badge-warning">
+                                                                            等待开始
+                                                                            {% else %}
+                                                                            {% if act.status == "审核中" %}
+                                                                            <span
+                                                                                class="flex badge badge-pill badge-secondary">
+                                                                                {% elif act.status == "未过审" or act.status == "已取消" or act.status == "已撤销" or act.status == "已结束" %}
+                                                                                <span
+                                                                                    class="badge badge-pill badge-danger">
+                                                                                    {% elif act.status == "报名中" %}
+                                                                                    <span
+                                                                                        class="badge badge-pill badge-info">
+                                                                                        {% elif act.status == "进行中" %}
+                                                                                        <span
+                                                                                            class="badge badge-pill badge-success">
+                                                                                            {% endif %}
+                                                                                            {{ act.status }}
+                                                                                            {% endif %}
+                                                                                        </span>
+                                                                                        {{ act.title }}
+                                                                    </h5>
+                                                                </div>
+
+                                                                <p
+                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    <i class="fa fa-info-circle"
+                                                                        style="width: 20px;"></i>
+                                                                    <span class="ml-1">{{ act.introduction }}</span>
+                                                                </p>
+
+                                                                <p
+                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    <i class="fa fa-clock" style="width: 20px;"></i>
+                                                                    <span class="ml-1">活动开始时间：{{ act.start }}&nbsp;</span>
+                                                                </p>
+
+                                                                <p
+                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    <i class="fa fa-location-arrow"
+                                                                        style="width: 20px;"></i>
+                                                                    <span class="ml-1">{{ act.location }}&nbsp;</span>
+                                                                </p>
+
+                                                            </div>
+
+                                                        </div>
+                                                        
+                                                        <!-- BEGIN DROPDOWN MENU -->
+                                                        <!-- TODO: modify href -->
+                                                        <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                                                            <a class="dropdown-item" href="/editCourseActivity/act.id">修改活动</a>
+                                                            <a class="dropdown-item" href="#">取消活动</a>
+                                                        </div>
+                                                        <!-- END DROPDOWN MENU -->
+
+                                                    </div>
+                                                    <!-- END ACTIVITY DISPLAY -->
+                                                </div>
+                                                {% endfor %}
+                                            </div>
+
+                                        </div>
+                                    </div>
+
+                                    <div id="finishedActivity" class="tab-pane fade">
+                                        <div class="bio-skill-box layout-top-spacing"
+                                            style="max-height: 75vh; overflow: scroll;">
+                                            {% if finished_activity_list|length == 0 %}
+                                            <p style="text-align: center;">没有已结束的课程活动！</p>
+                                            {% endif %}
+                                            <div class="row w-100 m-0">
+                                                {% for act in finished_activity_list %}
+                                                    <!-- BEGIN ACTIVITY DISPLAY -->
+                                                    <div class="col-xm-12 col-md-6 mb-xl-5 mb-5 ">
+                                                        <div class="dropdown">
+                                                        <div class="d-flex b-skills" role="button" data-toggle="dropdown">
+                                                            <div class="text-nowrap mw-100">
+                                                                <div class="d-flex justify-content-between">
+                                                                    <h5
+                                                                        style="max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                        {% if act.status == "等待中" %}
+                                                                        <span class="badge badge-pill badge-warning">
+                                                                            等待开始
+                                                                            {% else %}
+                                                                            {% if act.status == "审核中" %}
+                                                                            <span
+                                                                                class="flex badge badge-pill badge-secondary">
+                                                                                {% elif act.status == "未过审" or act.status == "已取消" or act.status == "已撤销" or act.status == "已结束" %}
+                                                                                <span
+                                                                                    class="badge badge-pill badge-danger">
+                                                                                    {% elif act.status == "报名中" %}
+                                                                                    <span
+                                                                                        class="badge badge-pill badge-info">
+                                                                                        {% elif act.status == "进行中" %}
+                                                                                        <span
+                                                                                            class="badge badge-pill badge-success">
+                                                                                            {% endif %}
+                                                                                            {{ act.status }}
+                                                                                            {% endif %}
+                                                                                        </span>
+                                                                                        {{ act.title }}
+                                                                    </h5>
+                                                                </div>
+
+                                                                <p
+                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    <i class="fa fa-info-circle"
+                                                                        style="width: 20px;"></i>
+                                                                    <span class="ml-1">{{ act.introduction }}</span>
+                                                                </p>
+
+                                                                <p
+                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    <i class="fa fa-clock" style="width: 20px;"></i>
+                                                                    <span class="ml-1">结束时间：{{ act.end }}&nbsp;</span>
+                                                                </p>
+
+                                                                <p
+                                                                    style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                                    <i class="fa fa-location-arrow"
+                                                                        style="width: 20px;"></i>
+                                                                    <span class="ml-1">{{ act.location }}&nbsp;</span>
+                                                                </p>
+
+                                                            </div>
+
+                                                        </div>
+                                                    
+                                                        <!-- BEGIN DROPDOWN MENU -->
+                                                        <!-- TODO: modify href -->
+                                                        <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                                                            <a class="dropdown-item" href="#">手工签到</a>
+                                                        </div>
+                                                        <!-- END DROPDOWN MENU -->
+
+                                                    </div>
+                                                    <!-- END ACTIVITY DISPLAY -->
+                                                </div>
+                                                {% endfor %}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                </div>
+
+                            </div>
+                        </div>
+
+                        <!-- END ACTIVITY LIST -->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- END BOOTSTRAP GRID-->
+
+
+
+
+</div>
+<!--  END CONTENT AREA  -->
+
+{% endwith %}
+
+{% endblock %}


### PR DESCRIPTION
更新后，聚合页面效果如图所示：

![image](https://user-images.githubusercontent.com/67158122/153719709-7efdeb26-b7d7-47f6-9ed7-680bf58980a8.png)

![image](https://user-images.githubusercontent.com/67158122/153719720-7212d2d7-0f54-484e-83ea-b4157855cc92.png)

![image](https://user-images.githubusercontent.com/67158122/153719723-bbc949a0-7616-4786-b33a-0cdb9b6fe80b.png)

P.S. 考虑到按钮组难扩展、易溢出，一番调试后我还是考虑保留了下拉菜单。

聚合页面中，已链接“增加课时”，（未开始课程活动）“修改活动”。