### PR TITLE
课程聚合页面：连接“取消活动”后端

### DIFF
--- a/templates/org_show_course_activity.html
+++ b/templates/org_show_course_activity.html
@@ -109,11 +109,35 @@
                                                                     <div class="dropdown-menu">
                                                                         <a class="dropdown-item"
                                                                             href="/editCourseActivity/{{act.id}}">修改活动</a>
-                                                                        <a class="dropdown-item" href="#">取消活动</a>
+                                                                        <!-- Dropdown item trigger modal -->
+                                                                        <a class="dropdown-item" data-toggle="modal" data-target="#cancelActivityModal">取消活动</a>
                                                                     </div>
                                                                 </div>
                                                             </div>
-
+                                                            <!-- BEIGN cancelActivityModal -->
+                                                            <div class="modal fade" id="cancelActivityModal" tabindex="-1" role="dialog" aria-labelledby="cancelActivityModalLabel" aria-hidden="true">
+                                                                <div class="modal-dialog modal-dialog-centered" role="document">
+                                                                    <div class="modal-content">
+                                                                        <div class="modal-header">
+                                                                            <h5 class="modal-title" id="cancelActivityModalLabel">取消单次课程活动</h5>
+                                                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                                <span aria-hidden="true">&times;</span>
+                                                                            </button>
+                                                                        </div>
+                                                                        <div class="modal-body">
+                                                                            活动取消后不可撤回操作，确认要取消吗？
+                                                                        </div>
+                                                                        <div class="modal-footer">
+                                                                            <button type="button" class="btn btn-secondary" data-dismiss="modal">再想想</button>
+                                                                            <form method="POST" id="cancel-details">
+                                                                                <input type="hidden" name="cancel-action" value="{{act.id}}">
+                                                                                <button type="button" class="btn btn-primary" onclick="this.form.submit()" data-dismiss="modal">确认取消</button>
+                                                                            </form>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                            <!-- END cancelActivityModal -->
                                                         </div>
 
                                                         <p style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">

--- a/templates/org_show_course_activity.html
+++ b/templates/org_show_course_activity.html
@@ -70,8 +70,7 @@
 
                                 <div class="tab-content" id="activityTabContent">
                                     <div id="futureActivity" class="tab-pane active">
-                                        <div class="bio-skill-box layout-top-spacing"
-                                            style="max-height: 75vh; overflow: scroll;">
+                                        <div class="bio-skill-box layout-top-spacing" style="max-height: 75vh; overflow: scroll;">
                                             {% if future_activity_list|length == 0 %}
                                             <p style="text-align: center;">没有未开始的课程活动！</p>
                                             {% endif %}
@@ -135,9 +134,9 @@
                                                 </div>
 
                                                 <!-- END ACTIVITY DISPLAY -->
-                                            </div>
                                             {% endfor %}
-                                        </div>
+                                            </div>
+                                        </div>                                        
 
                                     </div>
 
@@ -204,8 +203,8 @@
                                                     </div>
                                                 </div>
                                                 <!-- END ACTIVITY DISPLAY -->
-                                            </div>
                                             {% endfor %}
+                                            </div>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
1. 修复空列表前端显示的bug
2. 与“取消单词课程活动”的后端部分(#409 )进行衔接
![image](https://user-images.githubusercontent.com/67158122/153744709-42e7798d-02e5-42f4-a5fd-98f1892dba80.png)
![image](https://user-images.githubusercontent.com/67158122/153744756-ba9b20ab-aad4-4a4c-908a-7791fba1158a.png)
