### PR TITLE
修复学时部分bug&增加结束课程逻辑

### DIFF
--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -208,10 +208,9 @@ def modify_course_activity(request, activity):
     #修改所有该时段的时间、地点
     course_time = activity.course_time
     if context["post_type"] == "modify_all" and course_time:
-        course_time = CourseTime.objects.get(id=course_time.id)
+        course_time = CourseTime.objects.select_for_update().get(id=course_time.id)
         org = activity.organization_id
-        course = Course.objects.activated().filter(organization=org)
-        course = course.first()
+        course = course_time.course
         schedule_start = course_time.start
         schedule_end = course_time.end
         #设置CourseTime初始时间为对应的 周几:hour:minute:second
@@ -905,7 +904,7 @@ def create_course(request, course_id=None):
     return context
 
 
-def cal_participate_num(course: Course)-> Counter:
+def cal_participate_num(course: Course) -> Counter:
     """
     计算该课程对应组织所有成员的参与次数
     return {Naturalperson.id:参与次数}
@@ -917,11 +916,17 @@ def cal_participate_num(course: Course)-> Counter:
         status=Activity.Status.END,
         category=Activity.ActivityCategory.COURSE,
     )
+    #只有小组成员才可以有学时
+    members = Position.objects.activated().filter(pos__gte=1,
+                                                person__identity=NaturalPerson.Identity.STUDENT
+                                                ).values_list("person__person_id", flat=True)
     all_participants = (
         Participant.objects.activated(no_unattend=True)
-        .filter(activity_id__in=activities)
+        .filter(activity_id__in=activities,person_id__person_id__in=members)
     ).values_list("person_id", flat=True)
-    participate_num = Counter(all_participants)
+    participate_num = dict(Counter(all_participants))
+    #没有参加的参与次数设置为0 
+    participate_num.update({id: 0 for id in members if id not in participate_num})
     return participate_num
 
 
@@ -952,3 +957,61 @@ def check_post_and_modify(records, post_data):
         return wrong(str(e))
     except:
         return wrong("数据格式异常，请检查输入数据！")
+
+
+def finish_course(course):
+    """
+    结束课程
+    设置课程状态为END 生成学时表并通知同学该课程已结束。
+    """
+    try:
+        # 取消发布每周定时活动
+        course_times = course.time_set
+        for course_time in course_times.all():
+            course_time.end_week = course_time.cur_week
+            course_time.save()
+    except:
+        return wrong("取消课程每周定时活动时失败，请联系管理员！")
+    try:
+        # 生成学时表
+        participate_num = cal_participate_num(course)
+        participants = NaturalPerson.objects.activated().filter(
+            id__in=participate_num.keys())
+        course_record_list = []
+        for participant in participants:
+            # 如果存在相同学期的学时表，则不创建
+            if not CourseRecord.objects.filter(person=participant, course=course).exists():
+                course_record_list.append(CourseRecord(
+                    person=participant,
+                    course=course,
+                    attend_times=participate_num[participant.id],
+                    total_hours=2*participate_num[participant.id]
+                ))
+        CourseRecord.objects.bulk_create(course_record_list)
+    except:
+        return wrong("生成学时表失败，请联系管理员！")
+    try:
+        # 通知课程小组成员该课程已结束
+        title = f'课程结束通知！'
+        msg = f'{course.name}在本学期的课程已结束！'
+        publish_kws = {"app": WechatApp.TO_PARTICIPANT}
+        receivers = participants.values_list('person_id', flat=True)
+        receivers = User.objects.filter(id__in=receivers)
+        bulk_notification_create(
+            receivers=list(receivers),
+            sender=course.organization.organization_id,
+            typename=Notification.Type.NEEDREAD,
+            title=title,
+            content=msg,
+            URL=f"/viewCourse/?courseid={course.id}",
+            publish_to_wechat=True,
+            publish_kws=publish_kws,
+        )
+        # 设置课程状态
+    except:
+        return wrong("生成通知失败，请联系管理员！")
+    course.status = Course.Status.END
+    course.save()
+    return succeed("结束课程成功！")
+
+

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -259,7 +259,7 @@ def showCourseActivity(request):
 
 @login_required(redirect_field_name="origin")
 @utils.check_user_access(redirect_url="/logout/")
-# @log.except_captured(EXCEPT_REDIRECT, source='course_views[showCourseRecord]', record_user=True)
+@log.except_captured(EXCEPT_REDIRECT, source='course_views[showCourseRecord]', record_user=True)
 def showCourseRecord(request):
     '''
     展示及修改学时数据

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -306,16 +306,17 @@ def showCourseRecord(request):
             else:
                 return redirect(message_url(
                     wrong('学时修改尚未开放。如有疑问，请联系管理员！'), request.path))
-        else:
-            with transaction.atomic():
-                # 检查信息并进行修改
-                record_search = CourseRecord.objects.filter(
-                    course=course,
-                    year=year,
-                    semester=semester,
-                ).select_for_update()
-                messages = check_post_and_modify(record_search, request.POST)
-                # TODO: 发送微信消息?不一定需要
+
+        # 不是其他post类型时的默认行为
+        with transaction.atomic():
+            # 检查信息并进行修改
+            record_search = CourseRecord.objects.filter(
+                course=course,
+                year=year,
+                semester=semester,
+            ).select_for_update()
+            messages = check_post_and_modify(record_search, request.POST)
+            # TODO: 发送微信消息?不一定需要
 
     # -------- GET 部分 --------
     # 如果进入这个页面时课程的状态(Course.Status)为未结束，那么只能查看不能修改，此时从函数读取

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -288,7 +288,7 @@ def showCourseRecord(request):
     if len(course) == 0: # 尚未开课的情况
         return redirect(message_url(wrong('没有检测到该组织本学期开设的课程。')))
     # TODO: 报错 这是代码不应该出现的bug
-    assert len(course) >= 2, "检测到该组织的课程超过一门，属于不可预料的错误，请及时处理！"
+    assert len(course) <= 1, "检测到该组织的课程超过一门，属于不可预料的错误，请及时处理！"
     course = course.first()
 
     # 是否可以编辑
@@ -319,15 +319,16 @@ def showCourseRecord(request):
             else:
                 return redirect(message_url(
                     wrong('学时修改尚未开放。如有疑问，请联系管理员！'), request.path))
-        with transaction.atomic():
-            # 检查信息并进行修改
-            record_search = CourseRecord.objects.filter(
-                course=course,
-                year=year,
-                semester=semester,
-            ).select_for_update()
-            messages = check_post_and_modify(record_search, request.POST)
-            # TODO: 发送微信消息?不一定需要
+        else:
+            with transaction.atomic():
+                # 检查信息并进行修改
+                record_search = CourseRecord.objects.filter(
+                    course=course,
+                    year=year,
+                    semester=semester,
+                ).select_for_update()
+                messages = check_post_and_modify(record_search, request.POST)
+                # TODO: 发送微信消息?不一定需要
 
     # -------- GET 部分 --------
     # 如果进入这个页面时课程的状态(Course.Status)为未结束，那么只能查看不能修改，此时从函数读取

--- a/app/models.py
+++ b/app/models.py
@@ -1337,8 +1337,6 @@ class CourseManager(models.Manager):
                                         ])
 
 
-
-
 class Course(models.Model):
     """
     助教发布课程需要填写的信息
@@ -1483,6 +1481,22 @@ class CourseParticipant(models.Model):
     )
 
 
+class CourseRecordManager(models.Manager):
+    def current(self):
+        # 选择当前学期的学时
+        return self.filter(
+            year=current_year(),
+            semester__contains=Semester.now().value,
+        )
+
+    def past(self):
+        # 只存在当前学期和过去的，非本学期即是过去
+        return self.exclude(
+            year=current_year(),
+            semester__contains=Semester.now().value,
+        )
+
+
 class CourseRecord(models.Model):
     class Meta:
         verbose_name = "学时表"
@@ -1507,6 +1521,8 @@ class CourseRecord(models.Model):
     )
     total_hours = models.FloatField("总计参加学时")
     attend_times = models.IntegerField("参加课程次数", default=0)
+
+    objects: CourseRecordManager = CourseRecordManager()
 
     def get_course_name(self):
         if self.course is not None:

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -77,9 +77,14 @@
 
           {% if editable %}
             <button type="submit" class="btn btn-primary btn-block mb-4 mr-2" value=""
-                onclick="return confirm('确认提交学时信息？学时更新后将会给全体参课成员发送消息！确认后请耐心等待，不要重复点击本按钮。')">
+                onclick="return confirm('确认提交学时信息？确认后请耐心等待，不要重复点击本按钮。')">
                 提交学时信息
             </button>
+          {% else %}
+          <button type="submit" class="btn btn-primary btn-block mb-4 mr-2" name="post_type" value="end"
+            onclick="return confirm('确认结束课程？结束课程后每周定时活动将不再发布且学时表将自动创建。确认后请耐心等待，不要重复点击本按钮。')">
+          结束课程
+          </button>
           {% endif %}
         </form>
       </div>

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -81,10 +81,10 @@
                 提交学时信息
             </button>
           {% else %}
-          <button type="submit" class="btn btn-primary btn-block mb-4 mr-2" name="post_type" value="end"
-            onclick="return confirm('确认结束课程？结束课程后每周定时活动将不再发布且学时表将自动创建。确认后请耐心等待，不要重复点击本按钮。')">
-          结束课程
-          </button>
+            <button type="submit" class="btn btn-primary btn-block mb-4 mr-2" name="post_type" value="end"
+                onclick="return confirm('确认结束课程？结束课程后每周定时活动将不再发布且学时表将自动创建。确认后请耐心等待，不要重复点击本按钮。')">
+                结束课程
+            </button>
           {% endif %}
         </form>
       </div>

--- a/templates/lesson_add.html
+++ b/templates/lesson_add.html
@@ -147,18 +147,18 @@
                                     <table>
                                         <tr>
                                             <button type="submit" class="btn btn-primary btn-lg mb-4 mr-2"
-                                                     name="post_type"
-                                                     value="modify_only"
+                                                    name="post_type"
+                                                    value="modify_only"
                                                     onclick="return confirm('确认修改活动信息？由于需要发送通知，点击提交后请耐心等待，不要重复点击！')""
                                             >仅修改当前活动
                                             </button>
                                         </tr>
                                         <tr>
                                             <button type="submit" class="btn btn-primary btn-lg mb-4 mr-2"
-                                                     name="post_type"
+                                                    name="post_type"
                                                     value="modify_all"
                                                     onclick="return confirm('确认修改活动信息？由于需要发送通知，点击提交后请耐心等待，不要重复点击！')""
-                                            >修改当前时段所有活动
+                                            >修改未来同时段所有活动
                                             </button>
                                         </tr>
                                     </table>

--- a/templates/org_show_course_activity.html
+++ b/templates/org_show_course_activity.html
@@ -134,7 +134,7 @@
                                                                             <label for="cancel_only">仅取消当前活动</label>
                                                                             <br/>
                                                                             <input type="radio" id="cancel_all" name="post_type" value="cancel_all"/>
-                                                                            <label for="cancel_all">取消该时段所有活动</label>
+                                                                            <label for="cancel_all">取消未来的同时段所有活动</label>
                                                                         </div>
                                                                         <div class="modal-footer">
                                                                                 <input type="hidden" name="cancel-action" value="{{act.id}}">

--- a/templates/org_show_course_activity.html
+++ b/templates/org_show_course_activity.html
@@ -134,7 +134,7 @@
                                                                             <label for="cancel_only">仅取消当前活动</label>
                                                                             <br/>
                                                                             <input type="radio" id="cancel_all" name="post_type" value="cancel_all"/>
-                                                                            <label for="cancel_all">取消未来的同时段所有活动</label>
+                                                                            <label for="cancel_all">取消未来同时段所有活动</label>
                                                                         </div>
                                                                         <div class="modal-footer">
                                                                                 <input type="hidden" name="cancel-action" value="{{act.id}}">

--- a/templates/register_course.html
+++ b/templates/register_course.html
@@ -287,13 +287,8 @@
 
                                                 {% for pic in defaultpics %}
                                                 <div class="col-xl-4 col-lg-4 col-md-4 mb-5">
-                                                    {% if pic.id == "picture1" %}
                                                     <input class="form-check-input" type="checkbox" value={{pic.src}}
-                                                        id={{pic.id}} name={{pic.id}} checked="checked">
-                                                    {% else %}
-                                                    <input class="form-check-input" type="checkbox" value={{pic.src}}
-                                                        id={{pic.id}} name={{pic.id}}>
-                                                    {% endif %}
+                                                        id={{pic.id}} name={{pic.id}} {% if forloop.first %} checked {% endif %} >
                                                     <label class="form-check-label" for="defaultCheck1">
                                                         <img src={{pic.src}} class="img-fluid">
                                                     </label>

--- a/templates/user_left_navbar.html
+++ b/templates/user_left_navbar.html
@@ -131,15 +131,11 @@
             <li class="menu">
                 <a href="/selectCourse/" aria-expanded="false" class="dropdown-toggle">
                     <div class="">
-<<<<<<< HEAD
-                        <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-smile'><circle cx='12' cy='12' r='10'></circle><path d='M8 14s1.5 2 4 2 4-2 4-2'></path><line x1='9' y1='9' x2='9.01' y2='9'></line><line x1='15' y1='9' x2='15.01' y2='9'></line></svg>
-=======
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
                             <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
                         </svg>
->>>>>>> 9272948db92576a0d55377a6021c3b9db8fbb803
                         <span>书院课程</span>
                     </div>
                 </a>

--- a/templates/user_left_navbar.html
+++ b/templates/user_left_navbar.html
@@ -128,7 +128,14 @@
                 </a>
             </li>
             {% else %}
-            
+            <li class="menu">
+                <a href="/selectCourse/" aria-expanded="false" class="dropdown-toggle">
+                    <div class="">
+                        <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-smile'><circle cx='12' cy='12' r='10'></circle><path d='M8 14s1.5 2 4 2 4-2 4-2'></path><line x1='9' y1='9' x2='9.01' y2='9'></line><line x1='15' y1='9' x2='15.01' y2='9'></line></svg>
+                        <span>书院课程</span>
+                    </div>
+                </a>
+            </li>
             <li class="menu">
                 <a href="/showPosition/" aria-expanded="false" class="dropdown-toggle">
                     <div class="">


### PR DESCRIPTION
实现逻辑：
（1）课程小组非小组成员、老师和负责人（书院辅导员）均无法计入学时；
（2）每次刷新学时呈现页面，更新参与次数，避免出现助教手动调整签到或者未结束课程活动结束后导致参与次数的修改无法在学时表中呈现出来；
（3）增加结束课程按钮（前提是所有课程活动均结束！）：
功能如下：a）取消每周定时发布活动的逻辑；b)创建学时表（注意去重）；c）通知选课同学，该课程已结束。