### PR TITLE
导出学时记录为表格 （前端+后端）

### DIFF
--- a/app/course_views.py
+++ b/app/course_views.py
@@ -310,7 +310,7 @@ def showCourseRecord(request):
                     wrong('学时修改尚未开放。如有疑问，请联系管理员！'), request.path))
         # 导出学时为表格
         if request.POST.get("download_course_record") is not None:
-            response = downloadCourseRecord(me)
+            response = downloadCourseRecord(me,year,semester)
             return response
         # 不是其他post类型时的默认行为
         with transaction.atomic():
@@ -619,7 +619,7 @@ def addCourse(request, cid=None):
     return render(request, "register_course.html", locals())
 
 
-def downloadCourseRecord(me):
+def downloadCourseRecord(me,year,semester):
     '''
     返回需要导出的文件
     '''
@@ -642,7 +642,7 @@ def downloadCourseRecord(me):
     wb.encoding = 'utf-8'
     sheet1 = wb.active	# 获取第一个工作表（sheet1）
     sheet1.title = str(me.oname) 	# 给工作表1设置标题
-    sheet_header = ['姓名','年级','次数','学时']
+    sheet_header = ['姓名','年级','次数','学时','学年','学期']
     for i in range(len(sheet_header)):	# 从第一行开始写，因为Excel文件的行号是从1开始，列号也是从1开始
         sheet1.cell(row=1, column=i+1).value=sheet_header[i]
     max_row = sheet1.max_row
@@ -652,7 +652,10 @@ def downloadCourseRecord(me):
             record.person.name, 
             str(record.person.person_id)[:2], 
             record.attend_times, 
-            record.total_hours ]
+            record.total_hours,
+            str(year),
+            str(semester),
+            ]
         for x in range(len(record_info)):		# 将每一个对象的所有字段的信息写入一行内
             sheet1.cell(row=max_row, column=x+1).value = record_info[x]
             

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -31,6 +31,8 @@ from datetime import datetime
 from django.db import transaction
 from io import BytesIO
 from openpyxl import Workbook
+import re
+from zhon.hanzi import punctuation
 
 __all__ = [
     'editCourseActivity',
@@ -641,7 +643,7 @@ def downloadCourseRecord(me,year,semester):
     wb = Workbook()		# 生成一个工作簿（即一个Excel文件）
     wb.encoding = 'utf-8'
     sheet1 = wb.active	# 获取第一个工作表（sheet1）
-    sheet1.title = str(me.oname) 	# 给工作表1设置标题
+    sheet1.title = re.sub('[{}]'.format(punctuation),"",str(me.oname)) # 给工作表设置标题
     sheet_header = ['课程','姓名','学号','次数','学时',"学年","学期"]
     for i in range(len(sheet_header)):	# 从第一行开始写，因为Excel文件的行号是从1开始，列号也是从1开始
         sheet1.cell(row=1, column=i+1).value=sheet_header[i]
@@ -664,6 +666,7 @@ def downloadCourseRecord(me,year,semester):
     output.seek(0)	 # 重新定位到开始
     ctime = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     file_name = str(me.oname)+'-{}'.format(ctime)	# 给文件名中添加日期时间
+    file_name = re.sub('[{}]'.format(punctuation),"",file_name) #去除中文符号
     response = HttpResponse(content_type='application/msexcel')
     response['Content-Disposition'] = 'attachment;filename={}.xlsx'.format(file_name).encode('utf-8')
     wb.save(response)

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -650,7 +650,7 @@ def downloadCourseRecord(me):
         max_row += 1
         record_info = [
             record.person.name, 
-            str(record.person.person_id), 
+            str(record.person.person_id)[:2], 
             record.attend_times, 
             record.total_hours ]
         for x in range(len(record_info)):		# 将每一个对象的所有字段的信息写入一行内

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -642,20 +642,20 @@ def downloadCourseRecord(me,year,semester):
     wb.encoding = 'utf-8'
     sheet1 = wb.active	# 获取第一个工作表（sheet1）
     sheet1.title = str(me.oname) 	# 给工作表1设置标题
-    sheet_header = ['姓名','年级','次数','学时','学年','学期']
+    sheet_header = ['课程','姓名','学号','次数','学时',"学年","学期"]
     for i in range(len(sheet_header)):	# 从第一行开始写，因为Excel文件的行号是从1开始，列号也是从1开始
         sheet1.cell(row=1, column=i+1).value=sheet_header[i]
     max_row = sheet1.max_row
     for record in records:
         max_row += 1
         record_info = [
+            str(me.oname),
             record.person.name, 
-            str(record.person.person_id)[:2], 
+            str(record.person.person_id), 
             record.attend_times, 
             record.total_hours,
             str(year),
-            str(semester),
-            ]
+            str(semester) ]
         for x in range(len(record_info)):		# 将每一个对象的所有字段的信息写入一行内
             sheet1.cell(row=max_row, column=x+1).value = record_info[x]
             
@@ -663,8 +663,8 @@ def downloadCourseRecord(me,year,semester):
     wb.save(output)	 # 将Excel文件内容保存到IO中
     output.seek(0)	 # 重新定位到开始
     ctime = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    file_name = 'CourseRecord-{}'.format(ctime)	# 给文件名中添加日期时间
+    file_name = str(me.oname)+'-{}'.format(ctime)	# 给文件名中添加日期时间
     response = HttpResponse(content_type='application/msexcel')
-    response['Content-Disposition'] = 'attachment;filename={}.xlsx'.format(file_name)
+    response['Content-Disposition'] = 'attachment;filename={}.xlsx'.format(file_name).encode('utf-8')
     wb.save(response)
     return response

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -17,32 +17,36 @@
         </div> <br>
         {% endif %}
 
-        <h3 class="text-primary" style="display:inline-block; vertical-align:middle; ">
-          {{course_info.year}}年{{course_info.semester}}{{course_info.course}}学时记录
-          <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="" data-original-title="在服务器开启权限后，才可以修改表格中的学时信息。">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 22 22" style="color:rgba(0, 0, 0, 0.404);">
+        <div style="vertical-align: middle;display: inline-block;">
+          <h3 class="text-primary" style="display:table-cell; vertical-align:middle; ">
+            {{course_info.year}}年{{course_info.semester}}{{course_info.course}}学时记录
+          </h3>
+
+          {% if editable %}
+            <div class="btn-group" role="group" style="display: table-cell; vertical-align:middle; left:20px;">
+              <form method="POST">
+                <button class="btn btn-sm btn-primary" name="download_course_record">
+                    <i class="bi bi-solid bi-download" style="font-size:15px; "></i>
+                </button>
+              </form>
+            </div>
+          {% endif %}
+        </div>
+
+        <div>
+          <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="" data-original-title="在服务器开启权限后，才可双击修改表格中的学时信息。">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 22 22" style="color:rgba(0, 0, 0, 0.404);">
                 <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"></path>
             </svg>
-          </a>
-        </h3>
-        
-        {% if editable %}
-          <div class="btn-group" role="group" style="display: inline-block; vertical-align:middle; left:100px;">
-            <form method="POST">
-              <button class="btn btn-success" name="download_course_record">
-                  <i class="bi bi-solid bi-download" style="font-size:15px;"></i>
-              </button>
-            </form>
-          </div>
-        {% endif %}
-       
+          </a>       
+        </div>
+
         <div class="col-12 row layout-spacing" style="text-align: left;">
           <div class="col-xl-3 col-lg-3 col-md-3 col-sm-0"></div>
           <div class="input-group mb-3 col-xl-6 col-lg-6 col-md-6 col-sm-12"></div> 
         </div>
 
         <form method="POST">
-                        
           <div class="col-12 layout-spacing">
             <div class="statbox widget box box-shadow">
               <table class="table table-striped table-active" id="store_table">

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block mainpage %}
-
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
   <div id="content" class="main-content">   
     {% if messages.warn_code == 1 %}
     <div class="alert alert-warning  text-center">{{ messages.warn_message }}</div>
@@ -17,7 +17,7 @@
         </div> <br>
         {% endif %}
 
-        <h3 class="text-primary" >
+        <h3 class="text-primary" style="display:inline-block; vertical-align:middle; ">
           {{course_info.year}}年{{course_info.semester}}{{course_info.course}}学时记录
           <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="" data-original-title="在服务器开启权限后，才可双击修改表格中的学时信息。">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 22 22" style="color:rgba(0, 0, 0, 0.404);">
@@ -26,6 +26,15 @@
           </a>
         </h3>
         
+        {% if editable %}
+          <div class="btn-group" role="group" style="display: inline-block; vertical-align:middle;">
+            <form method="POST">
+              <button class="btn btn-outline" name="download_course_record">
+                  <i class="bi bi-solid bi-download" style="font-size:15px;"></i>
+              </button>
+            </form>
+          </div>
+        {% endif %}
        
         <div class="col-12 row layout-spacing" style="text-align: left;">
           <div class="col-xl-3 col-lg-3 col-md-3 col-sm-0"></div>
@@ -35,9 +44,6 @@
         <form method="POST">
                         
           <div class="col-12 layout-spacing">
-            {% if editable %}
-            <button type="submit" class="btn btn-success" name="download_course_record" style="position:absolute; left:5%">导出学时为表格</button><br><br>
-            {% endif %}
             <div class="statbox widget box box-shadow">
               <table class="table table-striped table-active" id="store_table">
                 <thead>

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -76,7 +76,8 @@
           </div>
 
           {% if editable %}
-            <button type="submit" class="btn btn-primary btn-block mb-4 mr-2" value=""
+            <button type="submit" class="btn btn-success" name="download_course_record" style="position:absolute; left:20%">导出学时为表格</button>
+            <button type="submit" class="btn btn-primary mb-4 mr-2" value=""
                 onclick="return confirm('确认提交学时信息？学时更新后将会给全体参课成员发送消息！确认后请耐心等待，不要重复点击本按钮。')">
                 提交学时信息
             </button>

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -27,7 +27,7 @@
         </h3>
         
         {% if editable %}
-          <div class="btn-group" role="group" style="display: inline-block; vertical-align:middle;">
+          <div class="btn-group" role="group" style="display: inline-block; vertical-align:middle; left:20px;">
             <form method="POST">
               <button class="btn btn-outline" name="download_course_record">
                   <i class="bi bi-solid bi-download" style="font-size:15px;"></i>

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -19,7 +19,7 @@
 
         <h3 class="text-primary" style="display:inline-block; vertical-align:middle; ">
           {{course_info.year}}年{{course_info.semester}}{{course_info.course}}学时记录
-          <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="" data-original-title="在服务器开启权限后，才可双击修改表格中的学时信息。">
+          <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="" data-original-title="在服务器开启权限后，才可以修改表格中的学时信息。">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 22 22" style="color:rgba(0, 0, 0, 0.404);">
                 <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"></path>
             </svg>
@@ -27,9 +27,9 @@
         </h3>
         
         {% if editable %}
-          <div class="btn-group" role="group" style="display: inline-block; vertical-align:middle; left:20px;">
+          <div class="btn-group" role="group" style="display: inline-block; vertical-align:middle; left:100px;">
             <form method="POST">
-              <button class="btn btn-outline" name="download_course_record">
+              <button class="btn btn-success" name="download_course_record">
                   <i class="bi bi-solid bi-download" style="font-size:15px;"></i>
               </button>
             </form>

--- a/templates/course_record.html
+++ b/templates/course_record.html
@@ -35,7 +35,9 @@
         <form method="POST">
                         
           <div class="col-12 layout-spacing">
+            {% if editable %}
             <button type="submit" class="btn btn-success" name="download_course_record" style="position:absolute; left:5%">导出学时为表格</button><br><br>
+            {% endif %}
             <div class="statbox widget box box-shadow">
               <table class="table table-striped table-active" id="store_table">
                 <thead>


### PR DESCRIPTION
##### 导出学时记录为表格 （前端+后端）
现在的实现不需要在服务器上储存excel文件，而是直接下载到用户浏览器里
已实现在文件名中加入中文
<img width="959" alt="屏幕截图 2022-02-20 103202" src="https://user-images.githubusercontent.com/97432569/154826131-2bddbc0c-6667-44a9-bc47-35b32b893824.png">

<img width="589" alt="屏幕截图 2022-02-20 092501" src="https://user-images.githubusercontent.com/97432569/154824794-68052558-af20-4342-b7d7-87467c908c0d.png">
