### PR TITLE
选课页面+课程详情页

### DIFF
--- a/templates/activity_info.html
+++ b/templates/activity_info.html
@@ -529,12 +529,12 @@
                                     
                                     {% if person.status == "未签到" %}
 
-                                    <div class="messages" style="background-color: rgb(248, 76, 76);">  
+                                    <div class="messages" style="background-color: rgb(255, 132, 132);">   
                                         <a data-toggle="tooltip" data-placement="bottom" title="未签到">&nbsp;
                                         </a>
                                     </div>
                                     {% elif person.status == "已参与" %}
-                                    <div class="messages" style="background-color: rgb(101, 219, 97);">  
+                                    <div class="messages" style="background-color: rgb(163, 219, 161);">
                                         <a data-toggle="tooltip" data-placement="bottom" title="已签到">&nbsp;
                                         </a>
                                     </div>

--- a/templates/course_info.html
+++ b/templates/course_info.html
@@ -44,6 +44,12 @@
                         </td>
                     </tr>
                     <tr>
+                        <th width="20%" style="background-color: rgb(192, 190, 190); text-align: center;"> 上课地点</th>
+                        <td colspan="8"> 
+                            {{course.classroom}}
+                        </td>
+                    </tr>
+                    <tr>
                         <th width="20%" style="background-color: rgb(192, 190, 190); text-align: center;"> 课程简介</th>
                         <td colspan="8"> 
                             {{course.introduction}}

--- a/templates/select_course.html
+++ b/templates/select_course.html
@@ -13,8 +13,8 @@
 
     <div style="text-align: center;">
         <br>
-        <h4 class="text-primary">{{html_display.current_year}}学年{{html_display.semester}}季学期书院课程选课页面</h4>
-        {% comment %} 从后端获取学期数据 {% endcomment %}
+        <h4 class="text-primary">{{html_display.current_year}}学年{{html_display.semester}}书院选课</h4>
+        <!-- TODO : 从后端获取学期数据-->
         <br>
     </div>
 
@@ -23,6 +23,7 @@
         <p style="margin-top: 0%;">补退选时间：{{html_display.btx_election_start}}至{{html_display.btx_election_end}}</p>
     </div>
 
+    <div class="container-fluid">
     <!--  BEGIN SWITCH TAB  -->
     <ul class="nav nav-tabs nav-tabs-solid nav-justified" role="tablist">
         <li class="nav-item">
@@ -49,9 +50,10 @@
         </li>
     </ul>
     <!--  END SWITCH TAB  -->
+    </div>
 
     <div class="container-fluid tab-content" id="myTabContent">
-        {% comment %} 后端对接bool值 {% endcomment %}
+        <!--TODO : 后端对接bool值-->
         {% if is_drawing == True %}
         <div class="tab-pane fade show active" id="information" role="tabpanel">
             <div class="col-12 layout-top-spacing">
@@ -67,39 +69,51 @@
             </div>
         </div>
 
+        {% elif unselected_display|length == 0 %}<!--没有课程-->
+        <div class="tab-pane fade show active" id="information" role="tabpanel">
+            <div class="col-12 layout-top-spacing">
+                <br>
+                <p style="text-align: center;">暂时没有课程哦！</p>
+            </div>
+        </div>
+
         {% else %}
         <!--  BEGIN INFORMATION TAB  -->
         <div class="tab-pane fade show active" id="information" role="tabpanel">
             <div class="col-12 layout-top-spacing">
                 <div class="statbox widget box box-shadow">
                     <!-- Nav pills -->
-                    <ul class="nav nav-pills" role="tablist" style="flex-wrap: nowrap; overflow-x: auto">
+                    <ul class="nav nav-pills" role="tablist">
                         <li class="nav-item">
                             <a class="nav-link active" data-toggle="pill" href="#all">
                                 <span class="badge badge-pill badge-secondary">全部课程</span>
                             </a>
                         </li>
-                        {% for course_type_name in courses.keys %}
                         <li class="nav-item">
-                            <a class="nav-link" data-toggle="pill" href="#menu{{ forloop.counter }}">
-                                <span class="badge badge-pill" style="color:white;
-                                    {% if forloop.counter == 1 %}
-                                        background-color: #0092c7;
-                                    {% elif forloop.counter == 2 %}
-                                        background-color: #22c3aa;
-                                    {% elif forloop.counter == 3 %}
-                                        background-color: #AD8976;
-                                    {% elif forloop.counter == 4 %}
-                                        background-color: #f3b59b;
-                                    {% elif forloop.counter == 5 %}
-                                        background-color: #f29c9c;
-                                    {% else %}
-                                        background-color: #9E9EA3;
-                                    {% endif %}
-                                    ">{{ course_type_name }}</span>
+                            <a class="nav-link" data-toggle="pill" href="#menu0">
+                                <span class="badge badge-pill" style="color:white; background-color: #0092c7;">德</span>
                             </a>
                         </li>
-                        {% endfor %}
+                        <li class="nav-item">
+                            <a class="nav-link" data-toggle="pill" href="#menu1">
+                                <span class="badge badge-pill" style="color:white; background-color: #22c3aa;">智</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" data-toggle="pill" href="#menu2">
+                                <span class="badge badge-pill" style="color:white; background-color: #AD8976;">体</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" data-toggle="pill" href="#menu3">
+                                <span class="badge badge-pill" style="color:white; background-color: #f3b59b;">美</span>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" data-toggle="pill" href="#menu4">
+                                <span class="badge badge-pill" style="color:white; background-color: #f29c9c;">劳</span>
+                            </a>
+                        </li>
                     </ul>
 
                     <!-- Tab panes -->
@@ -109,11 +123,12 @@
     
                                 <thead>
                                   <tr>
-                                    <th scope="col" width="25%">课程名称</th>
-                                    <th scope="col" width="25%">上课时间</th>
+                                    <th scope="col" width="20%">课程名称</th>
+                                    <th scope="col" width="20%">上课时间</th>
+                                    <th scope="col" width="10%">课程周数</th>
                                     <th scope="col" width="10%">课程类型</th>
                                     <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">选课人数/容量</th>
+                                    <th scope="col" width="15%">容量/选课人数</th>
                                     <th scope="col" >操作</th>
                                   </tr>
                                 </thead>
@@ -122,22 +137,24 @@
                                   {% for course in unselected_display %}
                                   <tr>
                                     <th scope="row">
-                                        {% comment %} 课程小组头像路径 {% endcomment %}
+                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
                                         <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                                        <a href='/viewCourse/?courseid={{ course.course_id }}'>{% comment %} 做一个新的课程详情页 {% endcomment %}
+                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
                                             <u>{{course.name}}</u>
                                         </a>
                                     </th>
                                     <td>
                                         {% for time in course.time_set %}
+                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
                                             {{time}}<br>
                                         {% endfor %}
                                         {% if course.time_set|length == 0 %}
                                             时间待定
                                         {% endif %}
                                     </td>
+                                    <td>{{course.times}}</td>
                                     <td>{{course.type}}</td>
-                                    {% comment %} 注意这里的status是课程的，除了已撤销的四个都在这儿 {% endcomment %}
+                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
                                     <td>
                                         {% if course.status == "未开始" %}
                                         <span class="badge badge-pill badge-dark">{{course.status}}</span>
@@ -151,7 +168,7 @@
                                         <span class="badge badge-pill badge-warning">{{course.status}}</span>
                                         {% endif %}
                                     </td>
-                                    <td>{{course.current_participants}}/{{course.capacity}}</td>
+                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
                                     <td>
                                         <form action="/selectCourse/" method="post">
                                             <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
@@ -185,41 +202,43 @@
                                 </tbody>
                             </table>
                         </div>
-                        {% for course_type_name, typed_courses in courses.items %}
-                        <div id="menu{{ forloop.counter }}" class="tab-pane fade">
+                        <div id="menu0" class="tab-pane fade">
                             <table class="table table-striped table-responsive-sm table-active">
     
                                 <thead>
                                   <tr>
-                                    <th scope="col" width="25%">课程名称</th>
-                                    <th scope="col" width="25%">上课时间</th>
+                                    <th scope="col" width="20%">课程名称</th>
+                                    <th scope="col" width="20%">上课时间</th>
+                                    <th scope="col" width="10%">课程周数</th>
                                     <th scope="col" width="10%">课程类型</th>
                                     <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">选课人数/容量</th>
+                                    <th scope="col" width="15%">容量/选课人数</th>
                                     <th scope="col" >操作</th>
                                   </tr>
                                 </thead>
             
                                 <tbody class="table">
-                                  {% for course in typed_courses %}
+                                  {% for course in courses.0 %}
                                   <tr>
                                     <th scope="row">
-                                        {% comment %} 课程小组头像路径 {% endcomment %}
+                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
                                         <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                                        <a href='/viewCourse/?courseid={{ course.course_id }}'>{% comment %} 做一个新的课程详情页 {% endcomment %}
+                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
                                             <u>{{course.name}}</u>
                                         </a>
                                     </th>
                                     <td>
                                         {% for time in course.time_set %}
+                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
                                             {{time}}<br>
                                         {% endfor %}
                                         {% if course.time_set|length == 0 %}
                                             时间待定
                                         {% endif %}
                                     </td>
+                                    <td>{{course.times}}</td>
                                     <td>{{course.type}}</td>
-                                    {% comment %} 注意这里的status是课程的，除了已撤销的四个都在这儿 {% endcomment %}
+                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
                                     <td>
                                         {% if course.status == "未开始" %}
                                         <span class="badge badge-pill badge-dark">{{course.status}}</span>
@@ -233,7 +252,7 @@
                                         <span class="badge badge-pill badge-warning">{{course.status}}</span>
                                         {% endif %}
                                     </td>
-                                    <td>{{course.current_participants}}/{{course.capacity}}</td>
+                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
                                     <td>
                                         <form action="/selectCourse/" method="post">
                                             <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
@@ -241,8 +260,8 @@
                                             {% if course.status != "预选" and course.status != "补退选" %}
                                             <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
                                             {% else %}
-                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal{{ forloop.counter }}-{{course.course_id}}">选课</button>
-                                            <div class="modal fade" id="myModal{{ forloop.counter }}-{{course.course_id}}">
+                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal0-{{course.course_id}}">选课</button>
+                                            <div class="modal fade" id="myModal0-{{course.course_id}}">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                   <div class="modal-content">
                                                     <!-- 模态框主体 -->
@@ -266,7 +285,347 @@
                                 </tbody>
                             </table>
                         </div>
-                        {% endfor %}
+                          
+                        <div id="menu1" class="tab-pane fade">
+                            <table class="table table-striped table-responsive-sm table-active">
+    
+                                <thead>
+                                  <tr>
+                                    <th scope="col" width="20%">课程名称</th>
+                                    <th scope="col" width="20%">上课时间</th>
+                                    <th scope="col" width="10%">课程周数</th>
+                                    <th scope="col" width="10%">课程类型</th>
+                                    <th scope="col" width="15%">状态</th>
+                                    <th scope="col" width="15%">容量/选课人数</th>
+                                    <th scope="col" >操作</th>
+                                  </tr>
+                                </thead>
+            
+                                <tbody class="table">
+                                
+                                  {% for course in courses.1 %}
+                                  <tr>
+                                    <th scope="row">
+                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
+                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
+                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
+                                            <u>{{course.name}}</u>
+                                        </a>
+                                    </th>
+                                    <td>
+                                        {% for time in course.time_set %}
+                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
+                                            {{time}}<br>
+                                        {% endfor %}
+                                        {% if course.time_set|length == 0 %}
+                                            时间待定
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.times}}</td>
+                                    <td>{{course.type}}</td>
+                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
+                                    <td>
+                                        {% if course.status == "未开始" %}
+                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
+                                        {% elif course.status == "预选" %}
+                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
+                                        {% elif course.status == "补退选" %}
+                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
+                                        {% elif course.status == "选课结束" %}
+                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
+                                        {% else %}
+                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
+                                    <td>
+                                        <form action="/selectCourse/" method="post">
+                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
+                                            <input type="hidden" id="action" name="action"value="select" />
+                                            {% if course.status != "预选" and course.status != "补退选" %}
+                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
+                                            {% else %}
+                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal1-{{course.course_id}}">选课</button>
+                                            <div class="modal fade" id="myModal1-{{course.course_id}}">
+                                                <div class="modal-dialog modal-dialog-centered">
+                                                  <div class="modal-content">
+                                                    <!-- 模态框主体 -->
+                                                    <div class="modal-body">
+                                                      你确定要选课程《{{course.name}}》吗？
+                                                    </div>
+                                                    <!-- 模态框底部 -->
+                                                    <div class="modal-footer">
+                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
+                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                            </div>
+                                            {% endif %}
+                                        </form>
+                                        
+                                    </td>
+                                  </tr>
+                                  {% endfor %}
+                                
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="menu2" class="tab-pane fade">
+                            <table class="table table-striped table-responsive-sm table-active">
+    
+                                <thead>
+                                  <tr>
+                                    <th scope="col" width="20%">课程名称</th>
+                                    <th scope="col" width="20%">上课时间</th>
+                                    <th scope="col" width="10%">课程周数</th>
+                                    <th scope="col" width="10%">课程类型</th>
+                                    <th scope="col" width="15%">状态</th>
+                                    <th scope="col" width="15%">容量/选课人数</th>
+                                    <th scope="col" >操作</th>
+                                  </tr>
+                                </thead>
+            
+                                <tbody class="table">
+                                
+                                  {% for course in courses.2 %}
+                                  <tr>
+                                    <th scope="row">
+                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
+                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
+                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
+                                            <u>{{course.name}}</u>
+                                        </a>
+                                    </th>
+                                    <td>
+                                        {% for time in course.time_set %}
+                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
+                                            {{time}}<br>
+                                        {% endfor %}
+                                        {% if course.time_set|length == 0 %}
+                                            时间待定
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.times}}</td>
+                                    <td>{{course.type}}</td>
+                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
+                                    <td>
+                                        {% if course.status == "未开始" %}
+                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
+                                        {% elif course.status == "预选" %}
+                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
+                                        {% elif course.status == "补退选" %}
+                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
+                                        {% elif course.status == "选课结束" %}
+                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
+                                        {% else %}
+                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
+                                    <td>
+                                        <form action="/selectCourse/" method="post">
+                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
+                                            <input type="hidden" id="action" name="action"value="select" />
+                                            {% if course.status != "预选" and course.status != "补退选" %}
+                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
+                                            {% else %}
+                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal2-{{course.course_id}}">选课</button>
+                                            <div class="modal fade" id="myModal2-{{course.course_id}}">
+                                                <div class="modal-dialog modal-dialog-centered">
+                                                  <div class="modal-content">
+                                                    <!-- 模态框主体 -->
+                                                    <div class="modal-body">
+                                                      你确定要选课程《{{course.name}}》吗？
+                                                    </div>
+                                                    <!-- 模态框底部 -->
+                                                    <div class="modal-footer">
+                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
+                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                            </div>
+                                            {% endif %}
+                                        </form>
+                                        
+                                    </td>
+                                  </tr>
+                                  {% endfor %}
+                                
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="menu3" class="tab-pane fade">
+                            <table class="table table-striped table-responsive-sm table-active">
+    
+                                <thead>
+                                  <tr>
+                                    <th scope="col" width="20%">课程名称</th>
+                                    <th scope="col" width="20%">上课时间</th>
+                                    <th scope="col" width="10%">课程周数</th>
+                                    <th scope="col" width="10%">课程类型</th>
+                                    <th scope="col" width="15%">状态</th>
+                                    <th scope="col" width="15%">容量/选课人数</th>
+                                    <th scope="col" >操作</th>
+                                  </tr>
+                                </thead>
+            
+                                <tbody class="table">
+                                
+                                  {% for course in courses.3 %}
+                                  <tr>
+                                    <th scope="row">
+                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
+                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
+                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
+                                            <u>{{course.name}}</u>
+                                        </a>
+                                    </th>
+                                    <td>
+                                        {% for time in course.time_set %}
+                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
+                                            {{time}}<br>
+                                        {% endfor %}
+                                        {% if course.time_set|length == 0 %}
+                                            时间待定
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.times}}</td>
+                                    <td>{{course.type}}</td>
+                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
+                                    <td>
+                                        {% if course.status == "未开始" %}
+                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
+                                        {% elif course.status == "预选" %}
+                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
+                                        {% elif course.status == "补退选" %}
+                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
+                                        {% elif course.status == "选课结束" %}
+                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
+                                        {% else %}
+                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
+                                    <td>
+                                        <form action="/selectCourse/" method="post">
+                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
+                                            <input type="hidden" id="action" name="action"value="select" />
+                                            {% if course.status != "预选" and course.status != "补退选" %}
+                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
+                                            {% else %}
+                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal3-{{course.course_id}}">选课</button>
+                                            <div class="modal fade" id="myModal3-{{course.course_id}}">
+                                                <div class="modal-dialog modal-dialog-centered">
+                                                  <div class="modal-content">
+                                                    <!-- 模态框主体 -->
+                                                    <div class="modal-body">
+                                                      你确定要选课程《{{course.name}}》吗？
+                                                    </div>
+                                                    <!-- 模态框底部 -->
+                                                    <div class="modal-footer">
+                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
+                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                            </div>
+                                            {% endif %}
+                                        </form>
+                                        
+                                    </td>
+                                  </tr>
+                                  {% endfor %}
+                                
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="menu4" class="tab-pane fade">
+                            <table class="table table-striped table-responsive-sm table-active">
+    
+                                <thead>
+                                  <tr>
+                                    <th scope="col" width="20%">课程名称</th>
+                                    <th scope="col" width="20%">上课时间</th>
+                                    <th scope="col" width="10%">课程周数</th>
+                                    <th scope="col" width="10%">课程类型</th>
+                                    <th scope="col" width="15%">状态</th>
+                                    <th scope="col" width="15%">容量/选课人数</th>
+                                    <th scope="col" >操作</th>
+                                  </tr>
+                                </thead>
+            
+                                <tbody class="table">
+                                
+                                  {% for course in courses.4 %}
+                                  <tr>
+                                    <th scope="row">
+                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
+                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
+                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
+                                            <u>{{course.name}}</u>
+                                        </a>
+                                    </th>
+                                    <td>
+                                        {% for time in course.time_set %}
+                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
+                                            {{time}}<br>
+                                        {% endfor %}
+                                        {% if course.time_set|length == 0 %}
+                                            时间待定
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.times}}</td>
+                                    <td>{{course.type}}</td>
+                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
+                                    <td>
+                                        {% if course.status == "未开始" %}
+                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
+                                        {% elif course.status == "预选" %}
+                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
+                                        {% elif course.status == "补退选" %}
+                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
+                                        {% elif course.status == "选课结束" %}
+                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
+                                        {% else %}
+                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
+                                    <td>
+                                        <form action="/selectCourse/" method="post">
+                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
+                                            <input type="hidden" id="action" name="action"value="select" />
+                                            {% if course.status != "预选" and course.status != "补退选" %}
+                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
+                                            {% else %}
+                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal4-{{course.course_id}}">选课</button>
+                                            <div class="modal fade" id="myModal4-{{course.course_id}}">
+                                                <div class="modal-dialog modal-dialog-centered">
+                                                  <div class="modal-content">
+                                                    <!-- 模态框主体 -->
+                                                    <div class="modal-body">
+                                                      你确定要选课程《{{course.name}}》吗？
+                                                    </div>
+                                                    <!-- 模态框底部 -->
+                                                    <div class="modal-footer">
+                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
+                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                            </div>
+                                            {% endif %}
+                                        </form>
+                                        
+                                    </td>
+                                  </tr>
+                                  {% endfor %}
+                                
+                                </tbody>
+                            </table>    
+                        </div>
                     </div>
 
                 </div>
@@ -275,6 +634,16 @@
         <!--  END INFORMATION TAB  -->
         {% endif %}
 
+
+        {% if selected_display|length == 0 %}<!--没有课程-->
+        <div class="tab-pane fade" id="mycourses" role="tabpanel">
+            <div class="col-12 layout-top-spacing">
+                <br>
+                <p style="text-align: center;">暂时没有课程哦！</p>
+            </div>
+        </div>
+
+        {% else %}
         <!--  BEGIN MYCOURSE TAB  -->
         <div class="tab-pane fade" id="mycourses" role="tabpanel">
             <div class="col-12 layout-top-spacing">
@@ -283,11 +652,12 @@
     
                     <thead>
                         <tr>
-                            <th scope="col" width="25%">课程名称</th>
-                            <th scope="col" width="25%">上课时间</th>
+                            <th scope="col" width="20%">课程名称</th>
+                            <th scope="col" width="20%">上课时间</th>
+                            <th scope="col" width="10%">课程周数</th>
                             <th scope="col" width="10%">课程类型</th>
                             <th scope="col" width="15%">状态</th>
-                            <th scope="col" width="15%">选课人数/容量</th>
+                            <th scope="col" width="15%">容量/选课人数</th>
                             <th scope="col" >操作</th>
                         </tr>
                     </thead>
@@ -298,21 +668,23 @@
                       <tr>
                         <th scope="row">
                             <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                            <a href='/viewCourse/?courseid={{ course.course_id }}'>{% comment %} 做一个新的课程详情页 {% endcomment %}
+                            <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
                                 <u>{{course.name}}</u>
                             </a>
                         </th>
                         <td>
                             {% for time in course.time_set %}
+                            <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
                                 {{time}}<br>
                             {% endfor %}
                             {% if course.time_set|length == 0 %}
                                 时间待定
                             {% endif %}
                         </td>
+                        <td>{{course.times}}</td>
                         <td>{{course.type}}</td>
                         <td>
-                            {% comment %} 对接后端bool值 {% endcomment %}
+                            <!--TODO : 对接后端bool值-->
                             {% if is_drawing == True %}
                             <span class="badge badge-pill badge-info">抽签中</span>
                             {% elif course.student_status == "已选课" %}
@@ -323,7 +695,7 @@
                             <span class="badge badge-pill badge-danger">{{course.student_status}}</span>
                             {% endif %}
                         </td>
-                        <td>{{course.current_participants}}/{{course.capacity}}</td>
+                        <td>{{course.capacity}}/{{course.current_participants}}</td>
                         <td>
                             <form action="/selectCourse/" method="post">
                                 <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
@@ -364,6 +736,7 @@
 
         </div>
         <!--  END MYCOURSE TAB  -->
+        {% endif %}
 
     </div>
 

--- a/templates/select_course.html
+++ b/templates/select_course.html
@@ -83,37 +83,33 @@
             <div class="col-12 layout-top-spacing">
                 <div class="statbox widget box box-shadow">
                     <!-- Nav pills -->
-                    <ul class="nav nav-pills" role="tablist">
+                    <ul class="nav nav-pills" role="tablist" style="flex-wrap: nowrap; overflow-x: auto">
                         <li class="nav-item">
                             <a class="nav-link active" data-toggle="pill" href="#all">
                                 <span class="badge badge-pill badge-secondary">全部课程</span>
                             </a>
                         </li>
+                        {% for course_type_name in courses.keys %}
                         <li class="nav-item">
-                            <a class="nav-link" data-toggle="pill" href="#menu0">
-                                <span class="badge badge-pill" style="color:white; background-color: #0092c7;">德</span>
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" data-toggle="pill" href="#menu1">
-                                <span class="badge badge-pill" style="color:white; background-color: #22c3aa;">智</span>
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" data-toggle="pill" href="#menu2">
-                                <span class="badge badge-pill" style="color:white; background-color: #AD8976;">体</span>
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" data-toggle="pill" href="#menu3">
-                                <span class="badge badge-pill" style="color:white; background-color: #f3b59b;">美</span>
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" data-toggle="pill" href="#menu4">
-                                <span class="badge badge-pill" style="color:white; background-color: #f29c9c;">劳</span>
-                            </a>
-                        </li>
+                             <a class="nav-link" data-toggle="pill" href="#menu{{ forloop.counter }}">
+                                 <span class="badge badge-pill" style="color:white;
+                                     {% if forloop.counter == 1 %}
+                                         background-color: #0092c7;
+                                     {% elif forloop.counter == 2 %}
+                                         background-color: #22c3aa;
+                                     {% elif forloop.counter == 3 %}
+                                         background-color: #AD8976;
+                                     {% elif forloop.counter == 4 %}
+                                         background-color: #f3b59b;
+                                     {% elif forloop.counter == 5 %}
+                                         background-color: #f29c9c;
+                                     {% else %}
+                                         background-color: #9E9EA3;
+                                     {% endif %}
+                                     ">{{ course_type_name }}</span>
+                              </a>
+                         </li>
+                         {% endfor %}
                     </ul>
 
                     <!-- Tab panes -->
@@ -123,12 +119,11 @@
     
                                 <thead>
                                   <tr>
-                                    <th scope="col" width="20%">课程名称</th>
-                                    <th scope="col" width="20%">上课时间</th>
-                                    <th scope="col" width="10%">课程周数</th>
+                                    <th scope="col" width="25%">课程名称</th>
+                                    <th scope="col" width="25%">上课时间</th>
                                     <th scope="col" width="10%">课程类型</th>
                                     <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">容量/选课人数</th>
+                                    <th scope="col" width="15%">选课人数/容量</th>
                                     <th scope="col" >操作</th>
                                   </tr>
                                 </thead>
@@ -168,7 +163,7 @@
                                         <span class="badge badge-pill badge-warning">{{course.status}}</span>
                                         {% endif %}
                                     </td>
-                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
+                                    <td>{{course.current_participants}}/{{course.capacity}}</td>
                                     <td>
                                         <form action="/selectCourse/" method="post">
                                             <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
@@ -202,43 +197,42 @@
                                 </tbody>
                             </table>
                         </div>
-                        <div id="menu0" class="tab-pane fade">
+                        
+                        {% for course_type_name, typed_courses in courses.items %}
+                        <div id="menu{{ forloop.counter }}" class="tab-pane fade">
                             <table class="table table-striped table-responsive-sm table-active">
     
                                 <thead>
                                   <tr>
-                                    <th scope="col" width="20%">课程名称</th>
-                                    <th scope="col" width="20%">上课时间</th>
-                                    <th scope="col" width="10%">课程周数</th>
+                                    <th scope="col" width="25%">课程名称</th>
+                                    <th scope="col" width="25%">上课时间</th>
                                     <th scope="col" width="10%">课程类型</th>
                                     <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">容量/选课人数</th>
+                                    <th scope="col" width="15%">选课人数/容量</th>
                                     <th scope="col" >操作</th>
                                   </tr>
                                 </thead>
             
                                 <tbody class="table">
-                                  {% for course in courses.0 %}
+                                  {% for course in typed_courses %}
                                   <tr>
                                     <th scope="row">
-                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
+                                        {% comment %} 课程小组头像路径 {% endcomment %}
                                         <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
+                                        <a href='/viewCourse/?courseid={{ course.course_id }}'>{% comment %} 做一个新的课程详情页 {% endcomment %}
                                             <u>{{course.name}}</u>
                                         </a>
                                     </th>
                                     <td>
                                         {% for time in course.time_set %}
-                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
                                             {{time}}<br>
                                         {% endfor %}
                                         {% if course.time_set|length == 0 %}
                                             时间待定
                                         {% endif %}
                                     </td>
-                                    <td>{{course.times}}</td>
                                     <td>{{course.type}}</td>
-                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
+                                    {% comment %} 注意这里的status是课程的，除了已撤销的四个都在这儿 {% endcomment %}
                                     <td>
                                         {% if course.status == "未开始" %}
                                         <span class="badge badge-pill badge-dark">{{course.status}}</span>
@@ -252,7 +246,7 @@
                                         <span class="badge badge-pill badge-warning">{{course.status}}</span>
                                         {% endif %}
                                     </td>
-                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
+                                    <td>{{course.current_participants}}/{{course.capacity}}</td>
                                     <td>
                                         <form action="/selectCourse/" method="post">
                                             <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
@@ -260,8 +254,8 @@
                                             {% if course.status != "预选" and course.status != "补退选" %}
                                             <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
                                             {% else %}
-                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal0-{{course.course_id}}">选课</button>
-                                            <div class="modal fade" id="myModal0-{{course.course_id}}">
+                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal{{ forloop.counter }}-{{course.course_id}}">选课</button>
+                                            <div class="modal fade" id="myModal{{ forloop.counter }}-{{course.course_id}}">
                                                 <div class="modal-dialog modal-dialog-centered">
                                                   <div class="modal-content">
                                                     <!-- 模态框主体 -->
@@ -285,347 +279,8 @@
                                 </tbody>
                             </table>
                         </div>
-                          
-                        <div id="menu1" class="tab-pane fade">
-                            <table class="table table-striped table-responsive-sm table-active">
-    
-                                <thead>
-                                  <tr>
-                                    <th scope="col" width="20%">课程名称</th>
-                                    <th scope="col" width="20%">上课时间</th>
-                                    <th scope="col" width="10%">课程周数</th>
-                                    <th scope="col" width="10%">课程类型</th>
-                                    <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">容量/选课人数</th>
-                                    <th scope="col" >操作</th>
-                                  </tr>
-                                </thead>
-            
-                                <tbody class="table">
-                                
-                                  {% for course in courses.1 %}
-                                  <tr>
-                                    <th scope="row">
-                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
-                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
-                                            <u>{{course.name}}</u>
-                                        </a>
-                                    </th>
-                                    <td>
-                                        {% for time in course.time_set %}
-                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
-                                            {{time}}<br>
-                                        {% endfor %}
-                                        {% if course.time_set|length == 0 %}
-                                            时间待定
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.times}}</td>
-                                    <td>{{course.type}}</td>
-                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
-                                    <td>
-                                        {% if course.status == "未开始" %}
-                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
-                                        {% elif course.status == "预选" %}
-                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
-                                        {% elif course.status == "补退选" %}
-                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
-                                        {% elif course.status == "选课结束" %}
-                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
-                                        {% else %}
-                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
-                                    <td>
-                                        <form action="/selectCourse/" method="post">
-                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
-                                            <input type="hidden" id="action" name="action"value="select" />
-                                            {% if course.status != "预选" and course.status != "补退选" %}
-                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
-                                            {% else %}
-                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal1-{{course.course_id}}">选课</button>
-                                            <div class="modal fade" id="myModal1-{{course.course_id}}">
-                                                <div class="modal-dialog modal-dialog-centered">
-                                                  <div class="modal-content">
-                                                    <!-- 模态框主体 -->
-                                                    <div class="modal-body">
-                                                      你确定要选课程《{{course.name}}》吗？
-                                                    </div>
-                                                    <!-- 模态框底部 -->
-                                                    <div class="modal-footer">
-                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
-                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                            </div>
-                                            {% endif %}
-                                        </form>
-                                        
-                                    </td>
-                                  </tr>
-                                  {% endfor %}
-                                
-                                </tbody>
-                            </table>
-                        </div>
-                        <div id="menu2" class="tab-pane fade">
-                            <table class="table table-striped table-responsive-sm table-active">
-    
-                                <thead>
-                                  <tr>
-                                    <th scope="col" width="20%">课程名称</th>
-                                    <th scope="col" width="20%">上课时间</th>
-                                    <th scope="col" width="10%">课程周数</th>
-                                    <th scope="col" width="10%">课程类型</th>
-                                    <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">容量/选课人数</th>
-                                    <th scope="col" >操作</th>
-                                  </tr>
-                                </thead>
-            
-                                <tbody class="table">
-                                
-                                  {% for course in courses.2 %}
-                                  <tr>
-                                    <th scope="row">
-                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
-                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
-                                            <u>{{course.name}}</u>
-                                        </a>
-                                    </th>
-                                    <td>
-                                        {% for time in course.time_set %}
-                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
-                                            {{time}}<br>
-                                        {% endfor %}
-                                        {% if course.time_set|length == 0 %}
-                                            时间待定
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.times}}</td>
-                                    <td>{{course.type}}</td>
-                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
-                                    <td>
-                                        {% if course.status == "未开始" %}
-                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
-                                        {% elif course.status == "预选" %}
-                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
-                                        {% elif course.status == "补退选" %}
-                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
-                                        {% elif course.status == "选课结束" %}
-                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
-                                        {% else %}
-                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
-                                    <td>
-                                        <form action="/selectCourse/" method="post">
-                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
-                                            <input type="hidden" id="action" name="action"value="select" />
-                                            {% if course.status != "预选" and course.status != "补退选" %}
-                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
-                                            {% else %}
-                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal2-{{course.course_id}}">选课</button>
-                                            <div class="modal fade" id="myModal2-{{course.course_id}}">
-                                                <div class="modal-dialog modal-dialog-centered">
-                                                  <div class="modal-content">
-                                                    <!-- 模态框主体 -->
-                                                    <div class="modal-body">
-                                                      你确定要选课程《{{course.name}}》吗？
-                                                    </div>
-                                                    <!-- 模态框底部 -->
-                                                    <div class="modal-footer">
-                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
-                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                            </div>
-                                            {% endif %}
-                                        </form>
-                                        
-                                    </td>
-                                  </tr>
-                                  {% endfor %}
-                                
-                                </tbody>
-                            </table>
-                        </div>
-                        <div id="menu3" class="tab-pane fade">
-                            <table class="table table-striped table-responsive-sm table-active">
-    
-                                <thead>
-                                  <tr>
-                                    <th scope="col" width="20%">课程名称</th>
-                                    <th scope="col" width="20%">上课时间</th>
-                                    <th scope="col" width="10%">课程周数</th>
-                                    <th scope="col" width="10%">课程类型</th>
-                                    <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">容量/选课人数</th>
-                                    <th scope="col" >操作</th>
-                                  </tr>
-                                </thead>
-            
-                                <tbody class="table">
-                                
-                                  {% for course in courses.3 %}
-                                  <tr>
-                                    <th scope="row">
-                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
-                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
-                                            <u>{{course.name}}</u>
-                                        </a>
-                                    </th>
-                                    <td>
-                                        {% for time in course.time_set %}
-                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
-                                            {{time}}<br>
-                                        {% endfor %}
-                                        {% if course.time_set|length == 0 %}
-                                            时间待定
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.times}}</td>
-                                    <td>{{course.type}}</td>
-                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
-                                    <td>
-                                        {% if course.status == "未开始" %}
-                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
-                                        {% elif course.status == "预选" %}
-                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
-                                        {% elif course.status == "补退选" %}
-                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
-                                        {% elif course.status == "选课结束" %}
-                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
-                                        {% else %}
-                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
-                                    <td>
-                                        <form action="/selectCourse/" method="post">
-                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
-                                            <input type="hidden" id="action" name="action"value="select" />
-                                            {% if course.status != "预选" and course.status != "补退选" %}
-                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
-                                            {% else %}
-                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal3-{{course.course_id}}">选课</button>
-                                            <div class="modal fade" id="myModal3-{{course.course_id}}">
-                                                <div class="modal-dialog modal-dialog-centered">
-                                                  <div class="modal-content">
-                                                    <!-- 模态框主体 -->
-                                                    <div class="modal-body">
-                                                      你确定要选课程《{{course.name}}》吗？
-                                                    </div>
-                                                    <!-- 模态框底部 -->
-                                                    <div class="modal-footer">
-                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
-                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                            </div>
-                                            {% endif %}
-                                        </form>
-                                        
-                                    </td>
-                                  </tr>
-                                  {% endfor %}
-                                
-                                </tbody>
-                            </table>
-                        </div>
-                        <div id="menu4" class="tab-pane fade">
-                            <table class="table table-striped table-responsive-sm table-active">
-    
-                                <thead>
-                                  <tr>
-                                    <th scope="col" width="20%">课程名称</th>
-                                    <th scope="col" width="20%">上课时间</th>
-                                    <th scope="col" width="10%">课程周数</th>
-                                    <th scope="col" width="10%">课程类型</th>
-                                    <th scope="col" width="15%">状态</th>
-                                    <th scope="col" width="15%">容量/选课人数</th>
-                                    <th scope="col" >操作</th>
-                                  </tr>
-                                </thead>
-            
-                                <tbody class="table">
-                                
-                                  {% for course in courses.4 %}
-                                  <tr>
-                                    <th scope="row">
-                                        <!--TODO : 课程小组头像路径（后端调用get_user_ava获得）-->
-                                        <img src={{ course.avatar_path }} width="24" height="24" alt="avatar">
-                                        <a href='/viewCourse/?courseid={{ course.course_id }}'><!--要做一个新的课程详情页来着..先放着-->
-                                            <u>{{course.name}}</u>
-                                        </a>
-                                    </th>
-                                    <td>
-                                        {% for time in course.time_set %}
-                                        <!-- {{time.week}}&nbsp;{{time.start}}-{{time.end}}<br>-->
-                                            {{time}}<br>
-                                        {% endfor %}
-                                        {% if course.time_set|length == 0 %}
-                                            时间待定
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.times}}</td>
-                                    <td>{{course.type}}</td>
-                                    <!--注意这里的status是课程的，除了已撤销的四个都在这儿-->
-                                    <td>
-                                        {% if course.status == "未开始" %}
-                                        <span class="badge badge-pill badge-dark">{{course.status}}</span>
-                                        {% elif course.status == "预选" %}
-                                        <span class="badge badge-pill badge-secondary">{{course.status}}</span>
-                                        {% elif course.status == "补退选" %}
-                                        <span class="badge badge-pill badge-info">{{course.status}}</span>
-                                        {% elif course.status == "选课结束" %}
-                                        <span class="badge badge-pill badge-primary">{{course.status}}</span>
-                                        {% else %}
-                                        <span class="badge badge-pill badge-warning">{{course.status}}</span>
-                                        {% endif %}
-                                    </td>
-                                    <td>{{course.capacity}}/{{course.current_participants}}</td>
-                                    <td>
-                                        <form action="/selectCourse/" method="post">
-                                            <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />
-                                            <input type="hidden" id="action" name="action"value="select" />
-                                            {% if course.status != "预选" and course.status != "补退选" %}
-                                            <button type="submit" class="btn btn-primary btn-sm" disabled>选课</button>
-                                            {% else %}
-                                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#myModal4-{{course.course_id}}">选课</button>
-                                            <div class="modal fade" id="myModal4-{{course.course_id}}">
-                                                <div class="modal-dialog modal-dialog-centered">
-                                                  <div class="modal-content">
-                                                    <!-- 模态框主体 -->
-                                                    <div class="modal-body">
-                                                      你确定要选课程《{{course.name}}》吗？
-                                                    </div>
-                                                    <!-- 模态框底部 -->
-                                                    <div class="modal-footer">
-                                                        <button type="submit" class="btn btn-primary btn-sm">确定</button>
-                                                        <button type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">关闭</button>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                            </div>
-                                            {% endif %}
-                                        </form>
-                                        
-                                    </td>
-                                  </tr>
-                                  {% endfor %}
-                                
-                                </tbody>
-                            </table>    
-                        </div>
+                        {% endfor %}
+                        
                     </div>
 
                 </div>
@@ -652,12 +307,11 @@
     
                     <thead>
                         <tr>
-                            <th scope="col" width="20%">课程名称</th>
-                            <th scope="col" width="20%">上课时间</th>
-                            <th scope="col" width="10%">课程周数</th>
+                            <th scope="col" width="25%">课程名称</th>
+                            <th scope="col" width="25%">上课时间</th>
                             <th scope="col" width="10%">课程类型</th>
                             <th scope="col" width="15%">状态</th>
-                            <th scope="col" width="15%">容量/选课人数</th>
+                            <th scope="col" width="15%">选课人数/容量</th>
                             <th scope="col" >操作</th>
                         </tr>
                     </thead>
@@ -695,7 +349,7 @@
                             <span class="badge badge-pill badge-danger">{{course.student_status}}</span>
                             {% endif %}
                         </td>
-                        <td>{{course.capacity}}/{{course.current_participants}}</td>
+                        <td>{{course.current_participants}}/{{course.capacity}}</td>
                         <td>
                             <form action="/selectCourse/" method="post">
                                 <input type="hidden" id="courseid" name="courseid"value="{{course.course_id}}" />


### PR DESCRIPTION
1. 全部课程/我的课程这一整个class求一个container包住，不要贴边（完成）
2. 统一一下在没有课程的时候两边的行为，例如我的课程页面如果没有课程需要加一行字说明，全部课程同理（完成）
3. 时间的呈现求更加美观一点，参考主页时间的呈现（需要后端实现）
4. 真正的表格包裹的容器太多了，左右留白有点多，求减少一个container（目前看不需要，因为navbar有留白了）
5. 竖屏表格呈现不合理，求修改（未完成）
6.改title（完成）判断预选状态（需要后端实现）
7.详情页加上课地点（完成）