### PR TITLE
组织和个人的历史活动/历史组织&选课页的三个bug

### DIFF
--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -638,14 +638,13 @@
                                 
                                 <div id="act2" class="tab-pane fade">
                                 <div class="bio-skill-box ">
-                                    {% comment %} 后端对接：history_activity_list{% endcomment %}
-                                    {% if history_activity_list|length == 0 %}
+                                    {% if history_activity_list_participantrec|length == 0 %}
                                     <br />
                                     <p style="text-align: center;">没有该类别的活动</p>
                                     <br />
                                     {% endif %}
                                     <div class="row">
-                                        {% for act in history_activity_list %}
+                                        {% for act in history_activity_list_participantrec %}
                                         <div class="col-12 col-xl-4 col-lg-6 mb-xl-5 mb-5 ">
                                             <a href="/viewActivity/{{rec.act.id}}">
                                                 <div class="d-flex b-skills">

--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -419,6 +419,19 @@
                                 </a> -->
                                 <b class="nav-link" data-toggle="tab" role="tab" href="#act1">已结束</b>
                             </li>
+                            
+                            <li class="nav-item">
+                                
+                                <b class="nav-link" data-toggle="tab" role="tab" href="#act2">历史活动
+                                    <a data-toggle="tooltip" data-placement="bottom" data-html="true" title="展示非本学期的过往活动">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor"
+                                            class="bi bi-question-circle-fill" viewBox="0 0 22 22">
+                                            <path
+                                                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z" />
+                                        </svg>
+                                    </a>
+                                </b>
+                            </li>
 
                         </ul>
 
@@ -621,6 +634,93 @@
                                     </div>
                                 </div>
                             </div>
+                                
+                                
+                                <div id="act2" class="tab-pane fade">
+                                <div class="bio-skill-box ">
+                                    {% comment %} 后端对接：history_activity_list{% endcomment %}
+                                    {% if history_activity_list|length == 0 %}
+                                    <br />
+                                    <p style="text-align: center;">没有该类别的活动</p>
+                                    <br />
+                                    {% endif %}
+                                    <div class="row">
+                                        {% for act in history_activity_list %}
+                                        <div class="col-12 col-xl-4 col-lg-6 mb-xl-5 mb-5 ">
+                                            <a href="/viewActivity/{{rec.act.id}}">
+                                                <div class="d-flex b-skills">
+                                                    <div class="text-nowrap"
+                                                        style='overflow: hidden;text-overflow: ellipsis;'>
+                                                        <div class="d-flex justify-content-between">
+                                                            <h5
+                                                                style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+
+                                                                {% if act.status == "已取消" %}
+                                                                <span class="badge badge-pill badge-dark">
+                                                                {% else %}
+                                                                <span class="badge badge-pill badge-danger">
+                                                                {% endif %}
+                                                                    {{ act.status }}
+                                                                </span>
+
+                                                                {{ act.title }}
+
+                                                            </h5>
+                                                        </div>
+
+                                                        <p>{{ act.introduction }}</p>
+
+                                                        <div class="d-flex justify-content-start">
+                                                            <p class="flex mr-3" style="width: 20px;">
+                                                                <i class="fa fa-clock"></i>
+                                                            </p>
+                                                            <p class="flex">
+                                                                {{ act.start }}
+                                                            </p>
+                                                        </div>
+
+                                                        <div class="d-flex justify-content-start">
+                                                            <p class="flex mr-3" style="width: 20px;">
+                                                                <i class="fa fa-users"></i>
+                                                            </p>
+                                                            <p class="flex">
+                                                                {{ act.current_participants }}
+                                                                /
+                                                                {{ act.capacity }}
+                                                            </p>
+                                                        </div>
+
+                                                        <div class="row">
+                                                            <div class="col d-flex justify-content-start">
+                                                                <p class="flex mr-3" style="width: 20px;">
+                                                                    <i class="fa fa-money-bill"></i>
+                                                                </p>
+                                                                <p class="flex">
+                                                                    元气值{{ act.YQPoint }}
+                                                                </p>
+                                                            </div>
+
+                                                            <div class="col d-flex justify-content-start">
+                                                                <p class="flex mr-3" style="width: 20px;">
+                                                                    <i class="fa fa-location-arrow"></i>
+                                                                </p>
+                                                                <p class="flex">
+                                                                    {{ act.location }}
+                                                                </p>
+                                                            </div>
+                                                        </div>
+
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                        {% endfor %}
+
+                                    </div>
+                                </div>
+                            </div>
+                                
+                                
                         </div>
                     </div>
                 </div>

--- a/templates/select_course.html
+++ b/templates/select_course.html
@@ -13,14 +13,9 @@
 
     <div style="text-align: center;">
         <br>
-        <h4 class="text-primary">{{html_display.current_year}}学年{{html_display.semester}}季学期书院课程选课页面
-            {% if html_display.status == "预选" %}
-            <span class="badge badge-pill badge-secondary" style="font-size:14px">{{html_display.status}}</span>
-            {% elif html_display.status == "抽签中" %}
-            <span class="badge badge-pill badge-secondary" style="font-size:14px">{{html_display.status}}</span>
-            {% elif html_display.status == "补退选" %}
-            <span class="badge badge-pill badge-info" style="font-size:14px">{{html_display.status}}</span>
-            {% endif %}</h4>
+        <h4 class="text-primary">
+            {{html_display.current_year}}学年{{html_display.semester}}季学期书院课程选课页面 - {{html_display.status}}
+        </h4>
         {% comment %} 从后端获取学期数据 {% endcomment %}
         <br>
     </div>
@@ -123,8 +118,8 @@
 
                                     <th scope="col" width="25%" style="min-width: 160px;">课程名称</th>
                                     <th scope="col" width="25%" style="min-width: 160px;">上课时间</th>
-                                    <th scope="col" width="10%" style="min-width: 80px;">课程类型</th>
-                                    <th scope="col" width="15%" style="min-width: 120px;">选课人数/容量</th>
+                                    <th scope="col" width="15%" style="min-width: 80px;">课程类型</th>
+                                    <th scope="col" width="20%" style="min-width: 120px;">选课人数/容量</th>
                                     <th scope="col" style="min-width: 60px;" >操作</th>
 
                                   </tr>
@@ -192,7 +187,8 @@
                                 <div id="menu{{ forloop.counter }}" class="tab-pane fade">
                                     <div class="col-12 layout-top-spacing">
                                         <br>
-                                        <p style="text-align: center;">暂时没有课程哦！</p>
+                                        <p style="text-align: center;">暂时没有此类课程哦！</p>
+                                        <br>
                                     </div>
                                 </div>
 
@@ -205,8 +201,8 @@
                                         <tr>
                                             <th scope="col" width="25%" style="min-width: 160px;">课程名称</th>
                                             <th scope="col" width="25%" style="min-width: 160px;">上课时间</th>
-                                            <th scope="col" width="10%" style="min-width: 80px;">课程类型</th>
-                                            <th scope="col" width="15%" style="min-width: 120px;">选课人数/容量</th>
+                                            <th scope="col" width="15%" style="min-width: 80px;">课程类型</th>
+                                            <th scope="col" width="20%" style="min-width: 120px;">选课人数/容量</th>
                                             <th scope="col" style="min-width: 60px;" >操作</th>
                                         </tr>
                                         </thead>

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -739,7 +739,6 @@
                         </div>
 
                         <div class="row bio bio-skill-box">
-                            {% comment %}后端对接：history_act_info{% endcomment %}
                             {% if html_display.history_act_info is None %}
                             <p class="w-100" style="text-align: center;">没有历史活动</p>
                             {% else %}

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -456,7 +456,6 @@
 
                         <div class="bio-skill-box">
                             {% if html_display.history_orgs_info is None %}
-                            {% comment %} 后端对接：history_orgs_info {% endcomment %}
                             <p style="text-align: center;">没有历史小组</p>
                             {% else %}
                             <div class="row">

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -446,6 +446,48 @@
 
                     </div>
                     <!--  END JOINED ORGANIZATIONS  -->
+                    
+                    <!--  BEGIN HISTORY ORGANIZATIONS  -->
+                    <div class="widget-content widget-content-area my-3">
+
+                        <div class="row">
+                            <h3 class="col mb-0">历史小组</h3>
+                        </div>
+
+                        <div class="bio-skill-box">
+                            {% if html_display.history_orgs_info is None %}
+                            {% comment %} 后端对接：history_orgs_info {% endcomment %}
+                            <p style="text-align: center;">没有历史小组</p>
+                            {% else %}
+                            <div class="row">
+                                {% for org, ava, pos in html_display.history_orgs_info %}
+                                <div class="col-12 col-xl-6 col-lg-12 mb-xl-4 mb-4 ">
+                                    <div
+                                        style="padding-left: 2%;padding-right: 2%; background-image: url({{ ava }}); background-size: 55%; background-repeat: no-repeat; background-position: right;">
+                                        <div class=" b-skills row" style="background-color: #ffffffcc;">
+                                            <div class="col-9 container-fluid">
+                                                <a href="/orginfo/?name={{ org.oname }}">
+                                                    <h5>{{ org.oname }}</h5>
+                                                </a>
+                                                <p
+                                                    style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                    {{ org.introduction }}</p>
+                                                <!-- where's the custom static css file? -->
+                                            </div>
+                                            <div class="col-3 pr-0">
+                                                <p><b class="text-muted">{{ pos }}</b></p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                {% endfor %}
+
+                            </div>
+                            {% endif %}
+                        </div>
+
+                    </div>
+                    <!--  END HISTORY ORGANIZATIONS  -->
 
                     <!--  BEGIN HIDDEN ORGANIZATIONS  -->
                     {% if html_display.is_myself == True %}

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -734,6 +734,75 @@
 
                             {% endif %}
                         </div>
+                                            
+                         <div class="row">
+                            <h3 class="col mb-0">历史活动</h3>
+                        </div>
+
+                        <div class="row bio bio-skill-box">
+                            {% comment %}后端对接：history_act_info{% endcomment %}
+                            {% if html_display.history_act_info is None %}
+                            <p class="w-100" style="text-align: center;">没有历史活动</p>
+                            {% else %}
+                            {% for act in html_display.history_act_info %}
+                            <div class="col-sm-12 col-md-6 mb-3 custom-activity-card ">
+                                <a href="/viewActivity/{{ act.id }}">
+                                    <div class="d-flex b-skills">
+                                        <div class="text-nowrap mw-100">
+                                            <div class="d-flex justify-content-between">
+                                                <h5 style="max-width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+
+                                                    {% if act.status == "等待中" %}
+                                                    <span class="badge badge-pill badge-warning">
+                                                        等待开始
+                                                    {% else %}
+                                                    {% if act.status == "审核中" %}
+                                                    <span class="flex badge badge-pill badge-secondary">
+                                                    {% elif act.status == "已取消" %}
+                                                    <span class="badge badge-pill badge-dark">
+                                                    {% elif act.status == "未过审" or act.status == "已撤销" or act.status == "已结束" %}
+                                                    <span class="badge badge-pill badge-danger">
+                                                    {% elif act.status == "报名中" %}
+                                                    <span class="badge badge-pill badge-info">
+                                                    {% elif act.status == "进行中" %}
+                                                    <span class="badge badge-pill badge-success">
+                                                    {% endif %}
+                                                        {{ act.status }}
+                                                    {% endif %}
+                                                    </span>
+
+                                                    {{ act.title }}
+                                                </h5>
+                                            </div>
+
+                                            <p
+                                                style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                <i class="fa fa-sitemap" style="width: 20px;"></i>
+                                                <span class="ml-1">{{ act.organization_id }}</span>
+                                            </p>
+
+                                            <p
+                                                style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                <i class="fa fa-clock" style="width: 20px;"></i>
+                                                <span class="ml-1">{{ act.start }} - {{ act.end }}</span>
+                                            </p>
+
+                                            <p
+                                                style="text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                                                <i class="fa fa-info-circle" style="width: 20px;"></i>
+                                                <span class="ml-1">{{ act.introduction }}</span>
+                                            </p>
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+
+                            {% endfor %}
+
+                            {% endif %}
+                        </div>
+                                            
+                                            
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
“在个人主页的【我的小组】下面增加【历史小组】，【我的活动】增加一个【历史活动】，组织主页的我的活动增加【历史活动】，然后filter的函数pht已经帮写好了，就相当于加一个呈现block”
（没找到Pht的PR，可以搜索关键词“后端对接”找到对应的暂时的前端变量名）
“1、比例没有调整 2、提示语放在表格里有点奇怪 3、补退选不用badge算了，对不齐”改好了
<img width="322" alt="截屏2022-02-21 21 19 55" src="https://user-images.githubusercontent.com/55350524/154974796-b93574ef-1582-4151-81a1-a63d01fa0570.png">
