### PR TITLE
task24_借阅信息页面的后端数据准备

### DIFF
--- a/yp_library/test/test_lendinfo.py
+++ b/yp_library/test/test_lendinfo.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+from yp_library.models import Book, LendRecord, Reader
+from yp_library.utils import get_my_records, get_lendinfo_by_readers
+
+
+class GetLendRecordTestCase(TestCase):
+    def setUp(self):
+        Reader.objects.create(id=123456789, student_id='1900010000')
+        Reader.objects.create(id=1234567, student_id='1900010000')
+        Reader.objects.create(id=987654321, student_id='2000010000')
+
+        Book.objects.create(id=1, identity_code="MATH-1-1",
+                            title="数学分析I", author="伍胜健", publisher="北京大学出版社", returned=0)
+        Book.objects.create(id=2, identity_code="MATH-1-2",
+                            title="数学分析II", author="伍胜健", publisher="北京大学出版社")
+        Book.objects.create(id=3, identity_code="MATH-2",
+                            title="高等代数", author="丘维声", publisher="清华大学出版社", returned=0)
+
+        LendRecord.objects.create(reader_id_id=123456789, book_id_id=1, lend_time='2022-07-22',
+                                  due_time='2022-07-30', return_time='2022-07-23', returned=1, status=0)
+        LendRecord.objects.create(reader_id_id=123456789, book_id_id=2, lend_time='2022-07-22',
+                                  due_time='2022-07-30', return_time='2022-07-31', returned=1, status=1)
+        LendRecord.objects.create(reader_id_id=123456789, book_id_id=3, lend_time='2022-07-22',
+                                  due_time='2022-07-30', return_time='2022-07-31', returned=1, status=2)
+        LendRecord.objects.create(reader_id_id=1234567, book_id_id=1, lend_time='2022-07-25',
+                                  due_time='2022-08-01', returned=0, status=1)
+        LendRecord.objects.create(reader_id_id=1234567, book_id_id=2, lend_time='2022-08-01',
+                                  due_time='2022-08-07', returned=0, status=0)
+        LendRecord.objects.create(reader_id_id=987654321, book_id_id=3, lend_time='2022-07-01',
+                                  due_time='2022-07-07', return_time='2022-07-20', returned=0, status=4)
+
+    def test_get_my_records(self):
+        self.assertEqual(len(Book.objects.all().values()), 3)
+        self.assertEqual(len(Reader.objects.all().values()), 3)
+        self.assertEqual(len(LendRecord.objects.all().values()), 6)
+
+        self.assertEqual(len(get_my_records(123456789, returned=0)), 0)
+        self.assertEqual(len(get_my_records(123456789, returned=1)), 3)
+        self.assertEqual(len(get_my_records(123456789, status=[0, 1])), 2)
+        self.assertEqual(len(get_my_records(123456789, status=1)), 1)
+        self.assertEqual(
+            len(get_my_records(123456789, returned=0, status=2)), 0)
+        self.assertEqual(
+            len(get_my_records(123456789, returned=1, status=2)), 1)
+        self.assertEqual(len(get_my_records(1234567, returned=1)), 0)
+        self.assertEqual(
+            len(get_my_records(1234567, returned=1, status=[3, 4])), 0)
+        self.assertEqual(
+            len(get_my_records(1234567, returned=0, status=[3, 1, 2])), 1)
+        self.assertEqual(len(get_my_records(987654321, status=[4, ])), 1)
+
+        records = get_my_records(123456789, returned=1, status=0)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]['type'], 1)
+        records = get_my_records(123456789, returned=1, status=1)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]['type'], 0)
+        '''
+        # 测试记录类型'type', 对于未归还记录，结果会随测试时的时间不同而变化
+        records = get_my_records(1234567, returned=0, status=1)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]['type'], 'approaching')
+        records = get_my_records(1234567, returned=0, status=0)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]['type'], 'normal')
+        records = get_my_records(987654321, returned=0)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]['type'], 'overtime')
+        '''
+
+
+    def test_get_lendinfo_by_readers(self):
+        unreturned_records_list, returned_records_list = get_lendinfo_by_readers(
+            Reader.objects.filter(student_id='1900010000'))
+        self.assertEqual(len(unreturned_records_list), 2)
+        self.assertEqual(len(returned_records_list), 3)

--- a/yp_library/test/test_lendinfo.py
+++ b/yp_library/test/test_lendinfo.py
@@ -4,7 +4,8 @@ from yp_library.utils import get_my_records, get_lendinfo_by_readers
 
 
 class GetLendRecordTestCase(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         Reader.objects.create(id=123456789, student_id='1900010000')
         Reader.objects.create(id=1234567, student_id='1900010000')
         Reader.objects.create(id=987654321, student_id='2000010000')

--- a/yp_library/utils.py
+++ b/yp_library/utils.py
@@ -4,7 +4,7 @@ from yp_library.models import (
     LendRecord,
 )
 
-from typing import Union, List, Tuple
+from typing import Union, List, Tuple, Optional
 from datetime import datetime
 
 from django.contrib.auth.models import User
@@ -107,7 +107,8 @@ def get_query_dict(post_dict: QueryDict) -> dict:
     return query_dict
 
 
-def get_my_records(reader_id: str, returned: bool = None, status: Union[list, int] = None) -> List[dict]:
+def get_my_records(reader_id: str, returned: Optional[bool] = None, 
+    status: Optional[Union[list, int]] = None) -> List[dict]:
     """
     查询给定读者的借书记录
 
@@ -134,7 +135,7 @@ def get_my_records(reader_id: str, returned: bool = None, status: Union[list, in
         results = all_records_list
 
     if isinstance(status, list):
-        results = results.filter(Q(status__in=status))
+        results = results.filter(status__in=status)
     elif isinstance(status, int):
         results = results.filter(status=status)
     

--- a/yp_library/utils.py
+++ b/yp_library/utils.py
@@ -4,7 +4,7 @@ from yp_library.models import (
     LendRecord,
 )
 
-from typing import Union, List
+from typing import Union, List, Tuple
 from datetime import datetime
 
 from django.contrib.auth.models import User
@@ -161,7 +161,7 @@ def get_my_records(reader_id: str, returned: bool = None, status: Union[list, in
     return records
 
 
-def get_lendinfo_by_readers(readers: QuerySet):
+def get_lendinfo_by_readers(readers: QuerySet) -> Tuple[List[dict], List[dict]]:
     '''
     查询同一user关联的读者的借阅信息
 

--- a/yp_library/utils.py
+++ b/yp_library/utils.py
@@ -4,6 +4,9 @@ from yp_library.models import (
     LendRecord,
 )
 
+from typing import Union, List
+from datetime import datetime
+
 from django.contrib.auth.models import User
 from django.db.models import Q, QuerySet
 from django.http import QueryDict
@@ -102,3 +105,77 @@ def get_query_dict(post_dict: QueryDict) -> dict:
                               ["kw_title", "kw_author", "kw_publisher"]]
 
     return query_dict
+
+
+def get_my_records(reader_id: str, returned: bool = None, status: Union[list, int] = None) -> List[dict]:
+    """
+    查询给定读者的借书记录
+
+    :param reader_id: reader的id
+    :type reader_id: str
+    :param returned: 如非空，则限定是否已归还, defaults to None
+    :type returned: bool, optional
+    :param status: 如非空，则限定当前状态, defaults to None
+    :type status: Union[list, int], optional
+    :return: 查询结果，每个记录包括val_list中的属性以及记录类型(key为'type': 
+        对于已归还记录，False表示逾期记录，True表示正常记录；对于未归还记录，
+        'normal'表示一般记录，'overtime'表示逾期记录，'approaching'表示接近
+        期限记录即距离应归还时期<=1天)
+    :rtype: List[dict]
+    """
+    all_records_list = LendRecord.objects.filter(reader_id=reader_id)
+    val_list = ['book_id__title', 'lend_time', 'due_time', 'return_time']
+
+    if returned is not None:
+        results = all_records_list.filter(returned=returned)
+        if returned:
+            val_list.append('status')   # 已归还记录，增加申诉状态呈现
+    else:
+        results = all_records_list
+
+    if isinstance(status, list):
+        results = results.filter(Q(status__in=status))
+    elif isinstance(status, int):
+        results = results.filter(status=status)
+    
+    records = list(results.values(*val_list))
+    # 标记记录类型
+    if returned:
+        for record in records:
+            if  record['return_time'] > record['due_time']:
+                record['type'] = False          # 逾期记录
+            else:
+                record['type'] = True           # 正常记录
+    else:
+        now_time = datetime.now()
+        for record in records:
+            # 计算距离应归还时间的天数
+            delta_days = (record['due_time'] - now_time).total_seconds() / float(60 * 60 * 24)
+            if delta_days > 1:
+                record['type'] = 'normal'       # 一般记录
+            elif delta_days < 0:
+                record['type'] = 'overtime'     # 逾期记录
+            else:
+                record['type'] = 'approaching'  # 接近期限记录
+
+    return records
+
+
+def get_lendinfo_by_readers(readers: QuerySet):
+    '''
+    查询同一user关联的读者的借阅信息
+
+    :param readers: 与user关联的所有读者
+    :type readers: QuerySet
+    :return: 两个list，分别表示未归还记录和已归还记录
+    :rtype: List[dict], List[dict]
+    '''
+    unreturned_records_list = []
+    returned_records_list = []
+
+    reader_ids = list(readers.values('id'))
+    for reader_id in reader_ids:
+        unreturned_records_list.extend(get_my_records(reader_id['id'], returned=False))
+        returned_records_list.extend(get_my_records(reader_id['id'], returned=True))
+    
+    return unreturned_records_list, returned_records_list

--- a/yp_library/views.py
+++ b/yp_library/views.py
@@ -4,7 +4,12 @@ from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 
 from boottest.global_messages import wrong, succeed, message_url, transfer_message_context
-from yp_library.utils import get_readers_by_user, search_books, get_query_dict, get_lendinfo_by_readers
+from yp_library.utils import (
+    get_readers_by_user,
+    search_books,
+    get_query_dict,
+    get_lendinfo_by_readers,
+)
 from app.utils import get_sidebar_and_navbar, check_user_access
 
 

--- a/yp_library/views.py
+++ b/yp_library/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 
 from boottest.global_messages import wrong, succeed, message_url, transfer_message_context
-from yp_library.utils import get_readers_by_user, search_books, get_query_dict
+from yp_library.utils import get_readers_by_user, search_books, get_query_dict, get_lendinfo_by_readers
 from app.utils import get_sidebar_and_navbar, check_user_access
 
 
@@ -51,9 +51,33 @@ def search(request: HttpRequest) -> HttpResponse:
     return render(request, "yp_library/search.html", frontend_dict)
 
 
-def lendInfo(request):
+@login_required(redirect_field_name="origin")
+@check_user_access(redirect_url="/logout/")
+def lendInfo(request: HttpRequest) -> HttpResponse:
+    '''
+    借阅信息页面
+
+    :param request: 进入借阅信息页面的请求
+    :type request: HttpRequest
+    :return: lendinfo页面，显示与当前user学号关联的所有读者的所有借阅记录
+    :rtype: HttpResponse
+    '''
     bar_display = get_sidebar_and_navbar(request.user, "借阅信息")
     frontend_dict = {
         "bar_display": bar_display,
     }
+    transfer_message_context(request.GET, frontend_dict,
+                             normalize=True)
+
+    # 检查用户身份
+    # 要求必须为个人账号且账号必须通过学号关联至少一个reader，否则抛出AssertionError
+    try:
+        readers = get_readers_by_user(request.user)
+    except AssertionError as e:
+        return redirect(message_url(wrong(e)))
+
+    unreturned_records_list, returned_records_list = get_lendinfo_by_readers(readers)
+    frontend_dict['unreturned_records_list'] = unreturned_records_list
+    frontend_dict['returned_records_list'] = returned_records_list
+
     return render(request, "yp_library/lendinfo.html", frontend_dict)


### PR DESCRIPTION
1. yp_library/utils.py：工具函数
（1）get_my_records：根据reader_id查询给定读者的借阅记录，可根据returned参数限定图书归还状态（可为空），根据status参数限定借阅记录状态（可谓空）。
（2）get_lendinfo_by_readers：根据readers（同一user）查询未归还记录和已归还记录，对于readers中的每个reader通过调用get_my_records函数实现借阅记录查询

2. yp_library/views.py：借阅信息页面，通过调用yp_library/utils.py中的get_lendinfo_by_readers函数获取分别表示未归还记录和已归还记录的两个列表，并放入frontend_dict

3. yp_library/test/test_lendinfo.py：对utils.py的get_my_records和get_lendinfo_by_readers函数进行了简单的测试，其中，由于get_my_records函数对于未归还记录的记录类型判断受测试时的时间影响，已经注释掉了