### PR TITLE
一些杂项任务 + 书房借阅信息界面前端

### DIFF
--- a/app/feedback_views.py
+++ b/app/feedback_views.py
@@ -668,25 +668,31 @@ def modifyFeedback(request: HttpRequest):
             org_list[feedback.org.oname]['selected'] = True
         else:
             org_list['']['selected'] = True
-    else: # feedback_type 默认选中第一个反馈类型，默认选中项将在前端实时更新。
-        feedback_type = list(feedback_type_list.keys())[0]
-        if FeedbackType.objects.get(name=feedback_type).org_type is not None:
-            org_type_list[
-                FeedbackType.objects.get(name=feedback_type).org_type.otype_name
-            ]['selected'] = True
+    else: # feedback_type默认选中的反馈类型通过url获取，如未获取到则默认选中第一项。
+        if request.GET.get('type') is not None:
+            feedback_type = request.GET.get('type')
+            try:
+                FeedbackType.objects.get(name=feedback_type)
+            except:  # 有可能出现需要的反馈类型数据库不存在的情况，此时默认选中第一项
+                feedback_type = list(feedback_type_list.keys())[0]
+        else:
+            feedback_type = list(feedback_type_list.keys())[0]
+        feedback_type_list[feedback_type]['selected'] = True
+        selected_feedback = FeedbackType.objects.get(name=feedback_type)
+
+        if selected_feedback.org_type is not None:
+            org_type_list[selected_feedback.org_type.otype_name]['selected'] = True
             for org in Organization.objects.exclude(
                     otype=OrganizationType.objects.get(
-                        otype_name=FeedbackType.objects.get(name=feedback_type).org_type.otype_name)
+                        otype_name=selected_feedback.org_type.otype_name)
                     ):
                 org_list[org.oname]['disabled'] = True
         else:
             org_type_list['']['selected'] = True
             for org in org_list.keys():
                 org_list[org]['disabled'] = True
-        if FeedbackType.objects.get(name=feedback_type).org is not None:
-            org_list[
-                FeedbackType.objects.get(name=feedback_type).org.oname
-            ]['selected'] = True
+        if selected_feedback.org is not None:
+            org_list[selected_feedback.org.oname]['selected'] = True
         else:
             org_list['']['selected'] = True
     bar_display = utils.get_sidebar_and_navbar(

--- a/templates/Appointment/admin-credit.html
+++ b/templates/Appointment/admin-credit.html
@@ -204,14 +204,14 @@
 									</div>
 								</div>
 
-								<form method="POST">
-									<div class="appointment-action">
-										<button type="submit" class="btn btn-sm bg-warning-light"
-											name="feedback" value="{{appoint.Aid}}">
-											<i class="fa fa-question"></i> 违规申诉
-											</input>
-									</div>
-								</form>
+								<div class="appointment-action">
+									<button type="submit" class="btn btn-sm bg-warning-light"
+										name="feedback" value="{{appoint.Aid}}"
+										onclick="window.location.href='/modifyFeedback/?type=地下室预约反馈';">
+										<i class="fa fa-question"></i> 违规申诉
+									</button>
+								</div>
+
 							</div>
 							<!-- /Appointment List -->
 							{% endfor %}

--- a/templates/Appointment/admin-index.html
+++ b/templates/Appointment/admin-index.html
@@ -391,7 +391,7 @@
                                                             {% if appoint.Astatus == '违约' %}
                                                                 <!--<div>-->
                                                                 <div class="appointment-action">
-                                                                    <a href="https://shimo.im/forms/pcptwdvCPPXqTRTd/fill">
+                                                                    <a href="/modifyFeedback/?type=地下室预约反馈">
                                                                         <button class="btn btn-sm bg-danger-light" name="argue_btn">
                                                                             <i class="fas fa-times"></i> 我要申诉
                                                                         </button>

--- a/templates/org_left_navbar.html
+++ b/templates/org_left_navbar.html
@@ -47,14 +47,6 @@
                     </li>
 
                     <li class="menu">
-                        <a href="/QAcenter/" aria-expanded="false" class="dropdown-toggle">
-                            <div class="">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" /></svg>                                <span>问答中心</span>
-                            </div>
-                        </a>
-                    </li>
-
-                    <li class="menu">
                         <a href="/subscribeOrganization/" aria-expanded="false" class="dropdown-toggle">
                             <div class="">
                                 <!-- check-square -->

--- a/templates/yp_library/lendinfo.html
+++ b/templates/yp_library/lendinfo.html
@@ -67,12 +67,12 @@
                                                                 {% if record.type == "normal" %} 
                                                                     <span class="badge badge-pill" style="border-radius:4px; 
                                                                         background-color:#00C957; color:#FFFFFF; margin:2px;
-                                                                        margin-top:0px; margin-bottom:4px;">一般记录
+                                                                        margin-top:0px; margin-bottom:4px;">借阅中
                                                                     </span>
                                                                 {% elif record.type == "approaching" %}
                                                                     <span class="badge badge-pill" style="border-radius:4px; 
                                                                         background-color:#FFD700; color:#FFFFFF; margin:2px;
-                                                                        margin-top:0px; margin-bottom:4px;">接近期限
+                                                                        margin-top:0px; margin-bottom:4px;">待归还
                                                                     </span>
                                                                 {% else %}
                                                                     <span class="badge badge-pill" style="border-radius:4px; 
@@ -122,14 +122,27 @@
                                                             <td {% if record.type != "normal" %} style="color:#E3170D" {% endif %}>
                                                                 {{record.return_time}}
                                                             </td>
-                                                            <td {% if record.type == "normal" %} style="font-weight:bold" {% endif %}>
-                                                                {% if record.type == "normal" %} 
-                                                                    无需申诉。
-                                                                {% else %}
+                                                            <td>
+                                                                {% if record.type != "normal" %}
                                                                     <!-- 逾期记录还需分情况 -->
                                                                     {% if record.status == 0 or record.status == 1 %}
                                                                         <!-- 未申诉的逾期记录 -->
-                                                                        <button type="button" class="btn btn-primary" style="width:70px; height:40px; font-size:14px; font-weight:bold;">申诉</button>
+                                                                        <span class="badge badge-pill" style="border-radius:4px; 
+                                                                            background-color:#2759DA; color:#FFFFFF; margin:2px;
+                                                                            margin-top:0px; margin-bottom:4px;">未申诉
+                                                                        </span>
+                                                                        <div class="btn-group" style="display:inline-block;">
+                                                                            <div>
+                                                                                <a data-toggle="dropdown">
+                                                                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-three-dots" viewBox="0 0 16 16">
+                                                                                        <path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/>
+                                                                                    </svg>
+                                                                                </a>
+                                                                                <div class="dropdown-menu" style="max-width:200%; max-height:300%;">
+                                                                                    <button class="dropdown-item">申诉</button>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
                                                                     {% elif record.status == 2 %}
                                                                         <!-- 申诉中 -->
                                                                         <span class="badge badge-pill" style="border-radius:4px; 

--- a/templates/yp_library/lendinfo.html
+++ b/templates/yp_library/lendinfo.html
@@ -139,7 +139,7 @@
                                                                                     </svg>
                                                                                 </a>
                                                                                 <div class="dropdown-menu" style="max-width:200%; max-height:300%;">
-                                                                                    <button class="dropdown-item">申诉</button>
+                                                                                    <button class="dropdown-item" onclick="window.location.href='/modifyFeedback/?type=书房借阅申诉';">申诉</button>
                                                                                 </div>
                                                                             </div>
                                                                         </div>

--- a/templates/yp_library/lendinfo.html
+++ b/templates/yp_library/lendinfo.html
@@ -5,4 +5,168 @@
 
 {% block mainpage %}
 
+    <!--  BEGIN CONTENT AREA  -->
+    <div id="content" class="main-content">
+        {% if html_display.warn_code == 1 %}
+        <div class="alert alert-warning  text-center">{{ html_display.warn_message }}</div>
+        {% elif html_display.warn_code == 2 %}
+        <div class="alert alert-success  text-center">{{ html_display.warn_message }}</div>
+        {% endif %}
+        <div class="container">
+            <div class="layout-top-spacing">
+                <div class="col-12 layout-top-spacing">
+                    <div class="bio layout-spacing ">
+                        <div class="widget-content widget-content-area">
+                            <h3>借阅记录</h3>
+                            <ul id="myTab" class="nav nav-tabs nav-tabs-solid nav-justified">
+                                
+                                <li class="nav-item">
+                                    <a class="nav-link active" href="#unfinished" data-toggle="tab">
+                                        <h5>进行中</h5>
+                                    </a>
+                                </li>
+
+                                <li class="nav-item">
+                                    <a class="nav-link" href="#finished" data-toggle="tab">
+                                        <h5>已完成</h5>
+                                    </a>
+                                </li>
+                            
+                            </ul>
+
+                            <div id="myTabContent" class="tab-content">
+                                <div class="tab-pane fade in active show" id="unfinished">
+                                    {% if unreturned_records_list|length == 0 %}
+                                        <br/>
+                                        <p></p>
+                                        <p style="text-align:center;">没有进行中的借阅记录.</p>
+                                        <br/>
+                                    {% else %}
+                                        <br/>
+                                        <p>提示：移动端请左右滑动查看！</p>
+                                        <div class="tab-content">
+                                            <div id="all" class="tab-pane active">
+                                                <table class="table table-striped table-responsive-sm table-active">
+                                                    <thead>
+                                                        <tr>
+                                                            <th scope="col" width="25%" style="min-width: 160px;">书名</th>
+                                                            <th scope="col" width="30%" style="min-width: 160px;">借阅时间</th>
+                                                            <th scope="col" width="30%" style="min-width: 160px;">归还截止时间</th>
+                                                            <th scope="col" width="15%" style="min-width: 100px;">状态</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody class="table">
+                                                        {% for record in unreturned_records_list %}
+                                                        <tr>
+                                                            <th scope="row" style="vertical-align: middle;">
+                                                                《{{record.book_id__title}}》
+                                                            </th>
+                                                            <td>{{record.lend_time}}</td>
+                                                            <td>{{record.due_time}}</td>
+                                                            <td>
+                                                                {% if record.type == "normal" %} 
+                                                                    <span class="badge badge-pill" style="border-radius:4px; 
+                                                                        background-color:#00C957; color:#FFFFFF; margin:2px;
+                                                                        margin-top:0px; margin-bottom:4px;">一般记录
+                                                                    </span>
+                                                                {% elif record.type == "approaching" %}
+                                                                    <span class="badge badge-pill" style="border-radius:4px; 
+                                                                        background-color:#FFD700; color:#FFFFFF; margin:2px;
+                                                                        margin-top:0px; margin-bottom:4px;">接近期限
+                                                                    </span>
+                                                                {% else %}
+                                                                    <span class="badge badge-pill" style="border-radius:4px; 
+                                                                        background-color:#E3170D; color:#FFFFFF; margin:2px;
+                                                                        margin-top:0px; margin-bottom:4px;">已逾期
+                                                                    </span>
+                                                                {% endif %}
+                                                            </td>
+                                                        </tr>
+                                                        {% endfor %}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                    <br/><br/>
+                                </div>
+                                <div class="tab-pane fade" id="finished">
+                                    {% if returned_records_list|length == 0 %}
+                                        <br/>
+                                        <p></p>
+                                        <p style="text-align: center;">没有已完成的借阅记录.</p>
+                                        <br/>
+                                    {% else %}
+                                        <br/>
+                                        <p>提示：移动端请左右滑动查看！</p>
+                                        <div class="tab-content">
+                                            <div id="all" class="tab-pane active">
+                                                <table class="table table-striped table-responsive-sm table-active">
+                                                    <thead>
+                                                        <tr>
+                                                            <th scope="col" width="24%" style="min-width: 160px;">书名</th>
+                                                            <th scope="col" width="21%" style="min-width: 160px;">借阅时间</th>
+                                                            <th scope="col" width="21%" style="min-width: 160px;">归还截止时间</th>
+                                                            <th scope="col" width="21%" style="min-width: 160px;">归还时间</th>
+                                                            <th scope="col" width="13%" style="min-width: 100px;">申诉状态</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody class="table">
+                                                        {% for record in returned_records_list %}
+                                                        <tr>
+                                                            <th scope="row" style="vertical-align: middle;">
+                                                                《{{record.book_id__title}}》
+                                                            </th>
+                                                            <td>{{record.lend_time}}</td>
+                                                            <td>{{record.due_time}}</td>
+                                                            <td {% if record.type != "normal" %} style="color:#E3170D" {% endif %}>
+                                                                {{record.return_time}}
+                                                            </td>
+                                                            <td {% if record.type == "normal" %} style="font-weight:bold" {% endif %}>
+                                                                {% if record.type == "normal" %} 
+                                                                    无需申诉。
+                                                                {% else %}
+                                                                    <!-- 逾期记录还需分情况 -->
+                                                                    {% if record.status == 0 or record.status == 1 %}
+                                                                        <!-- 未申诉的逾期记录 -->
+                                                                        <button type="button" class="btn btn-primary" style="width:70px; height:40px; font-size:14px; font-weight:bold;">申诉</button>
+                                                                    {% elif record.status == 2 %}
+                                                                        <!-- 申诉中 -->
+                                                                        <span class="badge badge-pill" style="border-radius:4px; 
+                                                                            background-color:#6E757C; color:#FFFFFF; margin:2px;
+                                                                            margin-top:0px; margin-bottom:4px;">申诉中
+                                                                        </span>
+                                                                    {% elif record.status == 3 %}
+                                                                        <!-- 申诉通过 -->
+                                                                        <span class="badge badge-pill" style="border-radius:4px; 
+                                                                            background-color:#00C957; color:#FFFFFF; margin:2px;
+                                                                            margin-top:0px; margin-bottom:4px;">申诉通过
+                                                                        </span>
+                                                                    {% elif record.status == 4 %}
+                                                                        <!-- 申诉失败 -->
+                                                                        <span class="badge badge-pill" style="border-radius:4px; 
+                                                                            background-color:#E3170D; color:#FFFFFF; margin:2px;
+                                                                            margin-top:0px; margin-bottom:4px;">申诉失败
+                                                                        </span>
+                                                                    {% endif %}
+                                                                {% endif %}
+                                                            </td>
+                                                        </tr>
+                                                        {% endfor %}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                    <br/><br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!--  END CONTENT AREA  -->
+
 {% endblock %}

--- a/yp_library/admin.py
+++ b/yp_library/admin.py
@@ -1,3 +1,22 @@
 from django.contrib import admin
 
-# Register your models here.
+from boottest.admin_utils import *
+from yp_library.models import *
+
+
+@admin.register(Reader)
+class ReaderAdmin(admin.ModelAdmin):
+    list_display = ["id", "student_id",]
+    search_fields = ("student_id",)
+
+
+@admin.register(Book)
+class BookAdmin(admin.ModelAdmin):
+    list_display = ["identity_code", "title", "author", "publisher", "returned",]
+    search_fields =  ("identity_code", "title", "author", "publisher",)
+    
+    
+@admin.register(LendRecord)
+class LendRecordAdmin(admin.ModelAdmin):
+    list_display = ["reader_id", "book_id", "lend_time", "due_time", "return_time", "returned",]
+    search_fields =  ("reader_id__student_id", "book_id",)

--- a/yp_library/admin.py
+++ b/yp_library/admin.py
@@ -18,5 +18,5 @@ class BookAdmin(admin.ModelAdmin):
     
 @admin.register(LendRecord)
 class LendRecordAdmin(admin.ModelAdmin):
-    list_display = ["reader_id", "book_id", "lend_time", "due_time", "return_time", "returned",]
-    search_fields =  ("reader_id__student_id", "book_id",)
+    list_display = ["reader_stu_id", "book_name", "lend_time", "due_time", "return_time", "returned",]
+    search_fields =  ("reader_stu_id", "book_name",)

--- a/yp_library/models.py
+++ b/yp_library/models.py
@@ -16,6 +16,9 @@ class Reader(models.Model):
     id = models.AutoField("编号", primary_key=True)
     student_id = models.CharField("学号", max_length=30, blank=True, null=True)
 
+    def __str__(self):
+        return self.student_id
+
 
 class Book(models.Model):
     class Meta:

--- a/yp_library/models.py
+++ b/yp_library/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib import admin
 from django.contrib.auth.models import User
 
 __all__ = [
@@ -63,3 +64,11 @@ class LendRecord(models.Model):
     status = models.SmallIntegerField(
         "借阅记录状态", choices=Status.choices, default=Status.NORMAL
     )
+    
+    @admin.display(description="读者学号")
+    def reader_stu_id(self):
+        return self.reader_id.student_id
+    
+    @admin.display(description="书籍名称")
+    def book_name(self):
+        return self.book_id.title

--- a/yp_library/test/test_lendinfo.py
+++ b/yp_library/test/test_lendinfo.py
@@ -52,10 +52,10 @@ class GetLendRecordTestCase(TestCase):
 
         records = get_my_records(123456789, returned=1, status=0)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['type'], 1)
+        self.assertEqual(records[0]['type'], 'normal')
         records = get_my_records(123456789, returned=1, status=1)
         self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]['type'], 0)
+        self.assertEqual(records[0]['type'], 'overtime')
         '''
         # 测试记录类型'type', 对于未归还记录，结果会随测试时的时间不同而变化
         records = get_my_records(1234567, returned=0, status=1)

--- a/yp_library/utils.py
+++ b/yp_library/utils.py
@@ -144,9 +144,9 @@ def get_my_records(reader_id: str, returned: Optional[bool] = None,
     if returned:
         for record in records:
             if  record['return_time'] > record['due_time']:
-                record['type'] = False          # 逾期记录
+                record['type'] = 'overtime'     # 逾期记录
             else:
-                record['type'] = True           # 正常记录
+                record['type'] = 'normal'       # 正常记录
     else:
         now_time = datetime.now()
         for record in records:
@@ -178,5 +178,8 @@ def get_lendinfo_by_readers(readers: QuerySet) -> Tuple[List[dict], List[dict]]:
     for reader_id in reader_ids:
         unreturned_records_list.extend(get_my_records(reader_id['id'], returned=False))
         returned_records_list.extend(get_my_records(reader_id['id'], returned=True))
+    
+    unreturned_records_list.sort(key=lambda r: r['due_time'])                 # 进行中记录按照应归还时间排序
+    returned_records_list.sort(key=lambda r: r['return_time'], reverse=True)  # 已完成记录按照归还时间逆序排列
     
     return unreturned_records_list, returned_records_list


### PR DESCRIPTION
这个pr的主要更改是实现书房借阅信息界面，但同时也完成了一些杂项任务：
1. 去除小组信息界面侧边栏的问答中心入口；
2. 注册元培书房admin权限；
3. 略微修改借阅信息界面后端逻辑，方便前端利用。
4. 针对借阅信息界面后端逻辑的修改，略微修改了test文件。

书房借阅信息界面的具体信息：
1. 进行中的借阅记录以表格形式呈现，按照归还截止时间正序排列（越靠前的记录应归还时间越早）。呈现字段有：书名（前端加上书名号）、借阅时间、归还截止时间、状态。状态分一般记录（距离归还截止时间大于1天的）、接近期限（未逾期但距离归还截止时间不到1天）、已逾期，使用badge形式，详见下方截图。
2. 已完成的借阅记录同样以表格形式呈现，按照归还时间逆序排列（越靠前的记录归还时间越晚/与现在越接近）。呈现字段有：书名（前端加上书名号）、借阅时间、归还截止时间、归还时间、申诉状态。申诉状态分无需申诉（未逾期的记录，直接用文字呈现）、申诉（未申诉的逾期记录允许申诉，用button呈现，后期可链接到申诉界面）、申诉中、申诉通过、申诉不通过（用badge呈现）。特别地，若一条已完成的借阅记录为逾期记录，“归还时间”将变为较为醒目的红色。

> 上面提到已完成借阅记录中未申诉的逾期记录会呈现“申诉”button，但申诉的逻辑还未完成，所以这个button暂时还未链接到任何的url，可以待后续申诉逻辑完成后再完善。

效果图：
（1）电脑端：

![9981659604845_ pic](https://user-images.githubusercontent.com/95567950/182814067-673f4b32-b7bd-41e1-83d1-9a6b84dfca6e.jpg)

![9991659604862_ pic](https://user-images.githubusercontent.com/95567950/182814083-22a5317c-723c-4c8f-95c5-b226e586731c.jpg)

（2）手机端

![10001659604888_ pic](https://user-images.githubusercontent.com/95567950/182814134-67f8b587-e9a9-4e1b-9fca-dcb4416b9279.jpg)

![10011659604921_ pic](https://user-images.githubusercontent.com/95567950/182816350-aa8ef2c7-3df2-4677-8e49-e454a6738927.jpg)


