### PR TITLE
书房后端的一些小改动

### DIFF
--- a/yp_library/test/test_lendinfo.py
+++ b/yp_library/test/test_lendinfo.py
@@ -30,11 +30,12 @@ class GetLendRecordTestCase(TestCase):
         LendRecord.objects.create(reader_id_id=987654321, book_id_id=3, lend_time='2022-07-01',
                                   due_time='2022-07-07', return_time='2022-07-20', returned=0, status=4)
 
-    def test_get_my_records(self):
+    def test_models(self):
         self.assertEqual(len(Book.objects.all().values()), 3)
         self.assertEqual(len(Reader.objects.all().values()), 3)
         self.assertEqual(len(LendRecord.objects.all().values()), 6)
-
+    
+    def test_records_num(self):
         self.assertEqual(len(get_my_records(123456789, returned=0)), 0)
         self.assertEqual(len(get_my_records(123456789, returned=1)), 3)
         self.assertEqual(len(get_my_records(123456789, status=[0, 1])), 2)
@@ -49,7 +50,8 @@ class GetLendRecordTestCase(TestCase):
         self.assertEqual(
             len(get_my_records(1234567, returned=0, status=[3, 1, 2])), 1)
         self.assertEqual(len(get_my_records(987654321, status=[4, ])), 1)
-
+    
+    def test_records_type(self):
         records = get_my_records(123456789, returned=1, status=0)
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]['type'], 'normal')

--- a/yp_library/test/test_lendinfo.py
+++ b/yp_library/test/test_lendinfo.py
@@ -34,7 +34,7 @@ class GetLendRecordTestCase(TestCase):
         self.assertEqual(len(Book.objects.all().values()), 3)
         self.assertEqual(len(Reader.objects.all().values()), 3)
         self.assertEqual(len(LendRecord.objects.all().values()), 6)
-    
+
     def test_records_num(self):
         self.assertEqual(len(get_my_records(123456789, returned=0)), 0)
         self.assertEqual(len(get_my_records(123456789, returned=1)), 3)

--- a/yp_library/test/test_search.py
+++ b/yp_library/test/test_search.py
@@ -18,7 +18,7 @@ class BookSearchTestCase(TestCase):
                             title="数据结构与算法（A）", author="Bob", publisher="xyz", returned=0)
         Book.objects.create(id=6, identity_code="CS-3",
                             title="计算概论", author="北京大学", publisher="ABC")
-    
+
     def test_books_count(self):
         self.assertEqual(len(Book.objects.all().values()), 6)
 
@@ -31,23 +31,15 @@ class BookSearchTestCase(TestCase):
         query6 = {"returned": True}
         query7 = {"title": "数", "returned": True}
         query8 = {}
-        
-        self.assertEqual(
-            len(search_books(**query1)), 1)
-        self.assertEqual(
-            len(search_books(**query2)), 3)
-        self.assertEqual(
-            len(search_books(**query3)), 2)
-        self.assertEqual(
-            len(search_books(**query4)), 0)
-        self.assertEqual(
-            len(search_books(**query5)), 0)
-        self.assertEqual(
-            len(search_books(**query6)), 3)
-        self.assertEqual(
-            len(search_books(**query7)), 1)
-        self.assertEqual(
-            len(search_books(**query8)), 6)
+
+        self.assertEqual(len(search_books(**query1)), 1)
+        self.assertEqual(len(search_books(**query2)), 3)
+        self.assertEqual(len(search_books(**query3)), 2)
+        self.assertEqual(len(search_books(**query4)), 0)
+        self.assertEqual(len(search_books(**query5)), 0)
+        self.assertEqual(len(search_books(**query6)), 3)
+        self.assertEqual(len(search_books(**query7)), 1)
+        self.assertEqual(len(search_books(**query8)), 6)
 
     def test_keywords_query(self):
         query9 = {"keywords": "学"}
@@ -56,13 +48,8 @@ class BookSearchTestCase(TestCase):
         query12 = {"returned": True, "keywords": "A"}
         query13 = {"keywords": "CS"}
         
-        self.assertEqual(
-            len(search_books(**query9)), 4)
-        self.assertEqual(
-            len(search_books(**query10)), 2)
-        self.assertEqual(
-            len(search_books(**query11)), 1)
-        self.assertEqual(
-            len(search_books(**query12)), 3)
-        self.assertEqual(
-            len(search_books(**query13)), 3)
+        self.assertEqual(len(search_books(**query9)), 4)
+        self.assertEqual(len(search_books(**query10)), 2)
+        self.assertEqual(len(search_books(**query11)), 1)
+        self.assertEqual(len(search_books(**query12)), 3)
+        self.assertEqual(len(search_books(**query13)), 3)

--- a/yp_library/test/test_search.py
+++ b/yp_library/test/test_search.py
@@ -18,49 +18,51 @@ class BookSearchTestCase(TestCase):
                             title="数据结构与算法（A）", author="Bob", publisher="xyz", returned=0)
         Book.objects.create(id=6, identity_code="CS-3",
                             title="计算概论", author="北京大学", publisher="ABC")
-
-    def test_search_books(self):
+    
+    def test_books_count(self):
         self.assertEqual(len(Book.objects.all().values()), 6)
-        query1 = ['1', '', '', '', '', '', '']
-        query2 = ['', 'MATH', '数', '', '', '', '']
-        query3 = ['', '', '', '伍胜健', '北京大学', '', '']
-        query4 = ['0', '', '', '', '', '', '']
-        query5 = ['1', 'CS', '', '', '', '', '']
-        query6 = ['', '', '', '', '', True, '']
-        query7 = ['', '', '数', '', '', True, '']
-        query8 = ['', '', '', '', '', '', '']
-        query9 = ['', '', '', '', '', '', ['学', ["kw_title", "kw_publisher"]]]
-        query10 = ['', '', '', '', '', True, ['北京大学', ["kw_title", "kw_author", "kw_publisher"]]]
-        query11 = ['', '', '数学', '', '', True, ['北京大学', ["kw_title", "kw_author", "kw_publisher"]]]
-        query12 = ['', '', '', '', '', True, ['A', ["kw_title", "kw_author", "kw_publisher", "kw_identity_code"]]]
-        query13 = ['', '', '', '', '', '', ['CS', ["kw_title", "kw_author", "kw_publisher", "kw_identity_code"]]]
-        keys = ["id", "identity_code", "title",
-                "author", "publisher", "returned", "keywords"]
+
+    def test_normal_query(self):
+        query1 = {"id": '1'}
+        query2 = {"identity_code": "MATH", "title": "数"}
+        query3 = {"author": "伍胜健", "publisher": "北京大学"}
+        query4 = {"id": "0"}
+        query5 = {"id": "1", "identity_code": "CS"}
+        query6 = {"returned": True}
+        query7 = {"title": "数", "returned": True}
+        query8 = {}
         
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query1)})), 1)
+            len(search_books(**query1)), 1)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query2)})), 3)
+            len(search_books(**query2)), 3)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query3)})), 2)
+            len(search_books(**query3)), 2)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query4)})), 0)
+            len(search_books(**query4)), 0)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query5)})), 0)
+            len(search_books(**query5)), 0)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query6)})), 3)
+            len(search_books(**query6)), 3)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query7)})), 1)
+            len(search_books(**query7)), 1)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query8)})), 6)
+            len(search_books(**query8)), 6)
+
+    def test_keywords_query(self):
+        query9 = {"keywords": "学"}
+        query10 = {"returned": True, "keywords": "北京大学"}
+        query11 = {"title": "数学", "returned": True, "keywords": "北京大学"}
+        query12 = {"returned": True, "keywords": "A"}
+        query13 = {"keywords": "CS"}
+        
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query9)})), 3)
+            len(search_books(**query9)), 4)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query10)})), 2)
+            len(search_books(**query10)), 2)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query11)})), 1)
+            len(search_books(**query11)), 1)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query12)})), 3)
+            len(search_books(**query12)), 3)
         self.assertEqual(
-            len(search_books({k: v for (k, v) in zip(keys, query13)})), 3)
-        self.assertEqual(len(search_books({})), 6)
+            len(search_books(**query13)), 3)

--- a/yp_library/utils.py
+++ b/yp_library/utils.py
@@ -43,8 +43,7 @@ def search_books(**query_dict) -> QuerySet[Book]:
 
     :param query_dict: key为id/identity_code/title/author/publisher/returned, value为相应的query
         id和returned是精确查询，剩下四个是string按contains查询
-        特别地，还支持全关键词查询：键keywords的值为一个列表[word, [field1, field2, ...]]，表示在给定的（多个）field中检索word（即“或”的关系）
-        field可以是title/author/publisher
+        特别地，还支持全关键词查询：同时在identity_code/title/author/publisher中检索word
     :type query_dict: dict
     :return: 查询结果，每个记录是Book表的一行
     :rtype: QuerySet[Book]
@@ -80,7 +79,7 @@ def get_query_dict(post_dict: QueryDict) -> dict:
 
     :param post_dict: request.POST
     :type post_dict: QueryDict
-    :return: 一个词典，key为id/identity_code/title/author/publisher/returned, value为相应的query
+    :return: 一个词典，key为id/identity_code/title/author/publisher/returned/keywords, value为相应的query
     :rtype: dict
     """
     # 采用五种查询条件，即"identity_code", "title", "author", "publisher"和"returned"，可视情况修改

--- a/yp_library/utils.py
+++ b/yp_library/utils.py
@@ -13,10 +13,10 @@ from django.http import QueryDict
 
 from app.utils import check_user_type
 from app.models import Activity
-from app.constants import get_setting
+from app.constants import get_setting, UTYPE_PER
 
 
-def get_readers_by_user(user: User) -> QuerySet:
+def get_readers_by_user(user: User) -> QuerySet[Reader]:
     """
     根据学号寻找与user关联的reader，要求必须为个人账号且账号必须通过学号关联至少一个reader，否则抛出AssertionError
 
@@ -25,10 +25,10 @@ def get_readers_by_user(user: User) -> QuerySet:
     :raises AssertionError: 只允许个人账户登录
     :raises AssertionError: user的学号没有关联任何书房账号
     :return: 与user关联的所有reader
-    :rtype: QuerySet
+    :rtype: QuerySet[Reader]
     """
     valid, user_type, _ = check_user_type(user)
-    if user_type != "Person":  # 只允许个人账户登录
+    if user_type != UTYPE_PER:  # 只允许个人账户登录
         raise AssertionError('您目前使用非个人账号登录，如要查询借阅记录，请使用个人账号。')
     readers = Reader.objects.filter(
         student_id=user.username).values()  # 获取与当前user的学号对应的所有readers
@@ -37,7 +37,7 @@ def get_readers_by_user(user: User) -> QuerySet:
     return readers
 
 
-def search_books(query_dict: dict) -> QuerySet:
+def search_books(**query_dict) -> QuerySet[Book]:
     """
     根据给定的属性查询书
 
@@ -47,7 +47,7 @@ def search_books(query_dict: dict) -> QuerySet:
         field可以是title/author/publisher
     :type query_dict: dict
     :return: 查询结果，每个记录是Book表的一行
-    :rtype: QuerySet
+    :rtype: QuerySet[Book]
     """
     query = Q()
     if query_dict.get("id", "") != "":
@@ -63,17 +63,11 @@ def search_books(query_dict: dict) -> QuerySet:
     if query_dict.get("returned", "") != "":
         query &= Q(returned=query_dict["returned"])
 
-    if query_dict.get("keywords", "") != "" and query_dict["keywords"][0] != "":
-        kw_query = Q()
-        for kw_type in query_dict["keywords"][1]:
-            if kw_type == "kw_title":
-                kw_query |= Q(title__contains=query_dict["keywords"][0])
-            elif kw_type == "kw_author":
-                kw_query |= Q(author__contains=query_dict["keywords"][0])
-            elif kw_type == "kw_publisher":
-                kw_query |= Q(publisher__contains=query_dict["keywords"][0])
-            elif kw_type == "kw_identity_code":
-                kw_query |= Q(identity_code__contains=query_dict["keywords"][0])
+    if query_dict.get("keywords", "") != "":
+        kw_query = (Q(title__contains=query_dict["keywords"]) |\
+             Q(author__contains=query_dict["keywords"]) |\
+             Q(publisher__contains=query_dict["keywords"]) |\
+             Q(identity_code__contains=query_dict["keywords"]))
         query &= kw_query
 
     search_results = Book.objects.filter(query).values()
@@ -95,18 +89,18 @@ def get_query_dict(post_dict: QueryDict) -> dict:
     # search_books函数要求输入为一个词典，其条目对应"id", "identity_code", "title", "author", "publisher"和"returned"的query
     # 这里没有id的query，故query为空串
     # 此外，还提供“全关键词检索”，具体见search_books
-    query_dict = {k: post_dict.get(k, "") # 这四个可有可无而keywords和returned必须有，这样可以兼容welcome页面的搜索
-                  for k in ["identity_code", "title", "author", "publisher"]}
-    query_dict["id"] = ""
-
+    query_dict = {}
+    for query_type in ["identity_code", "title", "author", "publisher"]:
+        if query_type in post_dict.keys():
+            query_dict[query_type] = post_dict[query_type]
+    
+    # 上面的"identity_code", "title", "author", "publisher"在post_dict中可以没有（如welcome页面的搜索），
+    # 下面的"returned"和"keywords"必须有
     if len(post_dict.getlist("returned")) == 1:  # 如果对returned有要求
         query_dict["returned"] = True
-    else:  # 对returned没有要求
-        query_dict["returned"] = ""
 
     # 全关键词检索
-    query_dict["keywords"] = [post_dict["keywords"],
-                              ["kw_title", "kw_author", "kw_publisher", "kw_identity_code"]]
+    query_dict["keywords"] = post_dict["keywords"]
 
     return query_dict
 
@@ -166,12 +160,12 @@ def get_my_records(reader_id: str, returned: Optional[bool] = None,
     return records
 
 
-def get_lendinfo_by_readers(readers: QuerySet) -> Tuple[List[dict], List[dict]]:
+def get_lendinfo_by_readers(readers: QuerySet[Reader]) -> Tuple[List[dict], List[dict]]:
     '''
     查询同一user关联的读者的借阅信息
 
     :param readers: 与user关联的所有读者
-    :type readers: QuerySet
+    :type readers: QuerySet[Reader]
     :return: 两个list，分别表示未归还记录和已归还记录
     :rtype: List[dict], List[dict]
     '''
@@ -189,7 +183,7 @@ def get_lendinfo_by_readers(readers: QuerySet) -> Tuple[List[dict], List[dict]]:
     return unreturned_records_list, returned_records_list
 
 
-def get_library_activity(num: int) -> QuerySet:
+def get_library_activity(num: int) -> QuerySet[Activity]:
     """
     获取书房欢迎页面展示的活动列表
     目前筛选活动的逻辑是：书房组织的、状态为报名中/等待中/进行中、活动开始时间越晚越优先
@@ -197,7 +191,7 @@ def get_library_activity(num: int) -> QuerySet:
     :param num: 最多展示多少活动
     :type num: int
     :return: 展示的活动
-    :rtype: QuerySet
+    :rtype: QuerySet[Activity]
     """
     all_valid_library_activities = Activity.objects.activated().filter(
         organization_id__oname=get_setting("library/organization_name"),
@@ -211,7 +205,7 @@ def get_library_activity(num: int) -> QuerySet:
     return display_activities
 
 
-def get_recommended_or_newest_books(num: int, newest: bool = False) -> QuerySet:
+def get_recommended_or_newest_books(num: int, newest: bool = False) -> QuerySet[Book]:
     """
     获取推荐/新入馆书目（以id为入馆顺序）
 
@@ -220,7 +214,7 @@ def get_recommended_or_newest_books(num: int, newest: bool = False) -> QuerySet:
     :param newest: 是否获取新入馆书目, defaults to False
     :type newest: bool, optional
     :return: 包含推荐书目/新入馆书目的QuerySet
-    :rtype: QuerySet
+    :rtype: QuerySet[Book]
     """
     book_counts = Book.objects.count()
     select_num = min(num, book_counts)

--- a/yp_library/utils.py
+++ b/yp_library/utils.py
@@ -105,7 +105,7 @@ def get_query_dict(post_dict: QueryDict) -> dict:
 
 
 def get_my_records(reader_id: str, returned: Optional[bool] = None, 
-    status: Optional[Union[list, int]] = None) -> List[dict]:
+                   status: 'list | int | LendRecord.Status' = None) -> List[dict]:
     """
     查询给定读者的借书记录
 
@@ -114,7 +114,7 @@ def get_my_records(reader_id: str, returned: Optional[bool] = None,
     :param returned: 如非空，则限定是否已归还, defaults to None
     :type returned: bool, optional
     :param status: 如非空，则限定当前状态, defaults to None
-    :type status: Union[list, int], optional
+    :type status: Union[list, tuple, int, LendRecord.Status], optional
     :return: 查询结果，每个记录包括val_list中的属性以及记录类型(key为'type': 
         对于已归还记录，False表示逾期记录，True表示正常记录；对于未归还记录，
         'normal'表示一般记录，'overtime'表示逾期记录，'approaching'表示接近
@@ -131,10 +131,11 @@ def get_my_records(reader_id: str, returned: Optional[bool] = None,
     else:
         results = all_records_list
 
-    if isinstance(status, list):
-        results = results.filter(status__in=status)
-    elif isinstance(status, int):
-        results = results.filter(status=status)
+    if status is not None:
+        if isinstance(status, (int, LendRecord.Status)):
+            results = results.filter(status=status)
+        else:
+            results = results.filter(status__in=status)
     
     records = list(results.values(*val_list))
     # 标记记录类型

--- a/yp_library/views.py
+++ b/yp_library/views.py
@@ -77,7 +77,7 @@ def search(request: HttpRequest) -> HttpResponse:
 
     if request.method == "POST" and request.POST:  # POST表明发起检索
         query_dict = get_query_dict(request.POST)  # 提取出检索条件
-        frontend_dict["search_results_list"] = search_books(query_dict)
+        frontend_dict["search_results_list"] = search_books(**query_dict)
 
     return render(request, "yp_library/search.html", frontend_dict)
 


### PR DESCRIPTION
1.search_books的参数改为**query_dict，get_query_dict获取的query_dict不保留post_dict中不存在的键；全关键词检索的搜索范围固定为identity_code/title/author/publisher，query_dict中keywords项仅保留关键词而不再是一个列表
2.参数、返回值类型的QuerySet补充为QuerySet[Model]
3.判定账号类型时使用UTYPE_PER
4.对search、lendinfo的测试函数进行拆分，search的测试函数根据search_books的修改进行了调整