### PR TITLE
学术地图搜索结果页面后端

### DIFF
--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -1,6 +1,7 @@
 from app.utils_dependency import *
 from app.models import (
     AcademicTag,
+    AcademicEntry,
     AcademicTagEntry,
     AcademicTextEntry,
 )
@@ -18,23 +19,26 @@ def get_search_results(query: str) -> List[dict]:
 
     :param keyword: 关键词
     :type keyword: str
-    :return: 搜索结果list，元素为dict，包含key：姓名、条目内容中包含关键词的条目名
+    :return: 搜索结果list，元素为dict，包含key：姓名、年级、条目内容中包含关键词的条目名。
+             一个条目名可能对应一个或多个内容（如参与多个科研项目等），因此条目名对应的value统一用tuple打包。
     :rtype: List[dict]
     """
-    # 首先搜索所有含有关键词的学术地图项目，忽略大小写，同时转换成一个List[dict]
-    academic_tags = AcademicTagEntry.objects.filter(tag__tag_content__icontains=query).values(
-        "person__name", "person__stu_grade", "tag__atype", "tag__tag_content",
-    )
-    academic_texts = AcademicTextEntry.objects.filter(content__icontains=query).values(
-        "person__name", "person__stu_grade", "atype", "content",
-    )
-    academic_tags = [tag.update({
-        "tag__atype": AcademicTag.AcademicTagType(tag["tag__atype"]).label
-    }) for tag in academic_tags]     # 将choice的值更新为choice对应的名字
-    academic_texts = [text.update({
-        "atype": AcademicTextEntry.AcademicTextType(text["atype"]).label
-    }) for text in academic_texts]   # 将choice的值更新为choice对应的名字
-
+    # 首先搜索所有含有关键词的公开的学术地图项目，忽略大小写，同时转换成QuerySet[dict]
+    academic_tags = AcademicTagEntry.objects.filter( 
+        tag__tag_content__icontains=query,
+        status=AcademicEntry.EntryStatus.PUBLIC,
+    ).values("person__name", "person__stu_grade", "tag__atype", "tag__tag_content")
+    academic_texts = AcademicTextEntry.objects.filter(
+        content__icontains=query,
+        status=AcademicEntry.EntryStatus.PUBLIC,
+    ).values("person__name", "person__stu_grade", "atype", "content")
+    
+    # 将choice的值更新为对应的选项名
+    for tag in academic_tags:
+        tag.update({"tag__atype": AcademicTag.AcademicTagType(tag["tag__atype"]).label})
+    for text in academic_texts:
+        text.update({"atype": AcademicTextEntry.AcademicTextType(text["atype"]).label})
+        
     # 然后根据tag/text对应的人，整合学术地图项目
     academic_map_dict = {}  # 整理一个以人名为key，以含有年级和学术地图项目的dict为value的dict
     for tag in academic_tags:
@@ -42,15 +46,15 @@ def get_search_results(query: str) -> List[dict]:
         academic_map_dict[person_name] = academic_map_dict.get(
             person_name, {"年级": tag["person__stu_grade"]}
         )
-        academic_map_dict[person_name].update(
-            {tag["tag__atype"]: tag["tag__content"]}
-        )
+        entry = academic_map_dict[person_name].get(tag["tag__atype"], tuple())
+        academic_map_dict[person_name][tag["tag__atype"]] = entry + (tag["tag__tag_content"],)
     for text in academic_texts:
         person_name = text["person__name"]
         academic_map_dict[person_name] = academic_map_dict.get(
-            person_name, {"年级": tag["person__stu_grade"]}
+            person_name, {"年级": text["person__stu_grade"]}
         )
-        academic_map_dict[person_name].update({tag["atype"]: tag["content"]})
+        entry = academic_map_dict[person_name].get(text["atype"], tuple())
+        academic_map_dict[person_name][text["atype"]] = entry + (text["content"],)
     
     # 最后将整理好的dict转换成前端利用的list
     academic_map_list = [

--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -7,6 +7,7 @@ from app.models import (
 )
 
 from typing import List
+from collections import defaultdict
 
 __all__ = [
     'get_search_results',
@@ -50,28 +51,22 @@ def get_search_results(query: str) -> List[dict]:
     for tag in academic_tags:
         person_id = tag["person__person_id_id"]
         tag_type = tag["tag__atype"]
-        if not academic_map_dict.__contains__(person_id):
-            academic_map_dict[person_id] = {
-                "姓名": tag["person__name"],
-                "年级": tag["person__stu_grade"],
-            }
-        if academic_map_dict[person_id].__contains__(tag_type):
-            academic_map_dict[person_id][tag_type].append(tag["tag__tag_content"])
-        else:
-            academic_map_dict[person_id][tag_type] = [tag["tag__tag_content"],]
+        tag_content = tag["tag__tag_content"]
+        if not person_id in academic_map_dict:
+            academic_map_dict[person_id] = defaultdict(list)
+            academic_map_dict[person_id]["姓名"] = tag["person__name"]
+            academic_map_dict[person_id]["年级"] = tag["person__stu_grade"]
+        academic_map_dict[person_id][tag_type].append(tag_content)
     
     for text in academic_texts:
         person_id = text["person__person_id_id"]
         text_type = text["atype"]
-        if not academic_map_dict.__contains__(person_id):
-            academic_map_dict[person_id] = {
-                "姓名": text["person__name"],
-                "年级": text["person__stu_grade"],
-            }
-        if academic_map_dict[person_id].__contains__(text_type):
-            academic_map_dict[person_id][text_type].append(text["content"])
-        else:
-            academic_map_dict[person_id][text_type] = [text["content"],]
+        text_content = text["content"]
+        if not person_id in academic_map_dict:
+            academic_map_dict[person_id] = defaultdict(list)
+            academic_map_dict[person_id]["姓名"] = text["person__name"]
+            academic_map_dict[person_id]["年级"] = text["person__stu_grade"]
+        academic_map_dict[person_id][text_type].append(text_content)
     
     # 最后将整理好的dict转换成前端利用的list
     academic_map_list = [value for value in academic_map_dict.values()]

--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -20,18 +20,24 @@ def get_search_results(query: str) -> List[dict]:
     :param keyword: 关键词
     :type keyword: str
     :return: 搜索结果list，元素为dict，包含key：姓名、年级、条目内容中包含关键词的条目名。
-             一个条目名可能对应一个或多个内容（如参与多个科研项目等），因此条目名对应的value统一用tuple打包。
+             一个条目名可能对应一个或多个内容（如参与多个科研项目等），因此条目名对应的value统一用list打包。
     :rtype: List[dict]
     """
     # 首先搜索所有含有关键词的公开的学术地图项目，忽略大小写，同时转换成QuerySet[dict]
     academic_tags = AcademicTagEntry.objects.filter( 
         tag__tag_content__icontains=query,
         status=AcademicEntry.EntryStatus.PUBLIC,
-    ).values("person__name", "person__stu_grade", "tag__atype", "tag__tag_content")
+    ).values(
+        "person__person_id_id", "person__name",   # person_id_id用于避免重名
+        "person__stu_grade", "tag__atype", "tag__tag_content",
+    )
     academic_texts = AcademicTextEntry.objects.filter(
         content__icontains=query,
         status=AcademicEntry.EntryStatus.PUBLIC,
-    ).values("person__name", "person__stu_grade", "atype", "content")
+    ).values(
+        "person__person_id_id", "person__name",   # person_id_id用于避免重名
+        "person__stu_grade", "atype", "content",
+    )
     
     # 将choice的值更新为对应的选项名
     for tag in academic_tags:
@@ -40,24 +46,33 @@ def get_search_results(query: str) -> List[dict]:
         text.update({"atype": AcademicTextEntry.AcademicTextType(text["atype"]).label})
         
     # 然后根据tag/text对应的人，整合学术地图项目
-    academic_map_dict = {}  # 整理一个以人名为key，以含有年级和学术地图项目的dict为value的dict
+    academic_map_dict = {}  # 整理一个以person_id_id为key，以含有姓名、年级和学术地图项目的dict为value的dict
     for tag in academic_tags:
-        person_name = tag["person__name"]
-        academic_map_dict[person_name] = academic_map_dict.get(
-            person_name, {"年级": tag["person__stu_grade"]}
-        )
-        entry = academic_map_dict[person_name].get(tag["tag__atype"], tuple())
-        academic_map_dict[person_name][tag["tag__atype"]] = entry + (tag["tag__tag_content"],)
+        person_id = tag["person__person_id_id"]
+        tag_type = tag["tag__atype"]
+        if not academic_map_dict.__contains__(person_id):
+            academic_map_dict[person_id] = {
+                "姓名": tag["person__name"],
+                "年级": tag["person__stu_grade"],
+            }
+        if academic_map_dict[person_id].__contains__(tag_type):
+            academic_map_dict[person_id][tag_type].append(tag["tag__tag_content"])
+        else:
+            academic_map_dict[person_id][tag_type] = [tag["tag__tag_content"],]
+    
     for text in academic_texts:
-        person_name = text["person__name"]
-        academic_map_dict[person_name] = academic_map_dict.get(
-            person_name, {"年级": text["person__stu_grade"]}
-        )
-        entry = academic_map_dict[person_name].get(text["atype"], tuple())
-        academic_map_dict[person_name][text["atype"]] = entry + (text["content"],)
+        person_id = text["person__person_id_id"]
+        text_type = text["atype"]
+        if not academic_map_dict.__contains__(person_id):
+            academic_map_dict[person_id] = {
+                "姓名": text["person__name"],
+                "年级": text["person__stu_grade"],
+            }
+        if academic_map_dict[person_id].__contains__(text_type):
+            academic_map_dict[person_id][text_type].append(text["content"])
+        else:
+            academic_map_dict[person_id][text_type] = [text["content"],]
     
     # 最后将整理好的dict转换成前端利用的list
-    academic_map_list = [
-        dict({"姓名": key}, **value) for key, value in academic_map_dict.items()
-    ]
+    academic_map_list = [value for value in academic_map_dict.values()]
     return academic_map_list

--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -1,5 +1,6 @@
 from app.utils_dependency import *
 from app.models import (
+    AcademicTag,
     AcademicTagEntry,
     AcademicTextEntry,
 )
@@ -20,28 +21,39 @@ def get_search_results(query: str) -> List[dict]:
     :return: 搜索结果list，元素为dict，包含key：姓名、条目内容中包含关键词的条目名
     :rtype: List[dict]
     """
-    # 首先搜索所有含有关键词的学术地图项目，忽略大小写
-    academic_tags = AcademicTagEntry.objects.filter(tag__tag_content__icontains=query)
-    academic_texts = AcademicTextEntry.objects.filter(content__icontains=query)
+    # 首先搜索所有含有关键词的学术地图项目，忽略大小写，同时转换成一个List[dict]
+    academic_tags = AcademicTagEntry.objects.filter(tag__tag_content__icontains=query).values(
+        "person__name", "person__stu_grade", "tag__atype", "tag__tag_content",
+    )
+    academic_texts = AcademicTextEntry.objects.filter(content__icontains=query).values(
+        "person__name", "person__stu_grade", "atype", "content",
+    )
+    academic_tags = [tag.update({
+        "tag__atype": AcademicTag.AcademicTagType(tag["tag__atype"]).label
+    }) for tag in academic_tags]     # 将choice的值更新为choice对应的名字
+    academic_texts = [text.update({
+        "atype": AcademicTextEntry.AcademicTextType(text["atype"]).label
+    }) for text in academic_texts]   # 将choice的值更新为choice对应的名字
 
     # 然后根据tag/text对应的人，整合学术地图项目
     academic_map_dict = {}  # 整理一个以人名为key，以含有年级和学术地图项目的dict为value的dict
-    highlight_query = '<font style="background-color: yellow; font-weight: bold;">' + query + '</font>'
     for tag in academic_tags:
-        person_name = tag.person.name
-        academic_map_dict[person_name] = academic_map_dict.get(person_name, {"年级": tag.person.stu_grade})
+        person_name = tag["person__name"]
+        academic_map_dict[person_name] = academic_map_dict.get(
+            person_name, {"年级": tag["person__stu_grade"]}
+        )
         academic_map_dict[person_name].update(
-            {tag.tag.get_atype_display(): tag.content.replace(query, highlight_query)}  # 搜索结果高亮显示
+            {tag["tag__atype"]: tag["tag__content"]}
         )
     for text in academic_texts:
-        person_name = text.person.name
-        academic_map_dict[person_name] = academic_map_dict.get(person_name, {"年级": tag.person.stu_grade})
-        academic_map_dict[person_name].update(
-            {text.get_atype_display(): text.content.replace(query, highlight_query)}  # 搜索结果高亮显示
+        person_name = text["person__name"]
+        academic_map_dict[person_name] = academic_map_dict.get(
+            person_name, {"年级": tag["person__stu_grade"]}
         )
+        academic_map_dict[person_name].update({tag["atype"]: tag["content"]})
     
     # 最后将整理好的dict转换成前端利用的list
-    academic_map_list = []
-    for key, value in academic_map_dict.items():
-        academic_map_list.append(dict({"姓名": key}, **value))
+    academic_map_list = [
+        dict({"姓名": key}, **value) for key, value in academic_map_dict.items()
+    ]
     return academic_map_list

--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -1,0 +1,47 @@
+from app.utils_dependency import *
+from app.models import (
+    AcademicTagEntry,
+    AcademicTextEntry,
+)
+
+from typing import List
+
+__all__ = [
+    'get_search_results',
+]
+
+
+def get_search_results(query: str) -> List[dict]:
+    """
+    根据提供的关键词获取搜索结果。
+
+    :param keyword: 关键词
+    :type keyword: str
+    :return: 搜索结果list，元素为dict，包含key：姓名、条目内容中包含关键词的条目名
+    :rtype: List[dict]
+    """
+    # 首先搜索所有含有关键词的学术地图项目，忽略大小写
+    academic_tags = AcademicTagEntry.objects.filter(tag__tag_content__icontains=query)
+    academic_texts = AcademicTextEntry.objects.filter(content__icontains=query)
+
+    # 然后根据tag/text对应的人，整合学术地图项目
+    academic_map_dict = {}  # 整理一个以人名为key，以含有年级和学术地图项目的dict为value的dict
+    highlight_query = '<font style="background-color: yellow; font-weight: bold;">' + query + '</font>'
+    for tag in academic_tags:
+        person_name = tag.person.name
+        academic_map_dict[person_name] = academic_map_dict.get(person_name, {"年级": tag.person.stu_grade})
+        academic_map_dict[person_name].update(
+            {tag.tag.get_atype_display(): tag.content.replace(query, highlight_query)}  # 搜索结果高亮显示
+        )
+    for text in academic_texts:
+        person_name = text.person.name
+        academic_map_dict[person_name] = academic_map_dict.get(person_name, {"年级": tag.person.stu_grade})
+        academic_map_dict[person_name].update(
+            {text.get_atype_display(): text.content.replace(query, highlight_query)}  # 搜索结果高亮显示
+        )
+    
+    # 最后将整理好的dict转换成前端利用的list
+    academic_map_list = []
+    for key, value in academic_map_dict.items():
+        academic_map_list.append(dict({"姓名": key}, **value))
+    return academic_map_list

--- a/app/academic_views.py
+++ b/app/academic_views.py
@@ -29,7 +29,8 @@ def searchAcademic(request: HttpRequest) -> HttpResponse:
     
     # POST表明搜索框发起检索
     if request.method == "POST" and request.POST:  
-        query = request.POST["query"]  # 获取用户输入的关键词
+        query = request.POST["query"]   # 获取用户输入的关键词
+        frontend_dict["query"] = query  # 前端可借此将字体设置为高亮
         frontend_dict["academic_map_list"] = get_search_results(query)
         
     frontend_dict["bar_display"] = get_sidebar_and_navbar(request.user, "学术地图搜索结果")

--- a/app/academic_views.py
+++ b/app/academic_views.py
@@ -1,0 +1,36 @@
+from app.views_dependency import *
+from app.models import (
+    AcademicTagEntry,
+    AcademicTextEntry,
+)
+from app.academic_utils import (
+    get_search_results,
+)
+from app.utils import get_sidebar_and_navbar
+
+__all__ = [
+    'searchAcademic',
+]
+
+
+@login_required(redirect_field_name="origin")
+@utils.check_user_access(redirect_url="/logout/")
+@log.except_captured(EXCEPT_REDIRECT, source='academic_views[searchAcademic]', record_user=True)
+def searchAcademic(request: HttpRequest) -> HttpResponse:
+    """
+    学术地图的搜索结果界面
+
+    :param request: http请求
+    :type request: HttpRequest
+    :return: http响应
+    :rtype: HttpResponse
+    """
+    frontend_dict = {}
+    
+    # POST表明搜索框发起检索
+    if request.method == "POST" and request.POST:  
+        query = request.POST["query"]  # 获取用户输入的关键词
+        frontend_dict["academic_map_list"] = get_search_results(query)
+        
+    frontend_dict["bar_display"] = get_sidebar_and_navbar(request.user, "学术地图搜索结果")
+    return render(request, "search_academic.html", frontend_dict)

--- a/app/models.py
+++ b/app/models.py
@@ -81,6 +81,10 @@ __all__ = [
     'ModuleLog',
     'FeedbackType',
     'Feedback',
+    'AcademicTag',
+    'AcademicEntry',
+    'AcademicTagEntry',
+    'AcademicTextEntry',
 ]
 
 # 兼容Django3.0及以下版本
@@ -1991,10 +1995,12 @@ class Feedback(CommentBase):
 class AcademicTag(models.Model):
 
     class AcademicTagType(models.IntegerChoices):
-        # MAJOR = (0, '专业')
-        ...
+        MAJOR = (0, '主修专业')
+        MINOR = (1, '辅修专业')
+        DOUBLE_DEGREE = (2, '双学位专业')
+        # Uncompleted ...
 
-    atype = models.SmallIntegerField(choices=AcademicTagType)
+    atype = models.SmallIntegerField(choices=AcademicTagType.choices)
     tag_content = models.CharField(max_length=63)
 
 
@@ -2020,11 +2026,14 @@ class AcademicTagEntry(AcademicEntry):
     def content(self) -> str:
         return self.tag.tag_content
 
+
 class AcademicTextEntry(AcademicEntry):
 
     class AcademicTextType(models.IntegerChoices):
-        # INTERNSHIP = (0, '实习经历')
-        ...
+        INTERNSHIP = (0, '实习经历')
+        SCIENTIFIC_RESEARCH = (1, '科研经历')
+        CHALLENGE_CUP = (2, '挑战杯经历')
+        # Uncompleted ...
 
-    atype = models.SmallIntegerField(choices=AcademicTextType)
+    atype = models.SmallIntegerField(choices=AcademicTextType.choices)
     content = models.CharField(max_length=4095)

--- a/app/models.py
+++ b/app/models.py
@@ -833,11 +833,10 @@ class ActivityManager(models.Manager):
                 Activity.Status.WAITING,
                 Activity.Status.PROGRESSING,
                 Activity.Status.END
-            ]
-        )).order_by("-start")
-
+            ],
+        )).order_by("category", "-start")
+    
     def get_newlyreleased_activity(self):
-        # 最新一周内发布的活动，按发布的时间逆序
         nowtime = datetime.now()
         return select_current(self.filter(
             publish_time__gt=nowtime - timedelta(days=7),
@@ -845,8 +844,8 @@ class ActivityManager(models.Manager):
                 Activity.Status.APPLYING,
                 Activity.Status.WAITING,
                 Activity.Status.PROGRESSING
-            ]
-        )).order_by("-publish_time")
+            ],
+        )).order_by("category", "-publish_time")
 
     def get_today_activity(self):
         # 开始时间在今天的活动,且不展示结束的活动。按开始时间由近到远排序
@@ -1044,7 +1043,6 @@ class Activity(CommentBase):
     class ActivityCategory(models.IntegerChoices):
         NORMAL = (0, "普通活动")
         COURSE = (1, "课程活动")
-        ELECTION = (2, "选课活动") # 不一定会使用到
 
     category = models.SmallIntegerField(
         "活动类别", choices=ActivityCategory.choices, default=0

--- a/app/test/test_search_academic.py
+++ b/app/test/test_search_academic.py
@@ -136,14 +136,14 @@ class GetSearchAcademicTestCase(TestCase):
     
     def test_results_type(self):
         result_chinese = get_search_results("中文")
-        self.assertEqual(result_chinese[0].__contains__("辅修专业"), True)
+        self.assertEqual("辅修专业" in result_chinese[0], True)
         results_physics = get_search_results("物理")
         for result in results_physics:
             if result["姓名"] == "1":
-                self.assertEqual(result.__contains__("实习经历"), True)
+                self.assertEqual("实习经历" in result, True)
             else:
-                self.assertEqual(result.__contains__("主修专业"), True)
-                self.assertEqual(result.__contains__("科研经历"), True)
+                self.assertEqual("主修专业" in result, True)
+                self.assertEqual("科研经历" in result, True)
     
     def test_results_entry(self):
         result_1 = get_search_results("1")

--- a/app/test/test_search_academic.py
+++ b/app/test/test_search_academic.py
@@ -1,0 +1,160 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from app.models import (
+    NaturalPerson,
+    AcademicTag,
+    AcademicEntry,
+    AcademicTagEntry,
+    AcademicTextEntry,                        
+)
+from app.academic_utils import get_search_results
+
+
+class GetSearchAcademicTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        u1 = User.objects.create(username="11", password="111")
+        u2 = User.objects.create(username="22", password="222")
+        u3 = User.objects.create(username="33", password="333")
+        
+        NaturalPerson.objects.create(person_id=u1, name="1", stu_grade="2018")
+        NaturalPerson.objects.create(person_id=u2, name="2", stu_grade="2018")
+        NaturalPerson.objects.create(person_id=u3, name="3", stu_grade="2019")
+
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MAJOR, tag_content="数学")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MAJOR, tag_content="物理")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MAJOR, tag_content="中文")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MINOR, tag_content="数学")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MINOR, tag_content="物理")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MINOR, tag_content="中文")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, tag_content="数学")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, tag_content="物理")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, tag_content="中文")
+        
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MAJOR, 
+                tag_content="数学",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MINOR, 
+                tag_content="中文",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MAJOR, 
+                tag_content="物理",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, 
+                tag_content="数学",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MAJOR, 
+                tag_content="中文",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MINOR,
+                tag_content="物理",
+        ))
+        
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            atype=AcademicTextEntry.AcademicTextType.INTERNSHIP,
+            content="数学物理方法qwq",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            atype=AcademicTextEntry.AcademicTextType.SCIENTIFIC_RESEARCH,
+            content="浩浩中文，卷帙浩繁。",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            atype=AcademicTextEntry.AcademicTextType.SCIENTIFIC_RESEARCH,
+            content="数学分析123456789",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            atype=AcademicTextEntry.AcademicTextType.SCIENTIFIC_RESEARCH,
+            content="物理物理物理物理物理11111111的",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            atype=AcademicTextEntry.AcademicTextType.INTERNSHIP,
+            content="中文实习",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            atype=AcademicTextEntry.AcademicTextType.CHALLENGE_CUP,
+            content="离散数学的原理是非常美妙的",
+        )
+
+    def test_models(self):
+        self.assertEqual(len(NaturalPerson.objects.all().values()), 3)
+        self.assertEqual(len(AcademicTag.objects.all().values()), 9)
+        self.assertEqual(len(AcademicTag.objects.filter(
+            atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE
+        ).values()), 3)
+        self.assertEqual(len(AcademicTagEntry.objects.all().values()), 6)
+        self.assertEqual(len(AcademicTagEntry.objects.filter(
+            status=AcademicEntry.EntryStatus.PUBLIC
+        ).values()), 3)
+        self.assertEqual(len(AcademicTextEntry.objects.all().values()), 6)
+        self.assertEqual(len(AcademicTextEntry.objects.filter(
+            status=AcademicEntry.EntryStatus.PRIVATE
+        ).values()), 2)
+
+    def test_results_num(self):
+        self.assertEqual(len(get_search_results("数学")), 3)
+        self.assertEqual(len(get_search_results("物理")), 2)
+        self.assertEqual(len(get_search_results("中文")), 1)
+        self.assertEqual(len(get_search_results("1")), 1)
+        self.assertEqual(len(get_search_results("Q")), 1)
+        self.assertEqual(len(get_search_results("理")), 3)
+    
+    def test_results_type(self):
+        result_chinese = get_search_results("中文")
+        self.assertEqual(result_chinese[0].__contains__("辅修专业"), True)
+        results_physics = get_search_results("物理")
+        for result in results_physics:
+            if result["姓名"] == "1":
+                self.assertEqual(result.__contains__("实习经历"), True)
+            else:
+                self.assertEqual(result.__contains__("主修专业"), True)
+                self.assertEqual(result.__contains__("科研经历"), True)
+    
+    def test_results_entry(self):
+        result_1 = get_search_results("1")
+        self.assertEqual(len(result_1[0].keys()), 3)
+        self.assertEqual(len(result_1[0]["科研经历"]), 2)
+        results_de = get_search_results("的")
+        for result in results_de:
+            if result["姓名"] == "2":
+                self.assertEqual(result["年级"], "2018")
+                self.assertEqual(type(result["科研经历"]), tuple)
+                self.assertEqual(result["科研经历"][0], "物理物理物理物理物理11111111的")
+            else:
+                self.assertEqual(result["年级"], "2019")
+                self.assertEqual(result["挑战杯经历"], ("离散数学的原理是非常美妙的",))        

--- a/app/test/test_search_academic.py
+++ b/app/test/test_search_academic.py
@@ -13,9 +13,9 @@ from app.academic_utils import get_search_results
 class GetSearchAcademicTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        u1 = User.objects.create(username="11", password="111")
-        u2 = User.objects.create(username="22", password="222")
-        u3 = User.objects.create(username="33", password="333")
+        u1 = User.objects.create(id="1", username="11", password="111")
+        u2 = User.objects.create(id="2", username="22", password="222")
+        u3 = User.objects.create(id="3", username="33", password="333")
         
         NaturalPerson.objects.create(person_id=u1, name="1", stu_grade="2018")
         NaturalPerson.objects.create(person_id=u2, name="2", stu_grade="2018")
@@ -153,8 +153,8 @@ class GetSearchAcademicTestCase(TestCase):
         for result in results_de:
             if result["姓名"] == "2":
                 self.assertEqual(result["年级"], "2018")
-                self.assertEqual(type(result["科研经历"]), tuple)
+                self.assertEqual(type(result["科研经历"]), list)
                 self.assertEqual(result["科研经历"][0], "物理物理物理物理物理11111111的")
             else:
                 self.assertEqual(result["年级"], "2019")
-                self.assertEqual(result["挑战杯经历"], ("离散数学的原理是非常美妙的",))        
+                self.assertEqual(result["挑战杯经历"], ["离散数学的原理是非常美妙的",])        

--- a/app/urls.py
+++ b/app/urls.py
@@ -19,6 +19,7 @@ from app import (
     YQPoint_views,
     course_views,
     feedback_views,
+    academic_views,
 )
 from django.conf import settings
 
@@ -101,6 +102,9 @@ urlpatterns = [
     path("feedback/", feedback_views.feedbackWelcome, name="feadbackWelcome"),
     path("modifyFeedback/", feedback_views.modifyFeedback, name="modifyFeedback"),
     path("viewFeedback/<str:fid>", feedback_views.viewFeedback, name="viewFeedback"),
+] + [
+    # 学术地图
+    path("searchAcademic/", academic_views.searchAcademic, name="searchAcademic"),
 ] + [
     # 埋点
     path('eventTrackingFunc/', views.eventTrackingFunc, name='eventTracking'),

--- a/app/views.py
+++ b/app/views.py
@@ -862,9 +862,10 @@ def homepage(request: HttpRequest):
 
     # 即将截止的活动，按截止时间正序
     prepare_times = Activity.EndBeforeHours.prepare_times
-    signup_rec = Activity.objects.activated().select_related(
-        'organization_id').filter(status = Activity.Status.APPLYING)
+
     signup_list = []
+    signup_rec = Activity.objects.activated().select_related(
+        'organization_id').filter(status = Activity.Status.APPLYING).order_by("category", "apply_end")[:10]
     for act in signup_rec:
         deadline = act.apply_end
         dictmp = {}
@@ -872,8 +873,7 @@ def homepage(request: HttpRequest):
         dictmp["act"] = act
         dictmp["tobestart"] = (deadline - nowtime).total_seconds()//360/10
         signup_list.append(dictmp)
-    signup_list.sort(key=lambda x:x["deadline"])
-    signup_list = signup_list[:10]
+    
     # 如果提交了心愿，发生如下的操作
     if request.method == "POST" and request.POST:
         wishtext = request.POST.get("wish")

--- a/boottest/settings.py
+++ b/boottest/settings.py
@@ -113,6 +113,10 @@ DATABASES = {
             'charset': 'utf8mb4',
         #     "init_command": "SET sql_mode='STRICT_TRANS_TABLES'",
         },
+        'TEST': {
+            'CHARSET': 'utf8',
+            'COLLATION': 'utf8_general_ci',
+        },
     },
 }
 

--- a/templates/search_academic.html
+++ b/templates/search_academic.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+
+{% block mainpage %}
+
+{% endblock %}


### PR DESCRIPTION
总体工作：新建academic_utils.py与academic_views.py，写好学术地图搜索结果页面后端，添加对应的html文件与url。

具体：目前只支持全关键词搜索，根据关键词筛选所有content中含有关键词的条目（entry），并根据人进行归纳（即将一个人的所有content含关键词的entry整合成一个字典），最后提供给前端一个含有搜索结果字典（key还包含姓名与年级）的list。