### PR TITLE
对话模型

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2049,10 +2049,10 @@ class Chat(CommentBase):
         verbose_name_plural = verbose_name
     
     questioner: User = models.ForeignKey(User, on_delete=models.SET_NULL,
-                             related_name="send_chat_set", blank=True, null=True)
+                             related_name="send_chat_set")
     respondent: User = models.ForeignKey(User, on_delete=models.SET_NULL,
-                             related_name="receive_chat_set", blank=True, null=True)
-    title = models.CharField("主题", blank=True, null=True, max_length=50)
+                             related_name="receive_chat_set")
+    title = models.CharField("主题", default="", max_length=50)
     anonymous_flag = models.BooleanField("是否匿名", default=False) # 指发送方
 
     class Status(models.IntegerChoices):

--- a/app/models.py
+++ b/app/models.py
@@ -2048,9 +2048,9 @@ class Chat(CommentBase):
         verbose_name = "对话"
         verbose_name_plural = verbose_name
     
-    questioner: User = models.ForeignKey(User, on_delete=models.SET_NULL,
+    questioner: User = models.ForeignKey(User, on_delete=models.CASCADE,
                              related_name="send_chat_set")
-    respondent: User = models.ForeignKey(User, on_delete=models.SET_NULL,
+    respondent: User = models.ForeignKey(User, on_delete=models.CASCADE,
                              related_name="receive_chat_set")
     title = models.CharField("主题", default="", max_length=50)
     anonymous_flag = models.BooleanField("是否匿名", default=False) # 指发送方


### PR DESCRIPTION
新建Chat模型，继承自CommentBase。每个Chat记录支持一对用户间的多次通信，每一条信息是一个Comment记录；一对用户间可以开启多个Chat，进行不同主题的讨论。
将应用于学术地图的QA功能。