### PR TITLE
学术地图问答

### DIFF
--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -4,13 +4,20 @@ from app.models import (
     AcademicEntry,
     AcademicTagEntry,
     AcademicTextEntry,
+    User,
+    Chat,
 )
+from app.utils import get_person_or_org, check_user_type
+from app.comment_utils import addComment, showComment
 
-from typing import List
+from django.http import HttpRequest
+from typing import List, Tuple, Dict
 from collections import defaultdict
 
 __all__ = [
     'get_search_results',
+    'change_chat_status', 'chats2Display', 'comments2Display'
+    'add_chat_message', 'create_chat',
 ]
 
 
@@ -71,3 +78,225 @@ def get_search_results(query: str) -> List[dict]:
     # 最后将整理好的dict转换成前端利用的list
     academic_map_list = [value for value in academic_map_dict.values()]
     return academic_map_list
+
+
+def change_chat_status(chat_id: int, to_status: Chat.Status, allow_modify_forbidden: bool=False) -> MESSAGECONTEXT:
+    """
+    修改chat的状态
+
+    :param chat_id
+    :type chat_id: int
+    :param to_status: 目标状态
+    :type to_status: Chat.Status
+    :param allow_modify_forbidden: 若为True，则允许修改原始状态为FORBIDDEN的chat，一般情况下都不允许，但在用户改变“是否允许匿名提问”时应该要允许, defaults to False
+    :type allow_modify_forbidden: bool, optional
+    :return: 表明成功与否的MESSAGECONTEXT
+    :rtype: MESSAGECONTEXT
+    """
+    # 参考了notification_utils.py的notification_status_change
+    context = wrong("在修改问答状态的过程中发生错误，请联系管理员！")
+    with transaction.atomic():
+        try:
+            chat: Chat = Chat.objects.select_for_update().get(id=chat_id)
+        except:
+            return wrong("该问答不存在！", context)
+        
+        if chat.status == to_status:
+            return succeed("问答状态无需改变！", context)
+        if chat.status == Chat.Status.FORBIDDEN and allow_modify_forbidden == False:
+            return wrong("当前问答禁用中！接收方不允许匿名提问!", context)
+        
+        if to_status == Chat.Status.CLOSED:
+            chat.status = Chat.Status.CLOSED
+            chat.save()
+            succeed("您已成功关闭一个问答！", context)
+        elif to_status == Chat.Status.PROGRESSING: # 这个目前没有用到
+            chat.status = Chat.Status.PROGRESSING
+            chat.save()
+            succeed("您已成功开放一个问答！", context)
+        else: # 改为FORBIDDEN还没实现
+            raise NotImplementedError
+        return context
+
+
+def chats2Display(chats: QuerySet[Chat], sent: bool) -> Dict[str, List[dict]]:
+    """
+    把我收到/我发出的所有chat转化为供前端展示的两个列表，分别是进行中chat的信息、和其他chat的信息
+
+    :param chats: 我收到/我发出的所有chat
+    :type chats: QuerySet[Chat]
+    :param sent: 若为True则表示我发出的，否则表示我收到的
+    :type sent: bool
+    :return: 一个词典，key为progressing和not_progressing，value分别是进行中chat的列表、和其他chat的列表
+    :rtype: Dict[str, List[dict]]
+    """
+    not_progressing_chats = []
+    progressing_chats = []
+
+    for chat in chats:
+        chat_dict = {}
+        chat_dict['id'] = chat.id
+
+        if sent:
+            chat_dict['anonymously_sent'] = chat.anonymous_flag # 我以匿名方式发给别人，“问答中心”页面的卡片上会显示[匿名]
+            valid, receiver_type, _ = check_user_type(chat.respondent) # 学术地图应该只能是个人，不过以后或许可能复用Chat模型？
+            chat_dict['receiver_type'] = receiver_type
+            receiver = get_person_or_org(chat.respondent, receiver_type)
+            chat_dict['receiver_name'] = receiver.get_display_name()
+            chat_dict['academic_url'] = receiver.get_absolute_url() # 为了在“问答中心”页面的卡片上加入学术地图的url，超链接放在receiver_name上
+        else:
+            if chat.anonymous_flag: # 他人匿名发给我
+                chat_dict['sender_type'] = 'anonymous'
+                chat_dict['sender_name'] = '匿名用户'
+                chat_dict['academic_url'] = ''
+            else:
+                valid, sender_type, _ = check_user_type(chat.questioner) # 学术地图应该只能是个人，不过以后或许可能复用Chat模型？
+                chat_dict['sender_type'] = sender_type
+                sender = get_person_or_org(chat.questioner, sender_type)
+                chat_dict['sender_name'] = sender.get_display_name()
+                chat_dict['academic_url'] = sender.get_absolute_url() # 为了在“问答中心”页面的卡片上加入学术地图的url，超链接放在sender_name上（若sender匿名发送则无超链接）
+        
+        if len(chat.title) >= 12:
+            chat_dict['title'] = chat.title[:12] + "……"
+        elif len(chat.title) == 0:
+            chat_dict['title'] = "无主题"
+        else:
+            chat_dict['title'] = chat.title
+        
+        chat_dict['status'] = chat.get_status_display()
+        chat_dict['start_time'] = chat.time
+        chat_dict['last_modification_time'] = chat.modify_time
+        chat_dict['chat_url'] = f"/viewQA/{chat.id}" # 问答详情的url，超链接放在title上
+        chat_dict['message_count'] = chat.comments.count()
+        # chat_dict["messages"] = showComment(
+        #     chat, anonymous_users=[chat.questioner] if chat.anonymous_flag else None) # "问答中心"页面不再显示每个chat的comment
+        
+        if chat.status == Chat.Status.PROGRESSING:
+            progressing_chats.append(chat_dict)
+        else:
+            not_progressing_chats.append(chat_dict)
+        
+    return {"progressing": progressing_chats, "not_progressing": not_progressing_chats}
+
+
+def comments2Display(chat: Chat, frontend_dict: dict, user: User):
+    """
+    获取一个chat中的所有comment并转化为前端展示所需的形式（复用了comment_utils.py/showComment）
+
+    :param chat: 
+    :type chat: Chat
+    :param frontend_dict: 前端词典
+    :type frontend_dict: dict
+    :param user: 当前用户
+    :type user: User
+    """
+    if len(chat.title) == 0:
+        frontend_dict['title'] = "无主题"
+    else:
+        frontend_dict['title'] = chat.title
+    
+    # 获取当前chat的所有comment
+    frontend_dict["messages"] = showComment(
+        chat, anonymous_users=[chat.questioner] if chat.anonymous_flag else None)
+    if len(frontend_dict["messages"]) == 0:
+        # 基本不可能出现，除非提问者匿名向不允许匿名提问的人发起了chat
+        frontend_dict["not_found_messages"] = "当前问答没有信息." 
+    
+    frontend_dict['status'] = chat.get_status_display()
+    frontend_dict["commentable"] = (chat.status == Chat.Status.PROGRESSING) # 若为True，则前端会给出评论区和“关闭当前问答”的按钮
+    
+    # 问答详情页面需要展示“发给xxx的问答”或“来自xxx的问答”，且xxx附有指向学术地图页面的超链接
+    # 因而需要判断我是提问者还是回答者，并记录对方的名字
+    # 问答详情页面对于我的信息和对方的信息以不同的格式显示
+    # 因而还需要记录我的名字，通过和frontend_dict["messages"]中每条记录的commentator.name对比来判断是不是我发的
+    # 事实上这些操作如果放到showComment里能减少一些get_display_name、get_person_or_org、get_absolute_url的调用，但需要对showComment做较大修改，就暂时没有整合进去
+    if chat.anonymous_flag == False:
+        me = get_person_or_org(user)
+        frontend_dict['my_name'] = me.get_display_name()
+        if user == chat.questioner:
+            frontend_dict["questioner_name"] = frontend_dict['my_name']
+            you = get_person_or_org(chat.respondent)
+            frontend_dict["respondent_name"] = you.get_display_name()
+            frontend_dict["academic_url"] = you.get_absolute_url()
+        else:
+            you = get_person_or_org(chat.questioner)
+            frontend_dict["questioner_name"] = you.get_display_name()
+            frontend_dict["respondent_name"] = frontend_dict['my_name']
+            frontend_dict["academic_url"] = you.get_absolute_url()
+    else: # 如果存在匿名情况，要注意删去指向学术地图页面的超链接
+        if user == chat.questioner: # 我匿名向他人提问
+            frontend_dict['my_name'] = "匿名用户"
+            frontend_dict["questioner_name"] = "匿名用户"
+            you = get_person_or_org(chat.respondent)
+            frontend_dict["respondent_name"] = you.get_display_name()
+            frontend_dict["academic_url"] = you.get_absolute_url()
+        else: # 他人匿名向我提问
+            me = get_person_or_org(user)
+            frontend_dict['my_name'] = me.get_display_name()
+            frontend_dict["questioner_name"] = "匿名用户"
+            frontend_dict["respondent_name"] = frontend_dict['my_name']
+            frontend_dict["academic_url"] = ""
+
+
+def add_chat_message(request: HttpRequest, chat: Chat) -> MESSAGECONTEXT:
+    """
+    给一个chat发送新comment，并给接收者发通知（复用了comment_utils.py/addComment）
+
+    :param request: addComment函数会用到，其user即为发送comment的用户，其POST参数至少应当包括：comment_submit（点击“回复”按钮），comment（回复内容）
+    :type request: HttpRequest
+    :param chat
+    :type chat: Chat
+    :return: 表明发送结果的MESSAGECONTEXT
+    :rtype: MESSAGECONTEXT
+    """
+    # 只能发给PROGRESSING的chat
+    if chat.status == Chat.Status.CLOSED:
+        return wrong("当前问答已关闭，无法发送新信息!")
+    if chat.status == Chat.Status.FORBIDDEN and request.user == chat.questioner:
+        return wrong("对方目前不允许匿名用户提问!")
+    
+    if request.user == chat.questioner:
+        receiver = chat.respondent # 我是这个chat的提问方，则我发送新comment时chat的接收方会收到通知
+        anonymous = chat.anonymous_flag # 如果chat是匿名提问的，则我作为提问方发送新comment时需要匿名
+    else:
+        receiver = chat.questioner # 我是这个chat的接收方，则我发送新comment时chat的提问方会收到通知
+        anonymous = False # 接收方发送的comment一定是实名的
+    
+    comment_context = addComment( # 复用comment_utils.py，这个函数包含了通知发送功能
+        request, chat, receiver, anonymous=anonymous, notification_title='学术地图问答信息')
+    return comment_context
+
+
+def create_chat(request: HttpRequest, respondent: User, title: str, anonymous: bool=False) -> Tuple[int, MESSAGECONTEXT]:
+    """
+    创建新chat并调用add_chat_message发送首条提问
+    将在views.py中被用到，因为发起问答的端口在个人主页-学术地图
+
+    :param request: add_chat_message会用到
+    :type request: HttpRequest
+    :param respondent: 被提问的人
+    :type respondent: User
+    :param title: chat主题，不超过50字
+    :type title: str
+    :param anonymous: chat是否匿名, defaults to False
+    :type anonymous: bool, optional
+    :return: 新chat的id（创建失败为-1）和表明创建chat/发送提问结果的MESSAGECONTEXT
+    :rtype: Tuple[int, MESSAGECONTEXT]
+    """
+    if len(title) > 50: # Chat.title的max_length为50
+        return -1, wrong("主题长度超过50字!")
+    if len(request.POST["comment"]) == 0:
+        return -1, wrong("提问内容不能为空!")
+    # 本函数暂未考虑receiver不允许匿名提问的情况，chat的初始status均为PROGRESSING
+    chat = Chat.objects.create(
+        questioner=request.user,
+        respondent=respondent,
+        title=title,
+        anonymous_flag=anonymous
+    )
+    # 创建chat后没有发送消息，随后创建chat的第一条comment时会发送消息
+    
+    comment_context = add_chat_message(request, chat)
+    # 如果创建comment成功，应该跳转到viewChat页面；如果失败，应该留在学术地图页面并显示warn_message
+
+    return chat.id, comment_context

--- a/app/academic_views.py
+++ b/app/academic_views.py
@@ -2,14 +2,19 @@ from app.views_dependency import *
 from app.models import (
     AcademicTagEntry,
     AcademicTextEntry,
+    Chat,
 )
 from app.academic_utils import (
     get_search_results,
+    change_chat_status,
+    add_chat_message,
+    chats2Display,
+    comments2Display,
 )
 from app.utils import get_sidebar_and_navbar
 
 __all__ = [
-    'searchAcademic',
+    'searchAcademic', 'showChats', 'viewChat'
 ]
 
 
@@ -35,3 +40,80 @@ def searchAcademic(request: HttpRequest) -> HttpResponse:
         
     frontend_dict["bar_display"] = get_sidebar_and_navbar(request.user, "学术地图搜索结果")
     return render(request, "search_academic.html", frontend_dict)
+
+
+@login_required(redirect_field_name="origin")
+@utils.check_user_access(redirect_url="/logout/")
+@log.except_captured(EXCEPT_REDIRECT, source='academic_views[showChats]', record_user=True)
+def showChats(request: HttpRequest) -> HttpResponse:
+    """
+    （学术地图）问答中心页面
+    展示我发出的和发给我的所有chat；可以关闭进行中的问答
+
+    :param request: 进入问答中心页面的request
+    :type request: HttpRequest
+    :return: 问答中心页面
+    :rtype: HttpResponse
+    """
+    frontend_dict = {}
+    frontend_dict["bar_display"] = get_sidebar_and_navbar(request.user, "学术地图问答")
+
+    if request.method == "POST" and request.POST:
+        if request.POST.get('close_chat', '') != '': # 关闭单个问答
+            chat_id = int(request.POST['close_chat'])
+            context = change_chat_status(chat_id, to_status=Chat.Status.CLOSED) # 会给出warn_message
+            my_messages.transfer_message_context(
+                context, frontend_dict, normalize=False)
+        # elif request.POST.get('comment_submit', '') != '': # 对某个问答新增评论。本页面不再支持此功能，挪到viewChat
+        #     chat_id = int(request.POST['comment_submit'])
+        #     context = add_chat_message(request, chat_id)
+        #     my_messages.transfer_message_context(context, frontend_dict, normalize=False)
+    
+    # 获取我发出的和发给我的所有chat
+    sent_chats = Chat.objects.filter(
+        questioner=request.user).order_by("-modify_time", "-time")
+    received_chats = Chat.objects.filter(
+        respondent=request.user).order_by("-modify_time", "-time")
+    frontend_dict["sent_chats"] = chats2Display(sent_chats, sent=True)
+    frontend_dict["received_chats"] = chats2Display(received_chats, sent=False) # chats2Display返回两个列表，分别是进行中的和其他
+    
+    return render(request, "showChats.html", frontend_dict)
+
+
+@login_required(redirect_field_name="origin")
+@utils.check_user_access(redirect_url="/logout/")
+@log.except_captured(EXCEPT_REDIRECT, source='academic_views[viewChat]', record_user=True)
+def viewChat(request: HttpRequest, chat_id: str) -> HttpResponse:
+    """
+    （学术地图）问答详情页面
+
+    :param request: 进入问答详情页面的request
+    :type request: HttpRequest
+    :param chat_id: 当前问答的id
+    :type chat_id: str
+    :return: 问答详情页面
+    :rtype: HttpResponse
+    """
+    try:
+        chat_id = int(chat_id)
+        chat = Chat.objects.get(id=chat_id)
+    except:
+        return redirect(message_url(wrong('问答不存在!')))
+    if chat.questioner != request.user and chat.respondent != request.user:
+        return redirect(message_url(wrong('您只能访问自己参与的问答!')))
+    
+    frontend_dict = {}
+    frontend_dict["bar_display"] = get_sidebar_and_navbar(request.user, "学术地图问答")
+
+    if request.method == "POST" and request.POST:
+        if request.POST.get('close', '') == '1': # 关闭当前问答
+            status_change_context = change_chat_status(chat.id, Chat.Status.CLOSED)
+            my_messages.transfer_message_context(status_change_context, frontend_dict, normalize=False)
+            chat = Chat.objects.get(id=chat_id) # 数据库中状态修改了，需要重新取一遍
+        elif request.POST.get('comment_submit', '') == '1': # 发消息
+            comment_context = add_chat_message(request, chat)
+            my_messages.transfer_message_context(comment_context, frontend_dict, normalize=False)
+    
+    comments2Display(chat, frontend_dict, request.user) # 把包括chat中的所有comments在内的前端所需的各种信息填入frontend_dict
+    
+    return render(request, "viewChat.html", frontend_dict)

--- a/app/urls.py
+++ b/app/urls.py
@@ -105,6 +105,8 @@ urlpatterns = [
 ] + [
     # 学术地图
     path("searchAcademic/", academic_views.searchAcademic, name="searchAcademic"),
+    path("AcademicQA/", academic_views.showChats, name="showChats"),
+    path("viewQA/<str:chat_id>", academic_views.viewChat, name="viewChat"),
 ] + [
     # 埋点
     path('eventTrackingFunc/', views.eventTrackingFunc, name='eventTracking'),

--- a/templates/showChats.html
+++ b/templates/showChats.html
@@ -1,0 +1,312 @@
+{% extends "base.html" %}
+
+
+{% block mainpage %}
+
+
+<!--  BEGIN CONTENT AREA  -->
+<div id="content" class="main-content">
+    <!--  BEGIN WARN_MESSAGE  -->
+    {% if warn_code == 1 %}
+    <div class="alert alert-warning  text-center">{{ warn_message }}</div>
+    {% elif warn_code == 2 %}
+    <div class="alert alert-success  text-center">{{ warn_message }}</div>
+    {% endif %}
+    <!--  END WARN_MESSAGE  -->
+        
+    <div class="container">
+        <div class="row layout-top-spacing">
+
+            {% if bar_display.help_paragraphs %}
+                {% include 'help.html' %}
+            {% endif %}
+
+            <div class="col-lg-12 col-12 layout-top-spacing">
+                <div class="bio layout-spacing ">
+                    <div class="widget-content widget-content-area">
+                        <div class="d-flex justify-content-between">
+                            <h3>问答中心</h3>
+                            <!-- <div class="btn-group">
+                                <div style="margin-left: 8px; ">
+                                    <a data-toggle="dropdown">
+                                        <h5><i class="fa fa-ellipsis-h"></i></h5>
+                                    </a>
+                                    <div class="dropdown-menu" style="max-width: 200%; max-height: 300%;">
+                                        <form role="form" method="POST" enctype="multipart/form-data">
+                                            <button class="dropdown-item" type="submit"
+                                                name='close_all' value="1"
+                                                onclick="return confirm('你确定要将全部问答关闭吗?')">关闭全部问答</button>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div> -->
+                        </div>
+                        
+                        
+                        <!--  BEGIN TAB TITLE  -->
+                        <ul id="myTab" class="nav nav-tabs nav-tabs-solid nav-justified">
+                            <li class="nav-item">
+                                <a class="nav-link active" href="#sent" data-toggle="tab">
+                                    <h5><i class="fa fa-envelope-o"></i> 我发出的提问</h5>
+                                </a>
+                            </li>
+
+                            <li class="nav-item">
+                                <a class="nav-link" href="#received" data-toggle="tab">
+                                    <h5><i class="fa fa-envelope-o"></i> 我收到的提问</h5>
+                                </a>
+                            </li>
+                        </ul>
+                        <!--  END TAB TITLE  -->
+
+                        <!--  BEGIN TAB CONTENT  -->
+                        <div id="myTabContent" class="tab-content">
+                            <!--  BEGIN SENT CHATS  -->
+                            <div class="tab-pane fade in active show" id="sent">
+                                <div id="sent-empty" style="display: none; margin-top: 40px; margin-bottom: -40px;">
+                                    <p style="text-align: center;">您没有进行过任何提问，可前往感兴趣的学术地图页面发起提问.</p>
+                                </div>
+                                <div class="bio-skill-box">
+                                    <div id="sent-list" class="row">
+                                        <!--  BEGIN SENT PROGRESSING CHATS  -->
+                                        {% for chat in sent_chats.progressing %}
+                                        <div class="col-12 col-xl-6 col-lg-12 mb-xl-4 mb-4 " id="sent-undone={{chat.id}}">
+                                            <div class=" b-skills">
+                                                <div class="d-flex justify-content-between">
+                                                    <div>
+                                                        <h5>
+                                                            <a href='{{chat.chat_url}}'><u>{{chat.title}}</u></a>
+                                                            <span class="badge badge-primary">{{chat.status}}</span><br />
+                                                        </h5>
+                                                    </div>
+                                                    <div>
+                                                        <h5>
+                                                            <form role="form" method="POST" enctype="multipart/form-data">
+                                                                <button class="btn btn-danger" type="submit"
+                                                                    name='close_chat' value="{{chat.id}}"
+                                                                    onclick="return confirm('确认关闭该问答？关闭后，问答双方无法再通过此问答发送消息.')">关闭该问答</button>
+                                                            </form>
+                                                        </h5>
+                                                    </div>
+                                                </div>
+                                                
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-address-book" style="width: 10px;"></i>
+                                                    <span class="ml-1">
+                                                        {% if chat.anonymously_sent %}
+                                                        <b>[匿名]</b>
+                                                        {% endif %}
+                                                        发给&nbsp;<b><a href='{{chat.academic_url}}'><u>{{chat.receiver_name}}</u></a></b>
+                                                    </span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-bell" style="width: 10px;"></i>
+                                                    <span class="ml-1">上次更新于{{chat.last_modification_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-envelope" style="width: 14px;"></i>
+                                                    <span class="ml-1">发起于{{chat.start_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-comments" style="width: 14px;"></i>
+                                                    <span class="ml-1">共{{chat.message_count}}条信息</span>
+                                                </p>
+                                            </div>
+                                        </div>
+                                        {% endfor %}
+                                        <!--  END SENT PROGRESSING CHATS  -->
+
+                                        <!--  BEGIN SENT NOT_PROGRESSING CHATS  -->
+                                        {% for chat in sent_chats.not_progressing %}
+                                        <div class="col-12 col-xl-6 col-lg-12 mb-xl-4 mb-4 " id="sent-done={{chat.id}}">
+                                            <div class=" b-skills">
+                                                <div class="d-flex justify-content-between">
+                                                    <div>
+                                                        <h5>
+                                                            <a href='{{chat.chat_url}}'><u>{{chat.title}}</u></a>
+                                                            {% if chat.status == "已关闭" %}
+                                                            <span class="badge badge-success">{{chat.status}}</span>
+                                                            {% else %}
+                                                            <span class="badge badge-danger">{{chat.status}}</span>
+                                                            {% endif %}
+                                                        </h5>
+                                                    </div>
+                                                </div>
+                                                
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-address-book" style="width: 10px;"></i>
+                                                    <span class="ml-1">
+                                                        {% if chat.anonymously_sent %}
+                                                        <b>[匿名]</b>
+                                                        {% endif %}
+                                                        发给&nbsp;<b><a href='{{chat.academic_url}}'><u>{{chat.receiver_name}}</u></a></b>
+                                                    </span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-bell" style="width: 10px;"></i>
+                                                    <span class="ml-1">上次更新于{{chat.last_modification_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-envelope" style="width: 14px;"></i>
+                                                    <span class="ml-1">发起于{{chat.start_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-comments" style="width: 14px;"></i>
+                                                    <span class="ml-1">共{{chat.message_count}}条信息</span>
+                                                </p>
+                                            </div>
+                                        </div>
+                                        {% endfor %}
+                                        <!--  END SENT NOT_PROGRESSING CHATS  -->
+                                    </div>
+                                </div>
+                            </div>
+                            <!--  END SENT CHATS  -->
+
+                            <!--  BEGIN RECEIVED CHATS  -->
+                            <div class="tab-pane fade" id="received">
+                                <div id="received-empty" style="display: none; margin-top: 40px; margin-bottom: -40px;">
+                                    <p style="text-align: center;">您没有收到任何提问.</p>
+                                </div>
+                                <div class="bio-skill-box">
+                                    <div id="received-list" class="row">
+                                        <!--  BEGIN RECEIVED PROGRESSING CHATS  -->
+                                        {% for chat in received_chats.progressing %}
+                                        <div class="col-12 col-xl-6 col-lg-12 mb-xl-4 mb-4 " id="received-undone={{chat.id}}">
+                                            <div class=" b-skills">
+                                                <div class="d-flex justify-content-between">
+                                                    <div>
+                                                        <h5>
+                                                            <a href='{{chat.chat_url}}'><u>{{chat.title}}</u></a>
+                                                            <span class="badge badge-primary">{{chat.status}}</span><br />
+                                                        </h5>
+                                                    </div>
+                                                    <div>
+                                                        <h5>
+                                                            <form role="form" method="POST" enctype="multipart/form-data">
+                                                                <button class="btn btn-danger" type="submit"
+                                                                    name='close_chat' value="{{chat.id}}"
+                                                                    onclick="return confirm('确认关闭该问答？关闭后，问答双方无法再通过此问答发送消息.')">关闭该问答</button>
+                                                            </form>
+                                                        </h5>
+                                                    </div>
+                                                </div>
+                                                
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-address-book" style="width: 10px;"></i>
+                                                    <span class="ml-1">
+                                                        来自&nbsp;
+                                                        {% if chat.academic_url != "" %}
+                                                        <b><a href='{{chat.academic_url}}'><u>{{chat.sender_name}}</u></a></b>
+                                                        {% else %}
+                                                        <b>{{chat.sender_name}}</b>
+                                                        {% endif %}
+                                                    </span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-bell" style="width: 10px;"></i>
+                                                    <span class="ml-1">上次更新于{{chat.last_modification_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-envelope" style="width: 14px;"></i>
+                                                    <span class="ml-1">发起于{{chat.start_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-comments" style="width: 14px;"></i>
+                                                    <span class="ml-1">共{{chat.message_count}}条信息</span>
+                                                </p>
+                                            </div>
+                                        </div>
+                                        {% endfor %}
+                                        <!--  END RECEIVED PROGRESSING CHATS  -->
+
+                                        <!--  BEGIN RECEIVED NOT_PROGRESSING CHATS  -->
+                                        {% for chat in received_chats.not_progressing %}
+                                        <div class="col-12 col-xl-6 col-lg-12 mb-xl-4 mb-4 " id="received-done={{chat.id}}">
+                                            <div class=" b-skills">
+                                                <div class="d-flex justify-content-between">
+                                                    <div>
+                                                        <h5>
+                                                            <a href='{{chat.chat_url}}'><u>{{chat.title}}</u></a>
+                                                            {% if chat.status == "已关闭" %}
+                                                            <span class="badge badge-success">{{chat.status}}</span>
+                                                            {% else %}
+                                                            <span class="badge badge-danger">{{chat.status}}</span>
+                                                            {% endif %}
+                                                        </h5>
+                                                    </div>
+                                                </div>
+                                                
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-address-book" style="width: 10px;"></i>
+                                                    <span class="ml-1">
+                                                        来自&nbsp;
+                                                        {% if chat.academic_url != "" %}
+                                                        <b><a href='{{chat.academic_url}}'><u>{{chat.sender_name}}</u></a></b>
+                                                        {% else %}
+                                                        <b>{{chat.sender_name}}</b>
+                                                        {% endif %}
+                                                    </span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-bell" style="width: 10px;"></i>
+                                                    <span class="ml-1">上次更新于{{chat.last_modification_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-envelope" style="width: 14px;"></i>
+                                                    <span class="ml-1">发起于{{chat.start_time}}</span>
+                                                </p>
+
+                                                <p style="color: rgb(66, 67, 68);">
+                                                    <i class="fa fa-comments" style="width: 14px;"></i>
+                                                    <span class="ml-1">共{{chat.message_count}}条信息</span>
+                                                </p>
+                                            </div>
+                                        </div>
+                                        {% endfor %}
+                                        <!--  END RECEIVED NOT_PROGRESSING CHATS  -->
+                                    </div>
+                                </div>
+                            </div>
+                            <!--  END RECEIVED CHATS  -->
+                        </div>
+                        <!--  END TAB CONTENT  -->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<!--  END CONTENT AREA  -->
+
+
+<script>
+    $('.nav-tabs').on('shown.bs.tab', 'a', function (e) {
+        if (e.relatedTarget) {
+            $(e.relatedTarget).removeClass('active');
+        }
+    })
+    $('.table').bootstrapTable({
+        onLoadSuccess: function () {
+            $('.table tr td').each(function () {
+
+                $(this).attr("title", $(this).text());
+                $(this).css("cursor", 'pointer');
+            });
+
+        }
+    })
+</script>
+
+{% endblock %}

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -45,6 +45,9 @@
             <b class="nav-link active" data-toggle="tab" role="tab" href="#information">个人信息</b>
         </li>
         <li class="nav-item">
+            <b class="nav-link" data-toggle="tab" role="tab" href="#academic_map">学术地图</b>
+        </li>
+        <li class="nav-item">
             <b class="nav-link" data-toggle="tab" role="tab" href="#organization">{{ context.title }}的小组</b>
         </li>
         <li class="nav-item">
@@ -296,6 +299,75 @@
 
         </div>
         <!--  END INFORMATION TAB  -->
+
+        <!--  BEGIN ACADEMICMAP TAB  -->
+        <div class="tab-pane fade" id="academic_map" role="tabpanel">
+
+            <div class="layout-px-spacing layout-top-spacing">
+                <div class="bio layout-spacing">
+                    <!--  BEGIN QUSETION AREA  -->
+                    {% if html_display.is_myself != True %}
+                    <div class="widget-content widget-content-area my-3">
+
+                        <div class="row">
+                            <h3 class="col mb-0">我要提问</h3>
+                        </div>
+
+                        <div class="bio-skill-box">
+                            <div class="row">
+                                <div class="col-md-12 mb-4">
+                                    <div class="statbox widget box box-shadow">
+                                        <div class="widget-content widget-content-area">
+                                            <table class="table table-bordered mb-4">
+                                                <form role="form" method="POST" enctype="multipart/form-data"
+                                                    onsubmit="return check_comment_inputs()">
+                                                    <div>
+                                                        <div class="form-group">
+                                                            <textarea type="text" id="comment_title" name="comment_title"
+                                                                    class="form-control"
+                                                                    aria-label="Default" rows="1"
+                                                                    placeholder="主题（50字以内，可以为空）"></textarea>
+                                                            <br \>
+                                                            <textarea type="text" id="comment" name="comment" 
+                                                                    class="form-control"
+                                                                    aria-label="Default" rows="5"
+                                                                    placeholder="具体内容（不能为空）"></textarea> <!-- 因为创建问答要复用comment_utils.py，这里必须叫“comment”  -->
+                                                            
+                                                        </div>
+                                                        <div class="d-flex justify-content-between">
+                                                            <div>
+                                                                
+                                                            </div>
+                                                            <div class="" style="text-align: right;">
+                                                                <input class="form-check-input" type="checkbox" id="comment_anonymous" name="comment_anonymous">
+                                                                <label class="form-check-label" for="comment_anonymous" style="font-size: 0.9rem;">
+                                                                    匿名提问&emsp;
+                                                                </label>
+                                                                <button type="submit"
+                                                                        class="btn btn-primary"
+                                                                        name="comment_submit" value="1"> <!-- 因为创建问答要复用comment_utils.py，这里必须叫“comment_submit”  -->
+                                                                    提问
+                                                                </button>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </form>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                    {% endif %}
+                    <!--  END QUESTION AREA  -->
+
+                </div>
+            </div>
+
+        </div>
+        <!--  END ACADEMICMAP TAB  -->
 
         <!--  BEGIN ORGANIZATION TAB  -->
         <div class="tab-pane fade" id="organization" role="tabpanel">

--- a/templates/viewChat.html
+++ b/templates/viewChat.html
@@ -1,0 +1,198 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+
+{% block mainpage %}
+<style>
+    select[readonly] {
+  background: #eee; /*Simular campo inativo - Sugestão @GabrielRodrigues*/
+  pointer-events: none;
+  touch-action: none;
+}
+</style>
+    <!--  BEGIN CONTENT AREA  -->
+    <div id="content" class="main-content">
+        <div class="container">
+            <!--  BEGIN WARN MESSAGES  -->
+            {% if warn_code == 2 %}
+            <div class="alert alert-success  text-center">{{warn_message}}</div>
+            {% elif warn_code == 1%}
+            <div class="alert alert-warning  text-center">{{warn_message}}</div>
+            {% endif %}
+            <!--  END WARN MESSAGES  -->
+            
+            <div class="row layout-top-spacing">
+
+                {% if bar_display.help_paragraphs %}
+                    {% include 'help.html' %}
+                {% endif %}
+
+                <div class="col-lg-12 col-sm-12 col-12 layout-spacing">
+                    <div class="bio layout-spacing ">
+                        <div class="widget-content widget-content-area">
+                            <!--  BEGIN CHAT TITLE  -->
+                            <div class="d-flex justify-content-between">
+                                <h3>
+                                    {% if my_name == questioner_name %}
+                                        {% if my_name == "匿名用户" %}
+                                        [匿名]
+                                        {% endif %}
+
+                                        {% if academic_url != "" and questioner_name != "匿名用户" %}
+                                        发给<a href='{{academic_url}}'><u>{{respondent_name}}</u></a>的问答：{{title}}&emsp;
+                                        {% else %}
+                                        发给{{respondent_name}}的问答：{{title}}&emsp;
+                                        {% endif %}
+                                    {% else %}
+                                        {% if academic_url != "" and questioner_name != "匿名用户" %}
+                                        来自<a href='{{academic_url}}'><u>{{questioner_name}}</u></a>的问答：{{title}}&emsp;
+                                        {% else %}
+                                        来自{{questioner_name}}的问答：{{title}}&emsp;
+                                        {% endif %}
+                                    {% endif %}
+                                    
+                                    {% if status == "进行中" %}
+                                    <span class="badge badge-primary">{{status}}</span><br />
+                                    {% elif status == "已关闭" %}
+                                    <span class="badge badge-success">{{status}}</span><br />
+                                    {% else %}
+                                    <span class="badge badge-danger">{{status}}</span><br />
+                                    {% endif %}
+                                </h3>
+                            </div>
+                            <!--  END CHAT TITLE  -->
+
+                            <!--  BEGIN CHAT CONTENT  -->
+                            <div class="row">
+                                <div class="col-md-12 mb-4">
+                                    <div class="statbox widget box box-shadow">
+                                        <div class="widget-content widget-content-area">
+                                            <table class="table table-bordered mb-4">
+                                            {% if messages|length != 0 %}
+                                                {% for comment in messages %}
+                                                <div class="form-group">
+                                                    <div class="d-flex justify-content-between">
+                                                        <!--  BEGIN MY MESSAGE HEAD -->
+                                                        {% if my_name == comment.commentator.name %}
+                                                        <div>
+                                                            <p style="color: rgb(66, 67, 68);">
+                                                                <i class="fa fa-calendar-o"></i>{{ comment.time }}</p>
+                                                        </div>
+                                                        <div align="right">
+                                                            <img src={{ comment.commentator.avatar }} width="24" height="24" alt="avatar">
+                                                                {% if comment.commentator.URL %}
+                                                                <a href='{{ comment.commentator.URL }}'>
+                                                                    <u>{{ comment.commentator.name }}</u>
+                                                                </a>
+                                                                {% else %}
+                                                                {{ comment.commentator.name }}
+                                                                {% endif %}
+                                                        </div>
+                                                        <!--  END MY MESSAGE HEAD -->
+                                                        
+                                                        <!--  BEGIN OTHERS MESSAGE HEAD -->
+                                                        {% else %}
+                                                        <div>
+                                                            <img src={{ comment.commentator.avatar }} width="24" height="24" alt="avatar">
+                                                                {% if comment.commentator.URL %}
+                                                                <a href='{{ comment.commentator.URL }}'>
+                                                                    <u>{{ comment.commentator.name }}</u>
+                                                                </a>
+                                                                {% else %}
+                                                                {{ comment.commentator.name }}
+                                                                {% endif %}
+                                                        </div>
+                                                        <div align="right">
+                                                            <p style="color: rgb(66, 67, 68);">
+                                                                <i class="fa fa-calendar-o"></i>{{ comment.time }}</p>
+                                                        </div>
+                                                        <!--  END OTHERS MESSAGE HEAD -->
+                                                        {% endif %}
+                                                    </div>
+                                                    <!--  BEGIN MESSAGE CONTENT -->
+                                                    {% if comment.text %}
+                                                        {% if comment.commentator.name == my_name %}
+                                                        <textarea name="comment" class="form-control no-gray" 
+                                                                disabled="disabled" rows="3" style="background-color:rgb(139, 206, 139) !important;color: black;">{{ comment.text }}</textarea>
+                                                        {% else %}
+                                                        <textarea name="comment" class="form-control no-gray"
+                                                                disabled="disabled" rows="3">{{ comment.text }}</textarea>
+                                                        {% endif %}
+                                                    {% endif %}
+                                                    {% if comment.photos %}
+                                                        {% if comment.text %}<br>{% endif %}
+                                                        <div style="max-height:1000px;overflow:auto;">
+                                                        {% for image in comment.photos %}
+                                                        <img src={{ image.get_image_path }} >
+                                                        {% endfor %}
+                                                        </div>
+                                                    {% endif %}
+                                                    <hr>
+                                                </div>
+                                                {% endfor %}
+                                                
+                                            {% else %}
+                                                <thead></thead>
+                                                <tbody>
+                                                    <tr>
+                                                        <td>{{ not_found_message }}</td>
+                                                    </tr>
+                                                </tbody>
+                                            {% endif %}
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!--  END CHAT CONTENT  -->
+
+                            <!--  BEGIN REPLY AREA  -->
+                            {% if commentable %}
+                            <div class="row">
+                                <div class="col-md-12 mb-4">
+                                    <div class="statbox widget box box-shadow">
+                                        <div class="widget-content widget-content-area">
+                                            <table class="table table-bordered mb-4">
+                                                <form role="form" method="POST" enctype="multipart/form-data"
+                                                    onsubmit="return check_comment_inputs()">
+                                                    <div>
+                                                        <div class="form-group">
+                                                            <textarea type="text" id="comment" name="comment"
+                                                                    class="form-control"
+                                                                    aria-label="Default" rows="3"
+                                                                    placeholder="添加回复或追问追答"></textarea>
+                                                            
+                                                        </div>
+                                                        <div class="d-flex justify-content-between">
+                                                            <div>
+                                                            </div>
+                                                            <div class="" style="text-align: right;">
+                                                                    <button type="submit"
+                                                                            class="btn btn-primary"
+                                                                            name="comment_submit" value="1">
+                                                                        回复
+                                                                    </button>
+                                                                    <button type="submit"
+                                                                            class="btn btn-danger"
+                                                                            name="close" value="1" onclick="return confirm('确认关闭该问答？关闭后，问答双方无法再通过此问答发送消息.')">
+                                                                        关闭当前问答
+                                                                    </button>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </form>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {% endif %}
+                            <!--  END REPLY AREA  -->
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### task43&task41 学术地图问答功能（前端+后端）
【后端部分】
1.academic_views.py加入showChats, viewChat两个页面，分别用于问答中心和问答详情
2.academic_views.py加入功能函数'change_chat_status', 'chats2Display', 'comments2Display', 'add_chat_message', 'create_chat'
**尚未编写测试，等这些函数的设计确定无误后我再补上吧**
3.对comment_utils.py的addComment函数做了一些拓展以便2中部分函数复用
4.urls.py加入1中提到的新页面
5.views.py的stuinfo页面加入对学术地图提问区的处理（没有写学术地图的呈现、编辑等部分）

【前端部分】
1.问答中心页面（/AcademicQA/）
（1）展示我收到的和我发出的问答，每个tab中均优先展示进行中的问答，order_by("-modify_time", "-time")
（2）在卡片的展示上与设计图略有不同，因为问答有title属性，我觉得用title作为标题会好区分一些。点击title会跳转到问答详情页面，点击发送人/接收人会跳转到其主页。**目前还没有实现跳转主页后自动打开“学术地图”tab**
（3）“进行中”状态的问答有“关闭该问答”按钮，点击后有确认窗口（“确认关闭该问答？关闭后，问答双方无法再通过此问答发送消息.”），确认则该问答转入“已关闭”状态，关闭后有提示语。问答双方均可进行此操作
（4）当前用户匿名发送的问答会在卡片上“发给”前面显示“[匿名]”；当前用户收到的匿名问答卡片上的“来自”后面显示“匿名用户”，且没有超链接
![28dfb4c59483101777d720de73a46ae](https://user-images.githubusercontent.com/60976065/185149776-ac5db1dc-5d22-47ad-a536-728006dd33ad.jpg)
![8a68ef78ca7d874e5b748d345572d80](https://user-images.githubusercontent.com/60976065/185149903-cc8b4948-1ae8-4115-8a2f-bc6763800f3b.jpg)

2.问答详情页面（/viewQA/<str:chat_id>）
（1）展示一个问答的具体内容，按时间顺序，我发送的和对方发送的在颜色和头像位置上有区分。**气泡形状和自适应高度、宽度还没有实现**，目前是仿照modify_position.html页面写的
（2）标题部分同样是改为了chat的title，点击“的问答”前面的用户名会跳转到对方的主页
（3）如果是进行中的问答，在页面下方可发送新消息或关闭当前问答，发送/关闭后均有提示语
（4）通过url访问不存在的问答详情页会跳到主页并提示“问答不存在!”；通过url访问提问者、回答者都不是自己的问答详情页会跳到主页并提示“您只能访问自己参与的问答!”
示意图如下
①我发送的
![502c4c6371821f06cb80906c458d6cc](https://user-images.githubusercontent.com/60976065/185150889-2dccf025-6021-4f16-88a5-f5166e8e8432.jpg)
![b239f589297691432c8e3d75aef8513](https://user-images.githubusercontent.com/60976065/185150914-02125af2-986e-4b5c-b894-db8a8ca4b7f0.jpg)
②发给我的
![image](https://user-images.githubusercontent.com/60976065/185150997-97d8dd75-3a69-44dc-9bab-a19b947db376.png)
![image](https://user-images.githubusercontent.com/60976065/185151039-6ba950d4-86f4-4266-8714-538ce3dd1bf5.png)
③匿名发给我的
![9c13f4efd2b9d0d36903670fea689e2](https://user-images.githubusercontent.com/60976065/185151292-1e396cd9-49d3-4591-b111-f2499fcbfec9.jpg)
④我匿名发送的
![b1f233ceadcd2c81f07b47162147334](https://user-images.githubusercontent.com/60976065/185154889-f91eab1e-804c-4306-ae78-4e04d2d328d8.jpg)

3.学术地图页面（即个人主页）
（1）加了个tab，但还没写学术地图的展示，只写了提问区。如果访问别人的主页，会出现提问区，点提问可以创建新问答并向其发送首条信息，随后跳转到这个问答的详情页面。目前可以匿名提问
（2）主题可以为空，在问答中心的页面会显示为“无主题”，超过50字会创建失败并给出提示（"主题长度超过50字!"）；具体内容不能为空，为空会创建失败并给出提示（"提问内容不能为空!"）
![image](https://user-images.githubusercontent.com/60976065/185151825-cf9ca8b0-2c9b-4563-b761-dfaa8fa8bafd.png)

4.通知
（1）每当我参与的问答有对方发来的消息时，我会收到一个知晓类的通知。点击“学术地图问答信息”会跳转到问答详情页面
（2）创建问答时没有单独发送通知，因为发第一条消息时会发通知
（3）**暂时没有把学术地图问答信息从通知信箱中独立出来，也没有在通知中加入跳转到发送人主页的链接**（不过可以进入详情页再点击其头像/标题中的用户名以跳转到其主页），**也暂时没有区分是我作为提问者的新信息还是我作为回答者的新信息**
![image](https://user-images.githubusercontent.com/60976065/185152768-b2ca06e1-25ca-4cd2-98db-37059aa0fe4d.png)
