### PR TITLE
小组主页增加跳转选课的按钮

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1,3 +1,4 @@
+from app.course_utils import str_to_time
 from app.views_dependency import *
 from app.models import (
     Feedback,
@@ -643,6 +644,14 @@ def orginfo(request: HttpRequest, name=None):
     wallpaper_path = utils.get_user_wallpaper(org, "Organization")
     # org的属性 YQPoint 和 information 不在此赘述，直接在前端调用
 
+    # 给前端传递选课的参数
+    html_display["yx_election_start"] = get_setting("course/yx_election_start")
+    html_display["yx_election_end"] = get_setting("course/yx_election_end")
+    if (str_to_time(html_display["yx_election_start"])) <= datetime.now() < (
+            str_to_time(html_display["yx_election_end"])):
+        html_display["select_ing"] = True
+    else:
+        html_display["select_ing"] = False
     if request.method == "POST" :
         if request.POST.get("export_excel") is not None and html_display["is_myself"]:
             html_display["warn_code"] = 2

--- a/app/views.py
+++ b/app/views.py
@@ -636,6 +636,7 @@ def orginfo(request: HttpRequest, name=None):
 
     # 判断是否为小组账户本身在登录
     html_display["is_myself"] = me == org
+    html_display["is_person"] = user_type == "Person"
     inform_share, alert_message = utils.get_inform_share(me=me, is_myself=html_display["is_myself"])
 
     organization_name = name
@@ -645,10 +646,10 @@ def orginfo(request: HttpRequest, name=None):
     # org的属性 YQPoint 和 information 不在此赘述，直接在前端调用
 
     # 给前端传递选课的参数
-    html_display["yx_election_start"] = get_setting("course/yx_election_start")
-    html_display["yx_election_end"] = get_setting("course/yx_election_end")
-    if (str_to_time(html_display["yx_election_start"])) <= datetime.now() < (
-            str_to_time(html_display["yx_election_end"])):
+    yx_election_start = get_setting("course/yx_election_start")
+    yx_election_end = get_setting("course/yx_election_end")
+    if (str_to_time(yx_election_start) <= datetime.now() < (
+            str_to_time(yx_election_end))):
         html_display["select_ing"] = True
     else:
         html_display["select_ing"] = False

--- a/app/views.py
+++ b/app/views.py
@@ -652,6 +652,7 @@ def orginfo(request: HttpRequest, name=None):
         html_display["select_ing"] = True
     else:
         html_display["select_ing"] = False
+        
     if request.method == "POST" :
         if request.POST.get("export_excel") is not None and html_display["is_myself"]:
             html_display["warn_code"] = 2

--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -67,7 +67,7 @@
                         <div class="d-flex justify-content-between">
                             <h3 class="">小组信息</h3>
                             <br /><br />
-                            {% if html_display.is_myself is False and html_display.select_ing is True %}
+                            {% if html_display.is_person is True and html_display.select_ing is True %}
                             <button class="flex btn btn-success btn-primary mb-4 mr-2" id="select_course" 
                                 onclick="location.href='/selectCourse/'" type="button">
                                 跳转至选课界面

--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -61,17 +61,18 @@
             <div class="col layout-top-spacing">
 
                 <div class="user-profile layout-spacing">
+                    <div class="bio layout-spacing">
                     <div class="widget-content widget-content-area">
 
                         <div class="d-flex justify-content-between">
                             <h3 class="">小组信息</h3>
                             <br /><br />
-                            <!-- {% if html_display.is_myself is False and html_display.select_ing is True %}
+                            {% if html_display.is_myself is False and html_display.select_ing is True %}
                             <button class="flex btn btn-success btn-primary mb-4 mr-2" id="select_course" 
                                 onclick="location.href='/selectCourse/'" type="button">
                                 跳转至选课界面
                             </button>
-                            {%endif%} -->
+                            {%endif%}
                         </div>
 
                         <div class="text-center user-info">
@@ -242,10 +243,11 @@
                         {% if not org.introduction == "" %}
                         <div class="d-flex justify-content-between">
                             <h3 class="">小组简介</h3>
-                            <br /><br />
                         </div>
                         <p class="m-3">{{org.introduction}}</p>
+                        <br /><br />
                         {% endif %}
+                    </div>
                     </div>
                 </div>
             </div>

--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -66,12 +66,12 @@
                         <div class="d-flex justify-content-between">
                             <h3 class="">小组信息</h3>
                             <br /><br />
-                            {% if html_display.is_myself is False and html_display.select_ing is True %}
+                            <!-- {% if html_display.is_myself is False and html_display.select_ing is True %}
                             <button class="flex btn btn-success btn-primary mb-4 mr-2" id="select_course" 
                                 onclick="location.href='/selectCourse/'" type="button">
                                 跳转至选课界面
                             </button>
-                            {%endif%}
+                            {%endif%} -->
                         </div>
 
                         <div class="text-center user-info">

--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -66,7 +66,7 @@
                         <div class="d-flex justify-content-between">
                             <h3 class="">小组信息</h3>
                             <br /><br />
-                            {% if html_display.is_myself is False and html_display.select_ing is False %}
+                            {% if html_display.is_myself is False and html_display.select_ing is True %}
                             <button class="flex btn btn-success btn-primary mb-4 mr-2" id="select_course" 
                                 onclick="location.href='/selectCourse/'" type="button">
                                 跳转至选课界面

--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -66,6 +66,12 @@
                         <div class="d-flex justify-content-between">
                             <h3 class="">小组信息</h3>
                             <br /><br />
+                            {% if html_display.is_myself is False and html_display.select_ing is False %}
+                            <button class="flex btn btn-success btn-primary mb-4 mr-2" id="select_course" 
+                                onclick="location.href='/selectCourse/'" type="button">
+                                跳转至选课界面
+                            </button>
+                            {%endif%}
                         </div>
 
                         <div class="text-center user-info">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/97873902/185459047-5092e018-47ea-4e8e-b42b-dcd80ce9ac1d.png)
暂时未实现跳转之后的定位，考虑到可能一个小组对应多个课程，能否在另作一个页面与小组信息、成员档案等并列，类似于一个新的聚合页面展示组织对应的所有选课？