### PR TITLE
优化禁止匿名问答的显示方法

### DIFF
--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -158,7 +158,9 @@ def comments2Display(chat: Chat, frontend_dict: dict, user: User):
     
     frontend_dict['status'] = chat.get_status_display()
     frontend_dict["commentable"] = (chat.status == Chat.Status.PROGRESSING) # 若为True，则前端会给出评论区和“关闭当前问答”的按钮
-    
+    frontend_dict["anonymous_chat"] = chat.anonymous_flag
+    frontend_dict["accept_anonymous"] = chat.respondent.accept_anonymous_chat
+
     # 问答详情页面需要展示“发给xxx的问答”或“来自xxx的问答”，且xxx附有指向学术地图页面的超链接
     # 因而需要判断我是提问者还是回答者，并记录对方的名字
     # 问答详情页面对于我的信息和对方的信息以不同的格式显示

--- a/app/chat_api.py
+++ b/app/chat_api.py
@@ -25,13 +25,13 @@ def startChat(request: HttpRequest) -> JsonResponse:
     :rtype: JsonResponse
     """
     receiver = User.objects.get(id=request.POST['receiver_id'])
-    anonymous_flag = (request.POST["comment_anonymous"]=="true")
+    anonymous = (request.POST["comment_anonymous"]=="true")
     
     new_chat_id, create_chat_context = create_chat(
         request, 
         receiver, 
         request.POST['comment_title'],
-        anonymous=anonymous_flag,
+        anonymous=anonymous,
     )
     result_context = { 
         # 只保留warn_code和warn_message，用于前端展示；

--- a/app/chat_utils.py
+++ b/app/chat_utils.py
@@ -62,7 +62,7 @@ def add_chat_message(request: HttpRequest, chat: Chat) -> MESSAGECONTEXT:
     # 只能发给PROGRESSING的chat
     if chat.status == Chat.Status.CLOSED:
         return wrong("当前问答已关闭，无法发送新信息!")
-    if (not chat.respondent.accept_anonymous_chat) and chat.anonymous_flag:
+    if (not chat.respondent.accept_anonymous_chat) and chat.anonymous:
         if request.user == chat.respondent:
             return wrong("您目前处于禁用匿名提问状态!")
         else:
@@ -70,7 +70,7 @@ def add_chat_message(request: HttpRequest, chat: Chat) -> MESSAGECONTEXT:
     
     if request.user == chat.questioner:
         receiver = chat.respondent # 我是这个chat的提问方，则我发送新comment时chat的接收方会收到通知
-        anonymous = chat.anonymous_flag # 如果chat是匿名提问的，则我作为提问方发送新comment时需要匿名
+        anonymous = chat.anonymous # 如果chat是匿名提问的，则我作为提问方发送新comment时需要匿名
     else:
         receiver = chat.questioner # 我是这个chat的接收方，则我发送新comment时chat的提问方会收到通知
         anonymous = False # 接收方发送的comment一定是实名的
@@ -123,7 +123,7 @@ def create_chat(request: HttpRequest, respondent: User, title: str, anonymous: b
             questioner=request.user,
             respondent=respondent,
             title=title,
-            anonymous_flag=anonymous
+            anonymous=anonymous
         )
         # 创建chat后没有发送通知，随后创建chat的第一条comment时会发送通知
         comment_context = add_chat_message(request, chat)

--- a/app/models.py
+++ b/app/models.py
@@ -2073,7 +2073,7 @@ class Chat(CommentBase):
     respondent: User = models.ForeignKey(User, on_delete=models.CASCADE,
                              related_name="receive_chat_set")
     title = models.CharField("主题", default="", max_length=50)
-    anonymous_flag = models.BooleanField("是否匿名", default=False) # 指发送方
+    anonymous = models.BooleanField("是否匿名", default=False) # 指发送方
 
     class Status(models.IntegerChoices):
         PROGRESSING = (0, "进行中")

--- a/app/views.py
+++ b/app/views.py
@@ -531,6 +531,7 @@ def stuinfo(request: HttpRequest, name=None):
             html_display["have_progressing_chat"] = True
         else: # 没有进行中的问答，显示提问区
             html_display["have_progressing_chat"] = False
+            html_display["accept_anonymous"] = person.get_user().accept_anonymous_chat
         
         
         # 存储被查询人的信息

--- a/templates/showChats.html
+++ b/templates/showChats.html
@@ -390,12 +390,12 @@
         }
         // 记录当前打开的tab
         if ($(".nav-tabs .nav-item .nav-link").eq(0).hasClass("active")){
-            sessionStorage.setItem("openTab", 0);
-            sessionStorage.setItem("openTabName", "sent");
+            sessionStorage.setItem("showChatsOpenTab", 0);
+            sessionStorage.setItem("showChatsOpenTabName", "sent");
         }
         else {
-            sessionStorage.setItem("openTab", 1);
-            sessionStorage.setItem("openTabName", "received");
+            sessionStorage.setItem("showChatsOpenTab", 1);
+            sessionStorage.setItem("showChatsOpenTabName", "received");
         }
     }
 
@@ -408,8 +408,8 @@
         
         // 恢复刷新前的tab
         $(".nav-tabs .nav-item .nav-link").eq(
-            sessionStorage.getItem("openTab")).addClass("active").parent().siblings().children().removeClass("active");
-        $("#"+sessionStorage.getItem("openTabName")).addClass("show active").siblings().removeClass("show active");
+            sessionStorage.getItem("showChatsOpenTab")).addClass("active").parent().siblings().children().removeClass("active");
+        $("#"+sessionStorage.getItem("showChatsOpenTabName")).addClass("show active").siblings().removeClass("show active");
 
         if (reloading == "chatRelatedReloading") { // 刷新是js提交导致的
             sessionStorage.removeItem("reloading"); // 清除掉，这样以后普通的页面刷新不会进这个if

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -16,14 +16,8 @@
         margin: 2px 0px 6px !important;
     }
 
-    label.check-anonymous span.anonymous-warning {
-        /* 禁用匿名提问时checkbox旁的提示语 */
-        display: none;
-    }
-    label.check-anonymous:hover span.anonymous-warning{
-        /* 禁用匿名提问时checkbox旁的提示语 */
-        display: block;
-        color: red;
+    .tooltip-inner {
+        max-width: 500px;
     }
 </style>
 
@@ -535,8 +529,9 @@
                                                                     {% if html_display.accept_anonymous %}
                                                                     <input type="checkbox" id="comment_anonymous" name="comment_anonymous" style="vertical-align:middle;" />
                                                                     {% else %}
-                                                                    <span class="anonymous-warning" style="vertical-align:middle;" >对方目前不允许匿名提问</span>
-                                                                    <input type="checkbox" disabled style="vertical-align:middle;" />
+                                                                    <a data-toggle="tooltip" data-placement="bottom" title="对方目前不允许匿名提问">
+                                                                        <input type="checkbox" id="comment_anonymous" name="comment_anonymous" disabled style="vertical-align:middle;" />
+                                                                    </a>
                                                                     {% endif %}
                                                                     <span style="vertical-align:middle;" >匿名提问&emsp;</span>
                                                                 </label>

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -15,6 +15,16 @@
         vertical-align: middle !important;
         margin: 2px 0px 6px !important;
     }
+
+    label.check-anonymous span.anonymous-warning {
+        /* 禁用匿名提问时checkbox旁的提示语 */
+        display: none;
+    }
+    label.check-anonymous:hover span.anonymous-warning{
+        /* 禁用匿名提问时checkbox旁的提示语 */
+        display: block;
+        color: red;
+    }
 </style>
 
 <div id="content" class="main-content pb-3" style="overflow: hidden;">
@@ -442,10 +452,17 @@
                                                     <table class="table table-bordered mb-4">
                                                         <div>
                                                             <div class="form-group">
+                                                                {% if html_display.anonymous_chat and not html_display.accept_anonymous %}
+                                                                <textarea type="text" id="comment" name="comment"
+                                                                        class="form-control"
+                                                                        aria-label="Default" rows="3"
+                                                                        placeholder="回答者目前不接收匿名提问哦" disabled></textarea>
+                                                                {% else %}
                                                                 <textarea type="text" id="comment" name="comment"
                                                                         class="form-control"
                                                                         aria-label="Default" rows="3"
                                                                         placeholder="添加回复或追问追答"></textarea>
+                                                                {% endif %}
                                                                 
                                                             </div>
                                                             <div class="d-flex justify-content-between">
@@ -514,8 +531,13 @@
                                                                 
                                                             </div>
                                                             <div class="" style="text-align: right;">
-                                                                <label>
+                                                                <label {% if not html_display.accept_anonymous %} class="check-anonymous" {% endif %}>  
+                                                                    {% if html_display.accept_anonymous %}
                                                                     <input type="checkbox" id="comment_anonymous" name="comment_anonymous" style="vertical-align:middle;" />
+                                                                    {% else %}
+                                                                    <span class="anonymous-warning" style="vertical-align:middle;" >对方目前不允许匿名提问</span>
+                                                                    <input type="checkbox" disabled style="vertical-align:middle;" />
+                                                                    {% endif %}
                                                                     <span style="vertical-align:middle;" >匿名提问&emsp;</span>
                                                                 </label>
                                                                 <button type="submit"
@@ -1092,20 +1114,20 @@
         }
         // 记录当前打开的tab
         if ($(".nav-tabs .nav-item .nav-link").eq(0).hasClass("active")){
-            sessionStorage.setItem("openTab", 0);
-            sessionStorage.setItem("openTabName", "information");
+            sessionStorage.setItem("stuinfoOpenTab", 0);
+            sessionStorage.setItem("stuinfoOpenTabName", "information");
         }
         else if ($(".nav-tabs .nav-item .nav-link").eq(1).hasClass("active")){
-            sessionStorage.setItem("openTab", 1);
-            sessionStorage.setItem("openTabName", "academic_map");
+            sessionStorage.setItem("stuinfoOpenTab", 1);
+            sessionStorage.setItem("stuinfoOpenTabName", "academic_map");
         }
         else if ($(".nav-tabs .nav-item .nav-link").eq(2).hasClass("active")){
-            sessionStorage.setItem("openTab", 2);
-            sessionStorage.setItem("openTabName", "organization");
+            sessionStorage.setItem("stuinfoOpenTab", 2);
+            sessionStorage.setItem("stuinfoOpenTabName", "organization");
         }
         else {
-            sessionStorage.setItem("openTab", 3);
-            sessionStorage.setItem("openTabName", "activity");
+            sessionStorage.setItem("stuinfoOpenTab", 3);
+            sessionStorage.setItem("stuinfoOpenTabName", "activity");
         }
     }
 
@@ -1119,8 +1141,8 @@
         // 恢复刷新前的tab
         if (window.location.href.indexOf("#tab=") == -1){
             $(".nav-tabs .nav-item .nav-link").eq(
-                sessionStorage.getItem("openTab")).addClass("active").parent().siblings().children().removeClass("active");
-            $("#"+sessionStorage.getItem("openTabName")).addClass("show active").siblings().removeClass("show active");
+                sessionStorage.getItem("stuinfoOpenTab")).addClass("active").parent().siblings().children().removeClass("active");
+            $("#"+sessionStorage.getItem("stuinfoOpenTabName")).addClass("show active").siblings().removeClass("show active");
         }
         else { // 从学术地图问答中心、问答详情等页面跳转过来时，url末尾为#tab=xxx，通过下面的函数直接打开相应的tab并去掉#tab=xxx，这样之后点到别的tab的时候可以正常刷新
             var type = window.location.href.split("#tab=")[1];

--- a/templates/viewChat.html
+++ b/templates/viewChat.html
@@ -175,10 +175,17 @@
                                             <table class="table table-bordered mb-4">
                                                 <div>
                                                     <div class="form-group">
+                                                        {% if anonymous_chat and not accept_anonymous %}
+                                                        <textarea type="text" id="comment" name="comment"
+                                                                class="form-control"
+                                                                aria-label="Default" rows="3"
+                                                                placeholder="回答者目前不接收匿名提问哦" disabled></textarea>
+                                                        {% else %}
                                                         <textarea type="text" id="comment" name="comment"
                                                                 class="form-control"
                                                                 aria-label="Default" rows="3"
                                                                 placeholder="添加回复或追问追答"></textarea>
+                                                        {% endif %}
                                                         
                                                     </div>
                                                     <div class="d-flex justify-content-between">


### PR DESCRIPTION
1.academic_utils.py的comments2Display函数补充前端量"anonymous_chat"，"accept_anonymous"；在问答中心页面通过这两个量判断能否匿名创建问答/能否匿名追问，如不能，相应的checkbox或textarea变为disabled并给出提示语；问答详情页面类似
示意图如下：
（红字是鼠标悬浮在“匿名提问”或checkbox上时出现的）
![aa9b3cc417a3258b8bb5d77cec37bf8](https://user-images.githubusercontent.com/60976065/186142734-4d193fc7-2506-440f-be2f-931d00c46de0.jpg)
![f2ba3912454fdbe463a49747a591154](https://user-images.githubusercontent.com/60976065/186142763-f8916462-8482-46c1-b6fe-45176c20c7a0.jpg)
![4487369ce125af8ea0ef9ad47542ba6](https://user-images.githubusercontent.com/60976065/186142781-7872abf8-6856-426e-8f0d-666e1ae01f3d.jpg)
![a6e5e7d43bf78c4acbba82492dccf04](https://user-images.githubusercontent.com/60976065/186142811-f905b94c-721f-4556-8275-2c6b10a75cee.jpg)

2.问答中心、个人主页这两个页面都设置了刷新后打开刷新前所在tab的功能，原来两个页面在sessionStorage中记录tab信息时用的变量名是相同的，从而load一个界面时采用的可能是另一个界面unload前记录的tab信息，导致出现问题。目前两边使用不同的变量名，应该没问题了。