### PR TITLE
移除临时预约flag，使用记录数据

### DIFF
--- a/Appointment/admin.py
+++ b/Appointment/admin.py
@@ -237,8 +237,6 @@ class AppointAdmin(admin.ModelAdmin):
         }
         color_code = status2color[obj.Astatus]
         status = obj.get_status()
-        # if obj.Atemp_flag == Appoint.Bool_flag.Yes:
-        #     status = '临时:' + status
         return format_html(
             '<span style="color: {};">{}</span>',
             color_code,

--- a/Appointment/models.py
+++ b/Appointment/models.py
@@ -102,7 +102,7 @@ class Room(models.Model):
 
     # 房间编号我不确定是否需要。如果地下室有门牌的话（例如B101）保留房间编号比较好
     # 如果删除Rid记得把Rtitle设置成主键
-    Rid = models.CharField('房间编号', max_length=8, primary_key=True)
+    Rid: str = models.CharField('房间编号', max_length=8, primary_key=True)
     Rtitle = models.CharField('房间名称', max_length=32)
     Rmin = models.IntegerField('房间预约人数下限', default=0)
     Rmax = models.IntegerField('房间使用人数上限', default=20)
@@ -219,11 +219,6 @@ class Appoint(models.Model):
 
     Atype: 'int|Type' = models.SmallIntegerField(
         '预约类型', choices=Type.choices, default=Type.NORMAL)
-
-    # TODO: remove temp_flag
-    # --- add by lhw --- #
-    Atemp_flag = models.SmallIntegerField('临时预约标识', default=0)
-    # --- end(2021.7.13) --- ##
 
     objects: AppointManager = AppointManager()
 

--- a/Appointment/utils/web_func.py
+++ b/Appointment/utils/web_func.py
@@ -31,7 +31,7 @@ def adjust_qualifiy_rate(original_rate: float, appoint: Appoint) -> float:
     if appoint.Room.Rid in {'B109A', 'B207'}:   # 公共区域
         return 0
     elif appoint.Room.Rid.startswith('R'):      # 俄文楼
-        rate = 0
+        return 0
     elif appoint.Room.Rid == 'B214':            # 暂时无法识别躺姿
         rate -= 0.15                # 建议在0.1-0.2之间 前者最严 后者最宽松
     elif appoint.Room.Rid == 'B107B':           # 无法监控摄像头正下方
@@ -41,7 +41,7 @@ def adjust_qualifiy_rate(original_rate: float, appoint: Appoint) -> float:
             rate -= 0.05            # 建议在0-0.1之间 因为主要是识别出的人数问题
 
     MIN31 = timedelta(minutes=31)
-    if appoint.Atemp_flag:                      # 临时预约不检查摄像头
+    if appoint.Atype == Appoint.Type.TEMPORARY: # 临时预约不检查摄像头
         return 0
     if appoint.Atype == Appoint.Type.LONGTERM:  # 长期预约不检查摄像头
         return 0

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -177,7 +177,7 @@ def cameracheck(request):   # 摄像头post的后端函数
         if content.Atime.date() == content.Astart.date():
             # 如果预约时间在使用时间的24h之内 则人数下限为2
             num_need = min(GLOBAL_INFO.today_min, num_need)
-        if content.Atemp_flag:
+        if content.Atype == Appoint.Type.TEMPORARY:
             # 如果为临时预约 则人数下限为1 不作为合格标准 只是记录
             num_need = min(GLOBAL_INFO.temporary_min, num_need)
         try:
@@ -684,9 +684,8 @@ def door_check(request):  # 先以Sid Rid作为参数，看之后怎么改
                     'non_yp_num': 0,
                     'Ausage': "临时预约",
                     'announcement': "",
-                    'Atemp_flag': True
                 }
-                response = scheduler_func.addAppoint(contents, Atype=Appoint.Type.TEMPORARY)
+                response = scheduler_func.addAppoint(contents, type=Appoint.Type.TEMPORARY)
 
                 if response.status_code == 200:  # 临时预约成功
                     cardcheckinfo_writer(


### PR DESCRIPTION
- 创建预约时的所需人数逻辑更加清楚，将所需人数记入预约中
- 摄像头检查时不再当场计算，而是使用记录的所需人数
- 临时预约flag全面转化为type判断