### PR TITLE
学术地图审核页面前后端

### DIFF
--- a/app/academic_utils.py
+++ b/app/academic_utils.py
@@ -15,7 +15,7 @@ from app.comment_utils import showComment
 from django.http import HttpRequest
 from django.db.models import QuerySet
 
-from typing import List, Dict
+from typing import List, Dict, Set
 from collections import defaultdict
 
 __all__ = [
@@ -29,6 +29,7 @@ __all__ = [
     'update_tag_entry',
     'update_text_entry',
     'update_academic_map',
+    'get_wait_audit_student',
 ]
 
 
@@ -472,3 +473,24 @@ def update_academic_map(request: HttpRequest) -> dict:
         request.user.save()
     
     return succeed("学术地图修改成功！")
+
+
+def get_wait_audit_student() -> Set[NaturalPerson]:
+    """
+    获取当前审核中的AcademicEntry对应的学生，因为要去重，所以返回一个集合
+
+    :return: 当前审核中的AcademicEntry对应的NaturalPerson组成的集合
+    :rtype: Set[NaturalPerson]
+    """
+    wait_audit_tag_entries = AcademicTagEntry.objects.filter(
+        status=AcademicEntry.EntryStatus.WAIT_AUDIT)
+    wait_audit_text_entries = AcademicTextEntry.objects.filter(
+        status=AcademicEntry.EntryStatus.WAIT_AUDIT)
+    
+    wait_audit_students = set()
+    for entry in wait_audit_tag_entries:
+        wait_audit_students.add(entry.person)
+    for entry in wait_audit_text_entries:
+        wait_audit_students.add(entry.person)
+    
+    return wait_audit_students

--- a/app/test/test_audit_academic.py
+++ b/app/test/test_audit_academic.py
@@ -1,0 +1,178 @@
+from django.test import TestCase
+from app.models import (
+    User,
+    NaturalPerson,
+    AcademicTag,
+    AcademicEntry,
+    AcademicTagEntry,
+    AcademicTextEntry,                        
+)
+from app.academic_utils import get_wait_audit_student
+
+
+class GetWaitAuditStudentsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        u1 = User.objects.create_user("11", "1", password="111")
+        u2 = User.objects.create_user("22", "2", password="222")
+        u3 = User.objects.create_user("33", "1", password="333")
+        u4 = User.objects.create_user("44", "1", password="333")
+        u5 = User.objects.create_user("55", "1", password="333")
+        
+        NaturalPerson.objects.create(person_id=u1, name="1", stu_grade="2018")
+        NaturalPerson.objects.create(person_id=u2, name="2", stu_grade="2018")
+        NaturalPerson.objects.create(person_id=u3, name="3", stu_grade="2019")
+        NaturalPerson.objects.create(person_id=u4, name="4", stu_grade="2020")
+        NaturalPerson.objects.create(person_id=u5, name="5", stu_grade="2021")
+
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MAJOR, tag_content="数学")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MAJOR, tag_content="物理")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MAJOR, tag_content="中文")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MINOR, tag_content="数学")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MINOR, tag_content="物理")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.MINOR, tag_content="中文")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, tag_content="数学")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, tag_content="物理")
+        AcademicTag.objects.create(atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, tag_content="中文")
+        
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MAJOR, 
+                tag_content="数学",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MINOR, 
+                tag_content="中文",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.WAIT_AUDIT,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MAJOR, 
+                tag_content="物理",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.WAIT_AUDIT,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, 
+                tag_content="数学",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MAJOR, 
+                tag_content="中文",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MINOR,
+                tag_content="物理",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="4"),
+            status=AcademicEntry.EntryStatus.WAIT_AUDIT,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MINOR,
+                tag_content="物理",
+        ))
+        AcademicTagEntry.objects.create(
+            person=NaturalPerson.objects.get(name="5"),
+            status=AcademicEntry.EntryStatus.OUTDATE,
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.MINOR,
+                tag_content="物理",
+        ))
+        
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.WAIT_AUDIT,
+            atype=AcademicTextEntry.AcademicTextType.INTERNSHIP,
+            content="数学物理方法qwq",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="1"),
+            status=AcademicEntry.EntryStatus.OUTDATE,
+            atype=AcademicTextEntry.AcademicTextType.SCIENTIFIC_RESEARCH,
+            content="浩浩中文，卷帙浩繁。",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            atype=AcademicTextEntry.AcademicTextType.SCIENTIFIC_RESEARCH,
+            content="数学分析123456789",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="2"),
+            status=AcademicEntry.EntryStatus.WAIT_AUDIT,
+            atype=AcademicTextEntry.AcademicTextType.SCIENTIFIC_RESEARCH,
+            content="物理物理物理物理物理11111111的",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PRIVATE,
+            atype=AcademicTextEntry.AcademicTextType.INTERNSHIP,
+            content="中文实习",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="3"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            atype=AcademicTextEntry.AcademicTextType.CHALLENGE_CUP,
+            content="离散数学的原理是非常美妙的",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="4"),
+            status=AcademicEntry.EntryStatus.PUBLIC,
+            atype=AcademicTextEntry.AcademicTextType.CHALLENGE_CUP,
+            content="离散数学的原理是非常美妙的",
+        )
+        AcademicTextEntry.objects.create(
+            person=NaturalPerson.objects.get(name="5"),
+            status=AcademicEntry.EntryStatus.WAIT_AUDIT,
+            atype=AcademicTextEntry.AcademicTextType.CHALLENGE_CUP,
+            content="离散数学的原理是非常美妙的",
+        )
+
+
+    def test_models(self):
+        self.assertEqual(len(NaturalPerson.objects.all().values()), 5)
+        self.assertEqual(len(AcademicTag.objects.all().values()), 9)
+        self.assertEqual(len(AcademicTagEntry.objects.all().values()), 8)
+        self.assertEqual(len(AcademicTextEntry.objects.all().values()), 8)
+
+    def test_result(self):
+        result = get_wait_audit_student()
+        self.assertEqual(len(result), 4)
+        id_set = set([person.get_user().id for person in result])
+        self.assertEqual(id_set, set([1, 2, 4, 5]))
+
+    def test_result_after_status_change(self):
+        entry1 = AcademicTextEntry.objects.select_for_update().get(content="数学物理方法qwq")
+        entry1.status = AcademicEntry.EntryStatus.PUBLIC
+        entry1.save()
+        entry2 = AcademicTagEntry.objects.select_for_update().get(
+            tag=AcademicTag.objects.get(
+                atype=AcademicTag.AcademicTagType.DOUBLE_DEGREE, 
+                tag_content="数学"
+            )
+        )
+        entry2.status = AcademicEntry.EntryStatus.PUBLIC
+        entry2.save()
+        entry3 = AcademicTextEntry.objects.select_for_update().get(
+            content="离散数学的原理是非常美妙的",
+            person=NaturalPerson.objects.get(name="3"))
+        entry3.status = AcademicEntry.EntryStatus.OUTDATE
+        entry3.save()
+
+        result = get_wait_audit_student()
+        self.assertEqual(len(result), 3)
+        id_set = set([person.get_user().id for person in result])
+        self.assertEqual(id_set, set([2, 4, 5]))

--- a/app/urls.py
+++ b/app/urls.py
@@ -109,6 +109,7 @@ urlpatterns = [
     path("modifyAcademic/", academic_views.modifyAcademic, name="modifyAcademic"),
     path("AcademicQA/", academic_views.showChats, name="showChats"),
     path("viewQA/<str:chat_id>", academic_views.viewChat, name="viewChat"),
+    path("auditAcademic/", academic_views.auditAcademic, name="auditAcademic"),
 ] + [
     # 问答相关
     path("addChatComment/", chat_api.addChatComment, name="addChatComment"),

--- a/templates/audit_academic.html
+++ b/templates/audit_academic.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+
+
+{% block mainpage %}
+
+
+<!--  BEGIN CONTENT AREA  -->
+<div id="content" class="main-content">
+    <!--  BEGIN WARN_MESSAGE  -->
+    {% if warn_code == 1 %}
+    <div class="alert alert-warning  text-center">{{ warn_message }}</div>
+    {% elif warn_code == 2 %}
+    <div class="alert alert-success  text-center">{{ warn_message }}</div>
+    {% endif %}
+    <!--  END WARN_MESSAGE  -->
+        
+    <div class="container">
+        <div class="row layout-top-spacing">
+
+            {% if bar_display.help_paragraphs %}
+                {% include 'help.html' %}
+            {% endif %}
+
+            <div class="col-lg-12 col-12 layout-top-spacing"  style="text-align:center">
+                <div class="bio layout-spacing ">
+                    <div class="widget-content widget-content-area">
+                        <div class="d-flex justify-content-between">
+                            <h3>待审核的学术地图</h3>
+                        </div>
+
+                        <div class="widget-content widget-content-area">
+                            <div class="table-responsive">
+                                <table class="table table-bordered mb-4">
+                                    {% if student_list|length != 0 %}
+                                    <thead></thead>
+                                    <tbody>
+                                        {% for person in student_list %}
+                                        <tr class="w-100">
+                                            <td style="min-width: 100px;">
+                                                <u>
+                                                    <a href="{{ person.get_absolute_url }}#tab=academic_map">
+                                                        <img src="{{ person.get_user_ava }}" alt="大头照" style="width: 20px; height: 20px;">{{ person.name }}
+                                                    </a>
+                                                </u>
+                                            </td>
+                                            <td style="min-width: 100px;">
+                                                <u>
+                                                    <a href="{{ person.get_absolute_url }}#tab=academic_map">
+                                                        <button type="button" class="btn btn-primary" >
+                                                            点击查看
+                                                        </button>
+                                                    </a>
+                                                </u>
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                    {% else %}
+                                    <thead></thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>没有待审核的学术地图~</td>
+                                        </tr>
+                                    </tbody>
+                                    {% endif %}
+                                </table>
+                            </div>
+                        </div>    
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<!--  END CONTENT AREA  -->
+
+
+{% endblock %}

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -1170,7 +1170,17 @@
                     updated_href = updated_href.replace("#tab=information?", "");
                 else updated_href = updated_href.replace("#tab=information", "");
             }
-            window.location.href = updated_href;
+            // 接下来需要把url改为updated_href，即去掉#tab=xxx的部分
+            // 相较于直接window.location.href = updated_href，下面的写法更好一些，
+            //      因为修改href会导致页面自动刷新，也即再调用一次window.onload这个函数，从而可能会看到页面在“个人信息”tab和目标tab之间来回跳转两次
+            //      而改history的这种方法不会导致页面再次刷新
+            // 参考https://stackoverflow.com/a/3503206
+            if (window.history.replaceState){
+                window.history.replaceState(null, '', updated_href);
+            }
+            else {
+                window.location.href = updated_href;
+            }
         }
 
         if (reloading == "chatRelatedReloading") { // 表明是发送comment/关闭chat/新建chat等js返回后调用的reload

--- a/templates/user_left_navbar.html
+++ b/templates/user_left_navbar.html
@@ -211,6 +211,22 @@
             </li>
             {% endif %}
 
+            {% if bar_display.person_type == 0 %}
+            <li class="menu">
+                <a href="/auditAcademic/" aria-expanded="false" class="dropdown-toggle">
+                    <div class="">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"></polygon>
+                            <line x1="8" y1="2" x2="8" y2="18"></line>
+                            <line x1="16" y1="6" x2="16" y2="22"></line>
+                        </svg>
+                        <span>学术地图审核</span>
+                    </div>
+                </a>
+            </li>
+            {% endif %}
+
             {% if request.session.Incharge %}
             <li class="menu">
                 <a href="#dashboard2" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">


### PR DESCRIPTION
## 学术地图审核页面
### 1.后端
academic_views.py新增auditAcademic，首先检查身份为教师，随后调用academic_utils.py的get_wait_audit_student获取所有有待审核的AcademicTagEntry/AcademicTextEntry的NaturalPerson集合；urls.py增加/auditAcademic/
非教师身份进入会跳转回首页并显示“只有教师账号可进入学术地图审核页面!”
![e09bd3234c00ef39f380c85161766bb](https://user-images.githubusercontent.com/60976065/187016946-c79974ea-6761-4919-a821-75bb21e1d780.jpg)

### 2.前端
新增audit_academic.html，如下图
![477f6d381e6ce608780c3e80f4d1bdc](https://user-images.githubusercontent.com/60976065/187016405-6222d4dc-6b61-4cb2-a646-4396d57ee985.jpg)
![3ed618d27149384237f5fbdf8894ca1](https://user-images.githubusercontent.com/60976065/187016412-82ca7e19-8ecd-4796-babc-c103ef9c5bcf.jpg)
![2a622c0d23046bd36ba7a2a3d10c22b](https://user-images.githubusercontent.com/60976065/187016417-cac01657-0263-4891-8f62-350a0e18c501.jpg)
![ddd5fe64e2c2174432a1698cceb8572](https://user-images.githubusercontent.com/60976065/187016420-1b40a309-ec05-40ce-bba4-4f9f87406d55.jpg)
点击姓名或右侧按钮均可跳转到其个人主页并打开学术地图tab
另外还顺便对stuinfo.html做了一点点优化，原来进入主页后会读取url中的tab=xxx、打开对应tab、修改window.location.href以删除url中的tab=xxx，而修改window.location.href会导致页面刷新，因而可能看到页面在“个人信息”tab和“学术地图”tab之间反复横跳两次；现在改为用window.history.replaceState修改url，不会自动刷新，避免了上述问题。

### 3.测试
现在在网页测试审核页面不太方便，我写了一个test简单验证了一下工具函数get_wait_audit_student的输出
