### PR TITLE
修改学术地图相关的若干bug

### DIFF
--- a/app/academic_views.py
+++ b/app/academic_views.py
@@ -259,7 +259,7 @@ def auditAcademic(request: HttpRequest) -> HttpResponse:
     """
     # 身份检查
     person = get_person_or_org(request.user)
-    if not person.is_teacher():
+    if not (person.get_type() == UTYPE_PER and person.is_teacher()):
         return redirect(message_url(wrong('只有教师账号可进入学术地图审核页面!')))
 
     frontend_dict = {}
@@ -273,7 +273,7 @@ def auditAcademic(request: HttpRequest) -> HttpResponse:
 @utils.check_user_access(redirect_url="/logout/")
 @log.except_captured(EXCEPT_REDIRECT, source='academic_views[applyAuditAcademic]', record_user=True)
 def applyAuditAcademic(request: HttpRequest):
-    if not NaturalPerson.objects.get_by_user(HttpRequest.user).is_teacher():
+    if not NaturalPerson.objects.get_by_user(request.user).is_teacher():
         return JsonResponse(wrong("只有老师才能执行审核操作！"))
     try:
         author = NaturalPerson.objects.get(person_id_id=request.POST.get("author_id"))

--- a/app/views.py
+++ b/app/views.py
@@ -575,7 +575,7 @@ def stuinfo(request: HttpRequest, name=None):
         status_in = None
         if is_myself:
             academic_params["user_type"] = "author"
-        elif oneself.is_teacher():
+        elif user_type == UTYPE_PER and oneself.is_teacher():
             academic_params["user_type"] = "inspector"
             status_in = ['public', 'wait_audit']
         else:

--- a/templates/stuinfo.html
+++ b/templates/stuinfo.html
@@ -814,164 +814,160 @@
                     
                         {% if html_display.have_progressing_chat %}
                         <!--  BEGIN PROGRESSING CHAT  -->
-                        <div class="col-lg-12 col-sm-12 col-12 layout-spacing">
-                            <div class="bio layout-spacing ">
-                                <div class="widget-content widget-content-area">
-                                    <!--  BEGIN CHAT TITLE  -->
-                                    <div class="d-flex justify-content-between">
-                                        <h3 class="noafter">
-                                            {% if html_display.my_name == "匿名用户" %}
-                                            我[匿名]发给{{html_display.respondent_name}}的问答：{{html_display.title}}&emsp;
-                                            {% else %}
-                                            我发给{{html_display.respondent_name}}的问答：{{html_display.title}}&emsp;
-                                            {% endif %}
-                                            
-                                            <span class="badge badge-primary followh3noafter">进行中</span><br />
-                                        </h3>
-                                    </div>
-                                    <!--  END CHAT TITLE  -->
-        
-                                    <!--  BEGIN CHAT CONTENT  -->
-                                    <div class="row">
-                                        <div class="col-md-12 mb-4">
-                                            <div class="statbox widget box box-shadow">
-                                                <div class="widget-content widget-content-area">
-                                                    <table class="table table-bordered mb-4">
-                                                    {% if html_display.messages|length != 0 %}
-                                                        {% for comment in html_display.messages %}
-                                                        <div class="form-group">
-                                                            <div class="d-flex justify-content-between">
-                                                                <!--  BEGIN MY MESSAGE HEAD -->
-                                                                {% if html_display.my_name == comment.commentator.name %}
-                                                                <div>
-                                                                    <p style="color: rgb(66, 67, 68);">
-                                                                        <i class="fa fa-calendar-o"></i>{{ comment.time }}</p>
-                                                                </div>
-                                                                <div align="right">
-                                                                    <img src={{ comment.commentator.avatar }} width="24" height="24" alt="avatar">
-                                                                        {% if comment.commentator.URL %}
-                                                                        <a href='{{ comment.commentator.URL }}#tab=academic_map'>
-                                                                            <u>{{ comment.commentator.name }}</u>
-                                                                        </a>
-                                                                        {% else %}
-                                                                        {{ comment.commentator.name }}
-                                                                        {% endif %}
-                                                                </div>
-                                                                <!--  END MY MESSAGE HEAD -->
-                                                                
-                                                                <!--  BEGIN OTHERS MESSAGE HEAD -->
-                                                                {% else %}
-                                                                <div>
-                                                                    <img src={{ comment.commentator.avatar }} width="24" height="24" alt="avatar">
-                                                                        {% if comment.commentator.URL %}
-                                                                        <a href='{{ comment.commentator.URL }}#tab=academic_map'>
-                                                                            <u>{{ comment.commentator.name }}</u>
-                                                                        </a>
-                                                                        {% else %}
-                                                                        {{ comment.commentator.name }}
-                                                                        {% endif %}
-                                                                </div>
-                                                                <div align="right">
-                                                                    <p style="color: rgb(66, 67, 68);">
-                                                                        <i class="fa fa-calendar-o"></i>{{ comment.time }}</p>
-                                                                </div>
-                                                                <!--  END OTHERS MESSAGE HEAD -->
-                                                                {% endif %}
-                                                            </div>
-                                                            <!--  BEGIN MESSAGE CONTENT -->
-                                                            {% if comment.text %}
-                                                                {% if comment.commentator.name == html_display.my_name %}
-                                                                <textarea name="comment" class="form-control no-gray" 
-                                                                        disabled="disabled" rows="3" style="background-color:rgb(255, 255, 255) !important;color: black;">{{ comment.text }}</textarea>
-                                                                        <!-- 颜色待调整 -->
-                                                                {% else %}
-                                                                <textarea name="comment" class="form-control no-gray"
-                                                                        disabled="disabled" rows="3" style="background-color:rgb(255, 255, 255) !important;color: black;">{{ comment.text }}</textarea>
-                                                                        <!-- 颜色待调整 -->
-                                                                {% endif %}
-                                                            {% endif %}
-                                                            {% if comment.photos %}
-                                                                {% if comment.text %}<br>{% endif %}
-                                                                <div style="max-height:1000px;overflow:auto;">
-                                                                {% for image in comment.photos %}
-                                                                <img src={{ html_display.image.get_image_path }} >
-                                                                {% endfor %}
-                                                                </div>
-                                                            {% endif %}
-                                                            <!--  END MESSAGE CONTENT -->
-                                                            <hr>
-                                                        </div>
-                                                        {% endfor %}
-                                                        
-                                                    {% else %}
-                                                        <thead></thead>
-                                                        <tbody>
-                                                            <tr>
-                                                                <td>{{ html_display.not_found_message }}</td>
-                                                            </tr>
-                                                        </tbody>
-                                                    {% endif %}
-                                                    </table>
-                                                    
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <!--  END CHAT CONTENT  -->
-        
-                                    <!--  BEGIN REPLY AREA  -->
-                                    {% if html_display.commentable %}
-                                    <div class="row">
-                                        <div class="col-md-12 mb-4">
-                                            <div class="statbox widget box box-shadow">
-                                                <div class="widget-content widget-content-area">
-                                                    <table class="table table-bordered mb-4">
-                                                        <div>
-                                                            <div class="form-group">
-                                                                {% if html_display.anonymous_chat and not html_display.accept_anonymous %}
-                                                                <textarea type="text" id="comment" name="comment"
-                                                                        class="form-control"
-                                                                        aria-label="Default" rows="3"
-                                                                        placeholder="回答者目前不接收匿名提问哦" disabled></textarea>
-                                                                {% else %}
-                                                                <textarea type="text" id="comment" name="comment"
-                                                                        class="form-control"
-                                                                        aria-label="Default" rows="3"
-                                                                        placeholder="添加回复或追问追答"></textarea>
-                                                                {% endif %}
-                                                                
-                                                            </div>
-                                                            <div class="d-flex justify-content-between">
-                                                                <div>
-                                                                </div>
-                                                                <div class="" style="text-align: right;">
-                                                                        <button type="submit"
-                                                                                class="btn btn-primary"
-                                                                                name="comment_submit" 
-                                                                                id="comment_submit"
-                                                                                value="{{html_display.chat_id}}"
-                                                                                onclick="add_chat_comment(this);">
-                                                                            回复
-                                                                        </button>
-                                                                        <button type="submit"
-                                                                                class="btn btn-danger"
-                                                                                name="close" id="close"
-                                                                                value="{{html_display.chat_id}}"
-                                                                                onclick="close_chat(this);">
-                                                                            关闭当前问答
-                                                                        </button>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </table>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
+                        <div class="widget-content widget-content-area my-3">
+                            <!--  BEGIN CHAT TITLE  -->
+                            <div class="d-flex justify-content-between">
+                                <h3 class="noafter">
+                                    {% if html_display.my_name == "匿名用户" %}
+                                    我[匿名]发给{{html_display.respondent_name}}的问答：{{html_display.title}}&emsp;
+                                    {% else %}
+                                    我发给{{html_display.respondent_name}}的问答：{{html_display.title}}&emsp;
                                     {% endif %}
-                                    <!--  END REPLY AREA  -->
+                                    
+                                    <span class="badge badge-primary followh3noafter">进行中</span><br />
+                                </h3>
+                            </div>
+                            <!--  END CHAT TITLE  -->
+
+                            <!--  BEGIN CHAT CONTENT  -->
+                            <div class="row">
+                                <div class="col-md-12 mb-4">
+                                    <div class="statbox widget box box-shadow">
+                                        <div class="widget-content widget-content-area">
+                                            <table class="table table-bordered mb-4">
+                                            {% if html_display.messages|length != 0 %}
+                                                {% for comment in html_display.messages %}
+                                                <div class="form-group">
+                                                    <div class="d-flex justify-content-between">
+                                                        <!--  BEGIN MY MESSAGE HEAD -->
+                                                        {% if html_display.my_name == comment.commentator.name %}
+                                                        <div>
+                                                            <p style="color: rgb(66, 67, 68);">
+                                                                <i class="fa fa-calendar-o"></i>{{ comment.time }}</p>
+                                                        </div>
+                                                        <div align="right">
+                                                            <img src={{ comment.commentator.avatar }} width="24" height="24" alt="avatar">
+                                                                {% if comment.commentator.URL %}
+                                                                <a href='{{ comment.commentator.URL }}#tab=academic_map'>
+                                                                    <u>{{ comment.commentator.name }}</u>
+                                                                </a>
+                                                                {% else %}
+                                                                {{ comment.commentator.name }}
+                                                                {% endif %}
+                                                        </div>
+                                                        <!--  END MY MESSAGE HEAD -->
+                                                        
+                                                        <!--  BEGIN OTHERS MESSAGE HEAD -->
+                                                        {% else %}
+                                                        <div>
+                                                            <img src={{ comment.commentator.avatar }} width="24" height="24" alt="avatar">
+                                                                {% if comment.commentator.URL %}
+                                                                <a href='{{ comment.commentator.URL }}#tab=academic_map'>
+                                                                    <u>{{ comment.commentator.name }}</u>
+                                                                </a>
+                                                                {% else %}
+                                                                {{ comment.commentator.name }}
+                                                                {% endif %}
+                                                        </div>
+                                                        <div align="right">
+                                                            <p style="color: rgb(66, 67, 68);">
+                                                                <i class="fa fa-calendar-o"></i>{{ comment.time }}</p>
+                                                        </div>
+                                                        <!--  END OTHERS MESSAGE HEAD -->
+                                                        {% endif %}
+                                                    </div>
+                                                    <!--  BEGIN MESSAGE CONTENT -->
+                                                    {% if comment.text %}
+                                                        {% if comment.commentator.name == html_display.my_name %}
+                                                        <textarea name="comment" class="form-control no-gray" 
+                                                                disabled="disabled" rows="3" style="background-color:rgb(255, 255, 255) !important;color: black;">{{ comment.text }}</textarea>
+                                                                <!-- 颜色待调整 -->
+                                                        {% else %}
+                                                        <textarea name="comment" class="form-control no-gray"
+                                                                disabled="disabled" rows="3" style="background-color:rgb(255, 255, 255) !important;color: black;">{{ comment.text }}</textarea>
+                                                                <!-- 颜色待调整 -->
+                                                        {% endif %}
+                                                    {% endif %}
+                                                    {% if comment.photos %}
+                                                        {% if comment.text %}<br>{% endif %}
+                                                        <div style="max-height:1000px;overflow:auto;">
+                                                        {% for image in comment.photos %}
+                                                        <img src={{ html_display.image.get_image_path }} >
+                                                        {% endfor %}
+                                                        </div>
+                                                    {% endif %}
+                                                    <!--  END MESSAGE CONTENT -->
+                                                    <hr>
+                                                </div>
+                                                {% endfor %}
+                                                
+                                            {% else %}
+                                                <thead></thead>
+                                                <tbody>
+                                                    <tr>
+                                                        <td>{{ html_display.not_found_message }}</td>
+                                                    </tr>
+                                                </tbody>
+                                            {% endif %}
+                                            </table>
+                                            
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
+                            <!--  END CHAT CONTENT  -->
+
+                            <!--  BEGIN REPLY AREA  -->
+                            {% if html_display.commentable %}
+                            <div class="row">
+                                <div class="col-md-12 mb-4">
+                                    <div class="statbox widget box box-shadow">
+                                        <div class="widget-content widget-content-area">
+                                            <table class="table table-bordered mb-4">
+                                                <div>
+                                                    <div class="form-group">
+                                                        {% if html_display.anonymous_chat and not html_display.accept_anonymous %}
+                                                        <textarea type="text" id="comment" name="comment"
+                                                                class="form-control"
+                                                                aria-label="Default" rows="3"
+                                                                placeholder="回答者目前不接收匿名提问哦" disabled></textarea>
+                                                        {% else %}
+                                                        <textarea type="text" id="comment" name="comment"
+                                                                class="form-control"
+                                                                aria-label="Default" rows="3"
+                                                                placeholder="添加回复或追问追答"></textarea>
+                                                        {% endif %}
+                                                        
+                                                    </div>
+                                                    <div class="d-flex justify-content-between">
+                                                        <div>
+                                                        </div>
+                                                        <div class="" style="text-align: right;">
+                                                                <button type="submit"
+                                                                        class="btn btn-primary"
+                                                                        name="comment_submit" 
+                                                                        id="comment_submit"
+                                                                        value="{{html_display.chat_id}}"
+                                                                        onclick="add_chat_comment(this);">
+                                                                    回复
+                                                                </button>
+                                                                <button type="submit"
+                                                                        class="btn btn-danger"
+                                                                        name="close" id="close"
+                                                                        value="{{html_display.chat_id}}"
+                                                                        onclick="close_chat(this);">
+                                                                    关闭当前问答
+                                                                </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {% endif %}
+                            <!--  END REPLY AREA  -->
                         </div>
                         <!--  END PROGRESSING CHAT  -->
                         {% elif html_display.accept_chat %}
@@ -1019,7 +1015,7 @@
                                                                 </label>
                                                                 <button type="submit"
                                                                         class="btn btn-primary"
-                                                                        name="comment_submit" value="{{person.id}}"
+                                                                        name="comment_submit" value="{{person.person_id.id}}"
                                                                         onclick="start_chat(this)"> <!-- 因为创建问答要复用comment_utils.py，这里必须叫“comment_submit”  -->
                                                                     提问
                                                                 </button>

--- a/templates/user_left_navbar.html
+++ b/templates/user_left_navbar.html
@@ -114,7 +114,36 @@
                 </a>
             </li>
             -->
-
+            {% if bar_display.person_type == 1 %}
+            <li class="menu">
+                <a href="#dashboard2" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">
+                    <div class="">
+                        <!-- repeat -->
+                        <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2"
+                            fill="none" stroke-linecap="round" stroke-linejoin="round" class="css-i6dzq1">
+                            <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"></polygon>
+                            <line x1="8" y1="2" x2="8" y2="18"></line>
+                            <line x1="16" y1="6" x2="16" y2="22"></line>
+                        </svg> <span>学术地图</span>
+                    </div>
+                    <div>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            class="feather feather-chevron-right">
+                            <polyline points="9 18 15 12 9 6"></polyline>
+                        </svg>
+                    </div>
+                </a>
+                <ul class="collapse submenu list-unstyled" id="dashboard2" data-parent="#accordionExample">
+                    <li>
+                        <a href="{{bar_display.profile_url}}#tab=academic_map">编辑学术地图</a>
+                    </li>
+                    <li>
+                        <a href="/AcademicQA/">学术地图问答</a>
+                    </li>
+                </ul>
+            </li>
+            {% endif %}
 
             {% if bar_display.person_type == 0 %}
             <li class="menu">


### PR DESCRIPTION
1.stuinfo.html提问按钮获取传user.id处把person.id改为person.person_id.id
2.academic_views.py的applyAuditAcademic函数HttpRequest.user改为request.user
3.academic_views.py和views.py的检查teacher前补充检查用户类型为person
4.增设学生个人账号学术地图侧边栏，两个下拉条目分别跳转stuinfo的academic_map tab和AcademicQA
![733cd9127325ae4179d34881834e957](https://user-images.githubusercontent.com/60976065/187472018-1341c8ff-f723-46a5-b515-7271babd3fee.jpg)
5.美化了一下stuinfo的academic_map tab前端
![13c6cdfd0a6c262a80abe3d93112cf8](https://user-images.githubusercontent.com/60976065/187471957-3e34f3ad-8183-4fa6-885d-e290c4edef15.jpg)
