### PR TITLE
修复学术地图侧边栏bug

### DIFF
--- a/templates/user_left_navbar.html
+++ b/templates/user_left_navbar.html
@@ -116,7 +116,7 @@
             -->
             {% if bar_display.person_type == 1 %}
             <li class="menu">
-                <a href="#dashboard2" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">
+                <a href="#dashboard4" data-toggle="collapse" aria-expanded="false" class="dropdown-toggle">
                     <div class="">
                         <!-- repeat -->
                         <svg viewBox="0 0 24 24" width="24" height="24" stroke="currentColor" stroke-width="2"
@@ -134,7 +134,7 @@
                         </svg>
                     </div>
                 </a>
-                <ul class="collapse submenu list-unstyled" id="dashboard2" data-parent="#accordionExample">
+                <ul class="collapse submenu list-unstyled" id="dashboard4" data-parent="#accordionExample">
                     <li>
                         <a href="{{bar_display.profile_url}}#tab=academic_map">编辑学术地图</a>
                     </li>


### PR DESCRIPTION
原来直接复制了下面的一段代码，忘记改collapse submenu的id和menu的href了，目前已修改
![9216e5f1ede97a43ad8955f265af8fe](https://user-images.githubusercontent.com/60976065/187674101-a602a5d5-fc9a-4c87-845d-eb38a1bdbbd5.jpg)
