### PR TITLE
恢复上传活动总结图片功能

### DIFF
--- a/templates/activity_info.html
+++ b/templates/activity_info.html
@@ -414,7 +414,7 @@
                                     {% endif %}
                                     <!-- ---------------------------- begin summary ---------------------------- -->
                                     {% if status == "已结束" %}
-                                    <!--<button class="btn btn-primary btn-block mb-2" data-toggle="collapse"
+                                    <button class="btn btn-primary btn-block mb-2" data-toggle="collapse"
                                         data-target="#summaryphoto">
                                         上传/更新总结照片
                                     </button>
@@ -432,10 +432,6 @@
                                             <input type="hidden" name="option" value="submitphoto">
                                             <button type="submit" class="btn btn-primary btn-block mb-2">确认上传</button>
                                         </div>
-                                    </form>-->
-                                    <form method="POST">
-                                        <input type="hidden" name="option" value="payment">
-                                        <button class="btn btn-primary btn-block mb-2">申请活动结项</button>
                                     </form>
                                     {% endif %}
                                     <!-- ----------------------------- end summary ----------------------------- -->
@@ -443,7 +439,7 @@
                                     {% if status == "已结束" %}
                                     <form method="POST">
                                         <input type="hidden" name="option" value="checkinoffline">
-                                        <button class="btn btn-primary btn-block mb-2">调整签到信息</button>>
+                                        <button class="btn btn-primary btn-block mb-2">调整签到信息</button>
                                     </form>
                                     {% endif %}
                                    <!-- --------------------------end checkinoffline--------------------------- -->


### PR DESCRIPTION
复用了一些旧的注释了的代码


<img width="1497" alt="截屏2022-09-05 10 17 31" src="https://user-images.githubusercontent.com/97432569/188348613-20aa45d5-c83a-4889-93f8-e9ce23541454.png">
<img width="1512" alt="截屏2022-09-05 10 17 41" src="https://user-images.githubusercontent.com/97432569/188348626-b7003e31-72cf-4dee-b880-fc2ce754c057.png">
<img width="1512" alt="截屏2022-09-05 10 17 51" src="https://user-images.githubusercontent.com/97432569/188348627-73091824-0aff-401e-b66e-84de84e68062.png">
