### PR TITLE
与元气值后端相关的一些优化

### DIFF
--- a/app/YQPoint_utils.py
+++ b/app/YQPoint_utils.py
@@ -97,7 +97,8 @@ def get_pools_and_items(pool_type: Pool.Type, user: User, frontend_dict: Dict[st
         ))
         for item in this_pool_items:
             item["remain_num"] = item["origin_num"] - item["consumed_num"]
-        this_pool_info["items"] = this_pool_items
+        this_pool_info["items"] = sorted(
+            this_pool_items, key=lambda x: -x["remain_num"]) # 按剩余数量降序排序，已卖完的在最后
 
         if pool_type != Pool.Type.EXCHANGE:
             this_pool_info["my_entry_time"] = PoolRecord.objects.filter(

--- a/app/YQPoint_views.py
+++ b/app/YQPoint_views.py
@@ -148,5 +148,5 @@ def showPools(request: HttpRequest) -> HttpResponse:
 
 
     frontend_dict["bar_display"] = get_sidebar_and_navbar(
-        request.user, "元气值兑换与抽奖")
+        request.user, "元气值商城")
     return render(request, "showPools.html", frontend_dict)

--- a/app/constants.py
+++ b/app/constants.py
@@ -14,7 +14,7 @@ constants.py
 # 本文件是最基础的依赖文件，应当只加入跨架构的必要常量，而不导入其他文件
 # 与使用环境有关的内容应在对应文件中定义
 
-from boottest import base_get_setting
+from boottest import base_get_setting, optional
 from boottest import (
     # settings相关常量
     DEBUG, MEDIA_URL, LOGIN_URL,
@@ -90,7 +90,7 @@ YQP_ONAME: str = get_setting('YQPoint_source_oname')
 COURSE_TYPENAME: str = get_config('course/type_name', default='书院课程')
 LEAST_RECORD_HOURS: float = get_config('course/valid_hours', float, default=8.0)
 YQP_PER_HOUR: float = get_config('thresholds/point/per_hour', float, default=10)
-YQP_ACTIVITY_MAX: 'int|None' = get_config('thresholds/point/limit', int, default=None)
+YQP_ACTIVITY_MAX: 'int|None' = get_config('thresholds/point/limit', optional(int), default=30)
 YQP_INVALID_HOUR: float = get_config('thresholds/point/invalid_hour', float, default=12)
 YQP_INVALID_TITLES: list = get_config('thresholds/point/invalid_titles', default=[])
 YQP_PER_FEEDBACK: int = get_config('thresholds/point/per_feedback', int, default=10)

--- a/app/constants.py
+++ b/app/constants.py
@@ -89,7 +89,7 @@ YQP_ONAME: str = get_setting('YQPoint_source_oname')
 # 本应用的可选设置，每个都应该给出默认值
 COURSE_TYPENAME: str = get_config('course/type_name', default='书院课程')
 LEAST_RECORD_HOURS: float = get_config('course/valid_hours', float, default=8.0)
-YQP_PER_HOUR: float = get_config('thresholds/point/per_hour', float, default=1)
+YQP_PER_HOUR: float = get_config('thresholds/point/per_hour', float, default=10)
 YQP_ACTIVITY_MAX: 'int|None' = get_config('thresholds/point/limit', int, default=None)
 YQP_INVALID_HOUR: float = get_config('thresholds/point/invalid_hour', float, default=12)
 YQP_INVALID_TITLES: list = get_config('thresholds/point/invalid_titles', default=[])

--- a/app/models.py
+++ b/app/models.py
@@ -1941,6 +1941,9 @@ class Prize(models.Model):
     reference_price = models.IntegerField('参考价格')
     image = models.ImageField('图片', upload_to=f'prize/%Y-%m/', null=True, blank=True)
 
+    def __str__(self):
+        return self.name
+
 
 class Pool(models.Model):
     class Meta:
@@ -1964,6 +1967,9 @@ class Pool(models.Model):
     redeem_start = models.DateTimeField('兑奖开始时间', null=True, blank=True) # 指线下获取奖品实物
     redeem_end = models.DateTimeField('兑奖结束时间', null=True, blank=True)
 
+    def __str__(self):
+        return self.title
+
 
 class PoolItem(models.Model):
     class Meta:
@@ -1981,6 +1987,9 @@ class PoolItem(models.Model):
     is_big_prize: bool = models.BooleanField('是否特别奖品', default=False)
     # 下面这个在盲盒奖池中有效，若为真则表示“谢谢参与”
     is_empty: bool = models.BooleanField('空盲盒', default=False)
+
+    def __str__(self):
+        return f'{self.pool} {self.prize}'
 
 
 class PoolRecord(models.Model):

--- a/app/models.py
+++ b/app/models.py
@@ -1941,6 +1941,7 @@ class Prize(models.Model):
     reference_price = models.IntegerField('参考价格')
     image = models.ImageField('图片', upload_to=f'prize/%Y-%m/', null=True, blank=True)
 
+    @invalid_for_frontend
     def __str__(self):
         return self.name
 
@@ -1967,6 +1968,7 @@ class Pool(models.Model):
     redeem_start = models.DateTimeField('兑奖开始时间', null=True, blank=True) # 指线下获取奖品实物
     redeem_end = models.DateTimeField('兑奖结束时间', null=True, blank=True)
 
+    @invalid_for_frontend
     def __str__(self):
         return self.title
 
@@ -1988,6 +1990,7 @@ class PoolItem(models.Model):
     # 下面这个在盲盒奖池中有效，若为真则表示“谢谢参与”
     is_empty: bool = models.BooleanField('空盲盒', default=False)
 
+    @invalid_for_frontend
     def __str__(self):
         return f'{self.pool} {self.prize}'
 

--- a/boottest/__init__.py
+++ b/boottest/__init__.py
@@ -61,6 +61,15 @@ def base_get_setting(path: str='', trans_func=None, default=None,
         return default
 
 
+def optional(type):
+    '''产生用于可选设置的转换函数，None被直接返回'''
+    def _trans_func(value):
+        if value is None:
+            return None
+        return type(value)
+    return _trans_func
+
+
 # 全局设置
 # 加载settings.xxx时会加载文件
 DEBUG: bool = settings.DEBUG

--- a/local_json_template.json
+++ b/local_json_template.json
@@ -44,8 +44,8 @@
         "注释": "下面这些都可以不写",
         "point": {
             "per_feedback": 10,
-            "per_hour": 1,
-            "limit": null,
+            "per_hour": 10,
+            "limit": 30,
             "invalid_hour": 12,
             "invalid_titles": [
                 "选课",

--- a/templates/myPrize.html
+++ b/templates/myPrize.html
@@ -12,6 +12,9 @@
         {% endif %}
         <div class="container">
             <div class="layout-top-spacing">
+                {% if bar_display.help_paragraphs %}
+                    {% include 'help.html' %}
+                {% endif %}
                 <div class="col-12 layout-top-spacing">
                     <div class="bio layout-spacing ">
                         <div class="widget-content widget-content-area">

--- a/templates/showPools.html
+++ b/templates/showPools.html
@@ -150,6 +150,10 @@
         {% elif warn_code == 2 %}
             <div class="alert alert-success text-center m-3">{{ warn_message }}</div>
         {% endif %}
+
+        {% if bar_display.help_paragraphs %}
+            {% include 'help.html' %}
+        {% endif %}
         <div class="container">
             <div class="layout-top-spacing">
                 <ul class="nav nav-pills nav-fill row mb-3" id="myTab" role="tablist">


### PR DESCRIPTION
1.每个奖池中的奖品按剩余数量降序排序，已卖完的在最后，例如
![4269445c59fd4dbbf2fa1e3438a13dc](https://user-images.githubusercontent.com/60976065/191481653-bceb419b-6f28-4a21-bf14-d302309f664f.jpg)

2.奖池页面更名为“元气值商城”，和其他地方保持一致
3.一些零碎修改，如constants.py中YQP_PER_HOUR的default设为10，几个奖品相关的模型加str属性
4.我的奖品和元气值商城页面前端导入help.html。目前与元气值相关的三个页面均有“使用帮助”，如下图
![6ca70621055d841498d85bf7b92f2d9](https://user-images.githubusercontent.com/60976065/191480967-91993dcc-ebd1-4d09-ba24-e077d6ac73b8.jpg)
![5a8a6edab80c62bc85a19e1d43e3e39](https://user-images.githubusercontent.com/60976065/191481100-918f9df0-e8c7-404f-a157-dec1eaf56d28.jpg)
![4f462202aed28f32e135f28a28c5ac9](https://user-images.githubusercontent.com/60976065/191480995-981dbcd9-4442-41e3-bb96-89c867d2113d.jpg)
另外，这三处帮助信息也已导入后台数据库

*元气值文档中还有一句比较概括性的“_元气值是YPPF的交易系统，用于奖励活跃用户。个人用户可通过签到、活动参与、公开反馈等方式获取元气值，并可在元气值商城兑换奖品。_”这句话需要加进去吗？该放在哪里呢？

*原定要给兑换奖池加上总的可兑换次数，但是感觉不是很有必要，因为每个奖品都有标注剩余数量、点开详情也能看到用户自己的剩余可兑换次数，把这些加起来对用户而言应该意义不大
