### PR TITLE
实现了空盲盒元气值补偿功能

### DIFF
--- a/app/YQPoint_utils.py
+++ b/app/YQPoint_utils.py
@@ -499,6 +499,8 @@ def buy_random_pool(user: User, pool_id: str) -> Tuple[MESSAGECONTEXT, int, int]
             if modify_item.is_empty:
                 compensate_YQPoint = random.randint(
                     pool.empty_YQPoint_compensation_lowerbound, pool.empty_YQPoint_compensation_upperbound)
+                if compensate_YQPoint == 0:
+                    return succeed(f'兑换盲盒成功!您抽到了空盒子，但是很遗憾这次没有元气值补偿QAQ'), -1, 1
                 User.objects.modify_YQPoint(
                     user,
                     compensate_YQPoint,

--- a/app/YQPoint_utils.py
+++ b/app/YQPoint_utils.py
@@ -495,6 +495,17 @@ def buy_random_pool(user: User, pool_id: str) -> Tuple[MESSAGECONTEXT, int, int]
                 source=f'盲盒奖池：{pool.title}',
                 source_type=YQPointRecord.SourceType.CONSUMPTION
             )
+            # 如果抽到了空盒子，按照设定值对用户给予元气值补偿并返回相应的提示
+            if modify_item.is_empty:
+                compensate_YQPoint = random.randint(
+                    pool.empty_YQPoint_compensation_lowerbound, pool.empty_YQPoint_compensation_upperbound)
+                User.objects.modify_YQPoint(
+                    user,
+                    compensate_YQPoint,
+                    source=f'盲盒奖池：{pool.title}空盒子补偿',
+                    source_type=YQPointRecord.SourceType.COMPENSATION
+                )
+                return succeed(f'兑换盲盒成功!您抽到了空盒子，获得{compensate_YQPoint}点元气值补偿!'), -1, 1
             if modify_item.prize is None:
                 return succeed('兑换盲盒成功!'), -1, 1
             return succeed('兑换盲盒成功!'), modify_item.prize.id, int(modify_item.is_empty)

--- a/app/models.py
+++ b/app/models.py
@@ -1801,6 +1801,7 @@ class Prize(models.Model):
     def __str__(self):
         return self.name
 
+
 class Pool(models.Model):
     class Meta:
         verbose_name = '5.奖池'

--- a/app/models.py
+++ b/app/models.py
@@ -1801,7 +1801,6 @@ class Prize(models.Model):
     def __str__(self):
         return self.name
 
-
 class Pool(models.Model):
     class Meta:
         verbose_name = '5.奖池'
@@ -1819,6 +1818,10 @@ class Pool(models.Model):
     # 类型为兑换池时无效
     entry_time = models.IntegerField('进入次数', default=1)
     ticket_price = models.IntegerField('抽奖费', default=0)
+    empty_YQPoint_compensation_lowerbound = models.IntegerField(
+        '空盒元气值补偿下限', default=0)
+    empty_YQPoint_compensation_upperbound = models.IntegerField(
+        '空盒元气值补偿上限', default=0)
     start = models.DateTimeField('开始时间')
     end = models.DateTimeField('结束时间', null=True, blank=True)
     redeem_start = models.DateTimeField(
@@ -1853,10 +1856,11 @@ class PoolItem(models.Model):
     exchange_price = models.IntegerField('价格', null=True, blank=True)
     # 下面这个在抽奖/盲盒奖池中有效
     is_big_prize = models.BooleanField('是否特别奖品', default=False)
+    is_empty_prize = models.BooleanField('是否空盒', default=False)
 
     @property
     def is_empty(self) -> bool:
-        return self.prize is None
+        return self.is_empty_prize or (self.prize is None)
 
     @invalid_for_frontend
     def __str__(self):

--- a/generic/models.py
+++ b/generic/models.py
@@ -453,6 +453,7 @@ class YQPointRecord(models.Model):
         ACHIEVE = (4, '达成成就')
         QUESTIONNAIRE = (5, '填写问卷')
         CONSUMPTION = (6, '奖池花费')
+        COMPENSATION = (7, '奖池补偿')
 
     source_type = models.SmallIntegerField(
         '来源类型', choices=SourceType.choices, default=SourceType.SYSTEM)


### PR DESCRIPTION
1. 抽到空盲盒时，对用户进行元气值补偿（在设定好的下限到上限的闭区间内随机抽取），并返回相应的提示
2. 将元气值补偿的上限和下限（整型）添加到奖池属性中
3. 添加了”奖池补偿“作为新的元气值来源
4. 将是否为空盒（布尔型）添加到奖池奖品的属性中