### PR TITLE
修了一下在某些管理界面搜索时出现的500错误

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -779,15 +779,14 @@ class AcademicEntryAdmin(admin.ModelAdmin):
 @admin.register(AcademicTagEntry)
 class AcademicTagEntryAdmin(AcademicEntryAdmin):
     list_display = ["person", "status", "tag"]
-    search_fields =  ("person", "status", "tag")
+    search_fields =  ("person__name", "tag__tag_content")
     list_filter = ["tag__atype", "status"]
 
 
 @admin.register(AcademicTextEntry)
 class AcademicTextEntryAdmin(AcademicEntryAdmin):
     list_display = ["person", "status", "atype", "content"]
-    # todo: django.core.exceptions.FieldError: Related Field got invalid lookup: icontains
-    search_fields =  ("person", "status", "atype", "content")
+    search_fields =  ("person__name", "content")
     list_filter = ["atype", "status"]
 
 

--- a/dormitory/admin.py
+++ b/dormitory/admin.py
@@ -12,5 +12,5 @@ class DormitoryAgreementAdmin(admin.ModelAdmin):
 @admin.register(DormitoryAssignment)
 class DormitoryAssignmentAdmin(admin.ModelAdmin):
     list_display = ['dormitory', 'user', 'bed_id', 'time']
-    list_filter = ['bed_id', 'time']
-    search_fields = ['dormitory', *UserAdmin.suggest_search_fields('user'), 'time']
+    list_filter = ['bed_id', 'dormitory__gender', 'time']
+    search_fields = ['dormitory__id', *UserAdmin.suggest_search_fields('user'), 'time']

--- a/feedback/admin.py
+++ b/feedback/admin.py
@@ -15,4 +15,4 @@ class FeedbackAdmin(admin.ModelAdmin):
 @admin.register(FeedbackType)
 class FeedbackTypeAdmin(admin.ModelAdmin):
     list_display = ["name", "org_type", "org",]
-    search_fields = ("name", "org_type", "org",)
+    search_fields = ("name", "org_type__otype_name", "org__oname",)


### PR DESCRIPTION
发现竟然是历史遗留问题。似乎是写的时候把 `ForeignKey` 当做搜索条件，但是没有注意到 `ForeignKey` 上并不能直接调用 `icontains`，所以指定用各个 `ForeignKey` 的 `name` 作为搜索条件，解决了这个问题。

顺便把一些搜索放到筛选里面去了，因为只有有限的几个值，似乎筛选更加合理。

Before:

![image](https://github.com/Yuanpei-Intelligence/YPPF/assets/44802910/b24e006e-66c4-4983-92a0-eef31fe4028a)

After:

![image](https://github.com/Yuanpei-Intelligence/YPPF/assets/44802910/b32bac75-a1c5-4e66-8c07-0ca43ed58cbe)
