### PR TITLE
在书院课退选课、小组状态更改界面检查用户是否激活

### DIFF
--- a/app/course_views.py
+++ b/app/course_views.py
@@ -468,6 +468,10 @@ def selectCourse(request: HttpRequest):
             wrong("非学生账号不能进行选课！", html_display)
             return redirect(message_url(html_display, request.path))
 
+        if not request.user.active:
+            wrong("您已毕业，不能进行选课或退课操作！", html_display)
+            return redirect(message_url(html_display, request.path))
+
         # 参数: 课程id，操作action: select/cancel
         try:
             course_id = request.POST.get('courseid')

--- a/app/org_views.py
+++ b/app/org_views.py
@@ -283,6 +283,9 @@ def modifyPosition(request: UserRequest):
     html_display = {}
     me = get_person_or_org(request.user)  # 获取自身
 
+    if not request.user.active:
+        return redirect(message_url(wrong("您的账号处于未激活状态，不能发起成员申请，如有需要请联系管理员！")))
+
     # 前端使用量user_type，表示观察者是小组还是个人
 
     # ———————————————— 读取可能存在的申请 为POST和GET做准备 ————————————————

--- a/app/org_views.py
+++ b/app/org_views.py
@@ -72,6 +72,9 @@ def modifyOrganization(request: UserRequest):
     if request.user.is_org():
         return redirect(message_url(wrong("请不要使用小组账号申请新小组！")))
 
+    if not request.user.active:
+        return redirect(message_url(wrong("您已毕业，无法更改小组信息！")))
+
     # ———————————————— 读取可能存在的申请 为POST和GET做准备 ————————————————
 
     # 设置application为None, 如果非None则自动覆盖

--- a/app/utils.py
+++ b/app/utils.py
@@ -211,6 +211,7 @@ def get_sidebar_and_navbar(user: User, navbar_name="", title_name=""):
     bar_display["user_type"] = _utype
     if user.is_staff:
         bar_display["is_staff"] = True
+    bar_display["user_active"] = user.active
 
     # 接下来填补各种前端呈现信息
 

--- a/templates/user_left_navbar.html
+++ b/templates/user_left_navbar.html
@@ -24,6 +24,7 @@
                     </div>
                 </a>
             </li>
+            {% if bar_display.user_active %}
             <li class="menu">
                 <a href="{{bar_display.underground_url}}" aria-expanded="false" class="dropdown-toggle">
                     <div class="">
@@ -39,6 +40,7 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
             <li class="menu">
                 <a href="/feedback/" aria-expanded="false" class="dropdown-toggle">
                     <div class="">
@@ -80,9 +82,11 @@
                     <li>
                         <a href="{% url 'myPrize' %}">我的奖品</a>
                     </li>
+                    {% if bar_display.user_active %}
                     <li>
                         <a href="{% url 'showPools' %}">元气值商城</a>
                     </li>
+                    {% endif %}
                 </ul>
             </li>
             <li class="menu">
@@ -97,6 +101,7 @@
                     </div>
                 </a>
             </li>
+            {% if bar_display.user_active %}
             <li class="menu">
                 <a href="/selectCourse/" aria-expanded="false" class="dropdown-toggle">
                     <div class="">
@@ -109,6 +114,7 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
             <!--
             <li class="menu">
                 <a href="/stuinfo/#organization" aria-expanded="false" class="dropdown-toggle">
@@ -214,6 +220,7 @@
                 </a>
             </li>
 
+            {% if bar_display.user_active %}
             <li class="menu">
                 <a href="/showNewOrganization/" aria-expanded="false" class="dropdown-toggle">
                     <div class="">
@@ -230,6 +237,7 @@
                     </div>
                 </a>
             </li>
+            {% endif %}
             <li class="menu">
                 <a href="/yplibrary/" aria-expanded="false" class="dropdown-toggle">
                     <div class="">


### PR DESCRIPTION
元气值商城、地下室预约中不允许已毕业用户使用的问题已在PR #806 中实现。
这个 PR 中加入了书院课退课、选课按钮，小组状态更改（现在似乎只有新建小组？）时检查用户是否已经毕业，如果已经毕业，会在页面上方显示一条错误信息，如下图所示：

<img width="1280" alt="新建小组效果图" src="https://github.com/user-attachments/assets/5ab5333a-5db5-4278-9f42-408ec3655680">

<img width="1262" alt="选课效果图" src="https://github.com/user-attachments/assets/0758cc07-f2ad-4540-9141-a219c43e568b">
