### PR TITLE
在生活习惯调研后面加上年份以示区别；问卷页面用next_semester确定应该显示哪一份问卷

### DIFF
--- a/dormitory/admin.py
+++ b/dormitory/admin.py
@@ -14,4 +14,4 @@ class DormitoryAgreementAdmin(admin.ModelAdmin):
 class DormitoryAssignmentAdmin(admin.ModelAdmin):
     list_display = ['dormitory', 'user', 'bed_id', 'time']
     list_filter = ['bed_id', 'time']
-    search_fields = ['dormitory', *UserAdmin.suggest_search_fields('user'), 'time']
+    search_fields = ['dormitory__id', *UserAdmin.suggest_search_fields('user'), 'time']

--- a/dormitory/management/commands/create_dormitory_questionnaire_2023.py
+++ b/dormitory/management/commands/create_dormitory_questionnaire_2023.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # 创建一个survey
         survey = Survey.objects.create(
-            title = "宿舍生活习惯调研",
+            title = "宿舍生活习惯调研-2023",
             description = "根据问卷情况对宿舍进行分配",
             status = Survey.Status.PUBLISHED, # 传参
             creator_id = 1, # 传参

--- a/dormitory/management/commands/create_dormitory_questionnaire_2024.py
+++ b/dormitory/management/commands/create_dormitory_questionnaire_2024.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # 创建一个survey
         survey = Survey.objects.create(
-            title = "宿舍生活习惯调研",
+            title = "宿舍生活习惯调研-2024",
             description = "根据问卷情况对宿舍进行分配",
             status = Survey.Status.PUBLISHED, # 传参
             creator_id = 1, # 传参

--- a/dormitory/views.py
+++ b/dormitory/views.py
@@ -11,6 +11,7 @@ from dormitory.serializers import (
     DormitoryAssignmentSerializer, DormitorySerializer,
     AgreementSerializerFixme, AgreementSerializer)
 from questionnaire.models import AnswerSheet, AnswerText, Survey
+from semester.api import next_semester
 
 
 class DormitoryViewSet(viewsets.ReadOnlyModelViewSet):
@@ -47,7 +48,7 @@ class DormitoryRoutineQAView(ProfileTemplateView):
     need_prepare = False
 
     def get_survey(self):
-        return Survey.objects.get(title='宿舍生活习惯调研')
+        return Survey.objects.get(title=f'宿舍生活习惯调研-{next_semester().year}')
 
     def get(self):
         survey = self.get_survey()

--- a/dormitory/views.py
+++ b/dormitory/views.py
@@ -99,14 +99,14 @@ class DormitoryAssignResultView(ProfileTemplateView):
             roommates = [NaturalPerson.objects.get_by_user(assign.user)
                          for assign in dorm_assignment.exclude(user=user)]
             self.extra_context.update(
-                dorm_assign=True,
+                dorm_assigned=True,
                 name=user.get_full_name(),
                 dorm_id=assignment.dormitory.id,
                 bed_id=assignment.bed_id,
                 roommates=roommates,
             )
         except DormitoryAssignment.DoesNotExist:
-            self.extra_context.update(dorm_assign=False)
+            self.extra_context.update(dorm_assigned=False)
 
 class AgreementView(ProfileTemplateView):
     template_name = 'dormitory/agreement.html'


### PR DESCRIPTION
执行修改后的create_questionnaire脚本之后，不同年份的问卷的标题会有所不同，如下所示：
![image](https://github.com/user-attachments/assets/000decac-c889-4e9d-823c-ab9fb6e61050)

同时，在 生活习惯调研 问卷界面会根据`next_semester().year`来选择合适的问卷。