### PR TITLE
Admin export

### DIFF
--- a/Appointment/models.py
+++ b/Appointment/models.py
@@ -91,6 +91,9 @@ class Participant(models.Model):
             return self.name
         return self.name + '_' + acronym
 
+    def natural_key(self):
+        return self.name
+
 
 class RoomQuerySet(models.QuerySet['Room']):
     def permitted(self):
@@ -190,6 +193,9 @@ class Room(models.Model):
 
     def __str__(self):
         return self.Rid + ' ' + self.Rtitle
+
+    def natural_key(self):
+        return self.Rid
 
 
 class AppointQuerySet(models.QuerySet['Appoint']):
@@ -369,6 +375,9 @@ class Appoint(models.Model, metaclass=PermissionModelBase):
         }
         return data
 
+    def natural_key(self):
+        return self.Aid
+
 
 class CardCheckInfo(models.Model):
     # 这里Room使用外键的话只能设置DO_NOTHING，否则删除房间就会丢失预约信息
@@ -517,6 +526,9 @@ class LongTermAppoint(models.Model):
     def get_applicant_id(self) -> str:
         '''获取申请者id'''
         return self.applicant.get_id()
+
+    def natural_key(self):
+        return self.appoint
 
 
 @receiver(pre_delete, sender=Appoint)

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,10 +1,14 @@
 from datetime import datetime
+from io import BytesIO
+import json
 
+from django.core import serializers
 from django.contrib import admin
 from django.db.models import QuerySet
 from django.utils.safestring import mark_safe
+from pandas import DataFrame
 
-from utils.http.dependency import HttpRequest
+from utils.http.dependency import HttpRequest, HttpResponse
 from utils.models.query import sfilter, f
 from utils.admin_utils import *
 from app.models import *
@@ -39,6 +43,33 @@ class CourseParticipantInline(admin.TabularInline):
     ordering = ['-id']
     fields = ['course', 'person', 'status']
     show_change_link = True
+
+
+# 导出为Excel的action
+def export_as_excel(modeladmin: admin.ModelAdmin, request: HttpRequest, queryset: QuerySet) -> HttpResponse:
+    # TODO: Add column selection
+    # Each item in json_list is a JSON string for one object.
+    json_list: list[str] = serializers.serialize(
+        'jsonl', queryset,
+        use_natural_foreign_keys = True,
+        use_natural_primary_keys = True,
+    ).strip().split('\n')
+    # We are not going to recover objects from this representation,
+    # so we only need to keep the "fields" property.
+    df = DataFrame(json.loads(s)['fields'] for s in json_list)
+    # Rename the columns to their corresponding verbose name for better UX
+    rename_dict = {k: getattr(modeladmin.model, k).field.verbose_name for k in df.columns}
+    df = df.rename(columns = rename_dict)
+    # Write to a BytesIO object to avoid creating temporary files
+    excel_file = BytesIO()
+    df.to_excel(excel_file, index = False)
+    return HttpResponse(excel_file.getvalue(), headers = {
+        "Content-Type": "application/vnd.ms-excel",
+        "Content-Disposition": 'attachment; filename="result.xlsx"',
+    })
+
+# Make exporting action available site-wide. See Django docs on "admin action".
+admin.site.add_action(export_as_excel, '导出为Excel文件')
 
 
 # 后台模型

--- a/app/models.py
+++ b/app/models.py
@@ -436,6 +436,9 @@ class NaturalPerson(models.Model):
             assert self.stu_id_dbonly == self.person_id.username, "学号不匹配！"
         super().save(*args, **kwargs)
 
+    def natural_key(self):
+        return self.name
+
 
 Person: TypeAlias = NaturalPerson
 
@@ -463,6 +466,9 @@ class Freshman(models.Model):
         user_exist = User.objects.filter(username=self.sid).exists()
         person_exist = SQ.mfilter(NaturalPerson.person_id, username=self.sid).exists()
         return "person" if person_exist else ("user" if user_exist else "")
+
+    def natural_key(self):
+        return self.name
 
 
 class OrganizationType(models.Model):
@@ -516,6 +522,9 @@ class OrganizationType(models.Model):
         '''供生成时方便调用的函数，是否成为负责人的默认值'''
         return position <= self.control_pos_threshold
 
+    def natural_key(self):
+        return self.otype_name
+
 
 class OrganizationTag(models.Model):
     class Meta:
@@ -538,6 +547,9 @@ class OrganizationTag(models.Model):
     color = models.CharField("颜色", choices=ColorChoice.choices, max_length=10)
 
     def __str__(self):
+        return self.name
+
+    def natural_key(self):
         return self.name
 
 
@@ -613,6 +625,9 @@ class Organization(models.Model):
             return NaturalPerson.objects.activated().exclude(
                 id__in=self.unsubscribers.all()).count()
         return NaturalPerson.objects.all().count() - self.unsubscribers.count()
+
+    def natural_key(self):
+        return self.oname
 
 
 class PositionManager(models.Manager['Position']):
@@ -729,6 +744,9 @@ class Position(models.Model):
 
     def get_pos_number(self):  # 返回对应的pos number 并作超出处理
         return min(len(self.org.otype.job_name_list), self.pos)
+
+    def natural_key(self):
+        return self.person, self.org
 
 
 class ActivityManager(models.Manager['Activity']):
@@ -1066,6 +1084,9 @@ class Activity(CommentBase):
         User.objects.bulk_increase_YQPoint(
             participants, point, "参加活动", YQPointRecord.SourceType.ACTIVITY)
 
+    def natural_key(self):
+        return self.title
+
 
 class ActivityPhoto(models.Model):
     class Meta:
@@ -1288,6 +1309,9 @@ class ModifyOrganization(CommentBase):
     def is_pending(self):  # 表示是不是pending状态
         return self.status == ModifyOrganization.Status.PENDING
 
+    def natural_key(self):
+        return self.oname
+
 
 class ModifyPosition(CommentBase):
     class Meta:
@@ -1380,6 +1404,9 @@ class ModifyPosition(CommentBase):
     def save(self, *args, **kwargs):
         self.typename = "modifyposition"
         super().save(*args, **kwargs)
+
+    def natural_key(self):
+        return self.org, self.person
 
 
 class Help(models.Model):
@@ -1551,6 +1578,9 @@ class Course(models.Model):
 
     def get_QRcode_path(self):
         return image_url(self.QRcode)
+
+    def natural_key(self):
+        return self.name
 
 
 class CourseTime(models.Model):
@@ -1802,6 +1832,9 @@ class Prize(models.Model):
     def __str__(self):
         return self.name
 
+    def natural_key(self):
+        return self.name
+
 
 class Pool(models.Model):
     class Meta:
@@ -1844,6 +1877,9 @@ class Pool(models.Model):
     @invalid_for_frontend
     def get_capacity(self):
         return self.items.aggregate(Sum('origin_num'))['origin_num__sum'] or 0
+
+    def natural_key(self):
+        return self.title
 
 
 class PoolItem(models.Model):

--- a/dormitory/models.py
+++ b/dormitory/models.py
@@ -38,6 +38,9 @@ class Dormitory(models.Model):
     def __str__(self):
         return str(self.id)
 
+    def natural_key(self):
+        return self.id
+
 
 class DormitoryAssignment(models.Model):
     class Meta:

--- a/feedback/models.py
+++ b/feedback/models.py
@@ -37,7 +37,10 @@ class FeedbackType(models.Model):
 
     def __str__(self):
         return self.name
-    
+
+    def natural_key(self):
+        return self.name
+
 
 class Feedback(CommentBase):
     class Meta:
@@ -116,3 +119,6 @@ class Feedback(CommentBase):
         else:
             url = f'/viewFeedback/{self.id}'
         return url
+
+    def natural_key(self):
+        return self.title

--- a/generic/models.py
+++ b/generic/models.py
@@ -406,6 +406,9 @@ class User(AbstractUser, PointMixin, metaclass=UserBase):
     def is_org(self) -> bool:
         return self.utype == self.Type.ORG
 
+    def natural_key(self):
+        return self.name
+
 
 class PermissionBlacklistManager(models.Manager['PermissionBlacklist']):
     '''

--- a/semester/models.py
+++ b/semester/models.py
@@ -14,6 +14,9 @@ class SemesterType(models.Model):
     def __str__(self):
         return self.name
 
+    def natural_key(self):
+        return self.name
+
 
 class Semester(models.Model):
     '''学期
@@ -35,3 +38,6 @@ class Semester(models.Model):
     type = models.ForeignKey(SemesterType, on_delete=models.CASCADE)
     start_date = models.DateField('开学日期')
     end_date = models.DateField('放假日期')
+
+    def natural_key(self):
+        return self.year, self.type

--- a/yp_library/models.py
+++ b/yp_library/models.py
@@ -21,6 +21,9 @@ class Reader(models.Model):
     def __str__(self):
         return self.student_id
 
+    def natural_key(self):
+        return self.student_id
+
 
 class Book(models.Model):
     class Meta:
@@ -39,6 +42,9 @@ class Book(models.Model):
 
     def __str__(self):
         return str(self.title)
+
+    def natural_key(self):
+        return self.title
 
 
 class LendRecord(models.Model):


### PR DESCRIPTION
简易的导出功能。

使用了`django.core.serializers`模块里提供的转化为字符串功能，并将序列化得到的JSON转化为Excel文件，返回给用户。Excel文件中每列的名称来自模型定义中每个field的`verbose_name`.

Django的序列化默认使用主键作为外键的输出。为了提高可读性，利用了Django的natural key功能，让序列化时可以指定外键的表现形式。例如，通过设置奖池`Pool`模型的natural key为奖池名称，在导出奖池记录`PoolRecord`时，其中含有的`Pool` foreign key列将包括奖池名称字符串，而不是对应`Pool`对象的id。本PR中包含了一些类的natural key定义，后续可以根据实际使用情况进行维护。

导出功能在设计时只考虑了“导出”，没有考虑从获得的Excel文件恢复数据库对象，所以**natural key并不一定能唯一确定对象**，没有完全实现Django的要求，这点需要注意。