### PR TITLE
修改了小组信息的标签对应的padding，使其动画效果不再被遮挡

### DIFF
--- a/templates/orginfo.html
+++ b/templates/orginfo.html
@@ -171,7 +171,7 @@
                                     <li class="contacts-block__item">
                                         <!-- 下面的css语句定义一个可滚动的框，其中滚动条隐藏 -->
                                         <style> 
-                                            .MyStyle {margin:0px; padding:0px; display:inline-block; white-space: nowrap; overflow: hidden; overflow-x: scroll; -webkit-backface-visibility: hidden; -webkit-overflow-scrolling: touch; }
+                                            .MyStyle {margin:0px; padding-top:4px; padding-left:0px; display:inline-block; white-space: nowrap; overflow: hidden; overflow-x: scroll; -webkit-backface-visibility: hidden; -webkit-overflow-scrolling: touch; }
                                             .MyStyle::-webkit-scrollbar {width:0; height:0; display:none;}
                                         </style>
                                         <div class="MyStyle">


### PR DESCRIPTION
通过修改padding-top与padding-left，使得标签被鼠标滑过或被触屏点击时向上移动的动画不再会被遮挡
<img width="284" alt="pr" src="https://github.com/user-attachments/assets/8863f5b3-8cc5-4758-9a73-aa74dd557dff" />
