### PR TITLE
#866 添加对单日预约时长和同时段预约的限制，修改前端的提示信息

### DIFF
--- a/Appointment/appoint/manage.py
+++ b/Appointment/appoint/manage.py
@@ -5,7 +5,7 @@ from django.db import transaction
 
 from Appointment.config import appointment_config as CONFIG
 from Appointment.models import Participant, Room, Appoint
-from Appointment.utils.utils import get_conflict_appoints
+from Appointment.utils.utils import get_conflict_appoints, get_total_appoint_time
 from Appointment.utils.log import logger, get_user_logger
 from Appointment.appoint.jobs import set_scheduler, cancel_scheduler
 from Appointment.extern.wechat import MessageType, notify_appoint
@@ -93,6 +93,9 @@ def _check_conflict(appoint: Appoint):
     conflict_appoints = get_conflict_appoints(appoint, lock=True)
     assert len(conflict_appoints) == 0, '预约时间段与已有预约冲突！'
 
+def _check_total_time(appointer: Participant, start: datetime, finish: datetime):
+    total_time = get_total_appoint_time(appointer, start.date(), lock=True)
+    assert total_time + finish - start <= CONFIG.max_appoint_time, '单日预约时长超限！'
 
 def _attend_require_num(room: Room, type: Appoint.Type, start: datetime, finish: datetime) -> int:
     '''实际监控检查要求的人数'''
@@ -163,6 +166,15 @@ def create_appoint(
         _check_create_num(room, type, inner_num, outer_num)
         _check_num_constraint(room, type, inner_num, outer_num)
 
+    # 个人预约需要检查总时长
+    user = appointer.Sid
+    if (
+        user.is_person()
+        and type != Appoint.Type.LONGTERM
+        and type != Appoint.Type.INTERVIEW
+    ):
+        _check_total_time(appointer, start, finish)
+
     _check_credit(appointer)
     appoint = Appoint(
         major_student=appointer, Room=room,
@@ -185,7 +197,6 @@ def create_appoint(
     get_user_logger(appointer).info(f"发起预约，预约号{appoint.pk}")
 
     # 如果预约者是个人，解锁成就-完成地下室预约 该部分尚未测试
-    user = appointer.Sid
     if user.is_person():
         unlock_achievement(user, '完成地下室预约')
 

--- a/Appointment/config.py
+++ b/Appointment/config.py
@@ -2,6 +2,7 @@ from boot.config import ROOT_CONFIG
 from utils.config import Config, LazySetting
 from utils.config.cast import str_to_time
 
+from datetime import timedelta
 
 __all__ = [
     'appointment_config',
@@ -43,6 +44,9 @@ class AppointmentConfig(Config):
     allow_newstu_appoint = True
     # 是否限制开始前的预约取消时间
     restrict_cancel_time = False
-
+    # 单人单日预约总时长上限
+    max_appoint_time = timedelta(hours=6)
+    # 是否允许单人同一时段预约两个房间
+    allow_overlap = False
 
 appointment_config = AppointmentConfig(ROOT_CONFIG, 'underground')

--- a/Appointment/utils/utils.py
+++ b/Appointment/utils/utils.py
@@ -1,9 +1,9 @@
-from datetime import timedelta
+from datetime import timedelta, date, datetime
 
 from django.http import HttpRequest
 from django.db.models import Q, QuerySet
 
-from Appointment.models import Room, Appoint
+from Appointment.models import Room, Appoint, Participant
 
 '''
 YWolfeee:
@@ -103,6 +103,29 @@ def door2room(door):
 def check_temp_appoint(room: Room) -> bool:
     return '研讨' in room.Rtitle
 
+# 获取当日预约总时长，不含长期预约和面试
+def get_total_appoint_time(appointer: Participant, day: date, lock=False) -> timedelta:
+    # 获取当日预约，不含长期预约和面试
+    appoints = appointer.appoint_list.filter(Astart__date=day).exclude(
+        Atype__in=(Appoint.Type.LONGTERM, Appoint.Type.INTERVIEW)
+    )
+    if lock:
+        appoints = appoints.select_for_update()
+    # 计算总时长
+    total_time = timedelta()
+    for appoint in appoints:
+        total_time += appoint.Afinish - appoint.Astart
+    return total_time
+
+# 获取预约者同时进行的预约，不含长期预约和面试
+def get_overlap_appoints(appointer: Participant, start_time: datetime, finish_time: datetime) -> QuerySet[Appoint]:
+    parallel_appoints = appointer.appoint_list.exclude(
+        Atype__in=(Appoint.Type.LONGTERM, Appoint.Type.INTERVIEW)
+    ).exclude(
+        Q(Afinish__lte=start_time) | Q(Astart__gte=finish_time)
+    ).all()
+    return parallel_appoints
+                           
 
 def get_conflict_appoints(appoint: Appoint, times: int = 1,
                           interval: int = 1, week_offset: int = 0,

--- a/Appointment/utils/utils.py
+++ b/Appointment/utils/utils.py
@@ -108,6 +108,8 @@ def get_total_appoint_time(appointer: Participant, day: date, lock=False) -> tim
     # 获取当日预约，不含长期预约和面试
     appoints = appointer.appoint_list.filter(Astart__date=day).exclude(
         Atype__in=(Appoint.Type.LONGTERM, Appoint.Type.INTERVIEW)
+    ).exclude(
+        Astatus=Appoint.Status.CANCELED
     )
     if lock:
         appoints = appoints.select_for_update()
@@ -121,6 +123,8 @@ def get_total_appoint_time(appointer: Participant, day: date, lock=False) -> tim
 def get_overlap_appoints(appointer: Participant, start_time: datetime, finish_time: datetime) -> QuerySet[Appoint]:
     parallel_appoints = appointer.appoint_list.exclude(
         Atype__in=(Appoint.Type.LONGTERM, Appoint.Type.INTERVIEW)
+    ).exclude(
+        Astatus=Appoint.Status.CANCELED
     ).exclude(
         Q(Afinish__lte=start_time) | Q(Astart__gte=finish_time)
     ).all()

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -422,6 +422,7 @@ def arrange_time(request: HttpRequest):
     # 用于前端使用
     allow_overlap = CONFIG.allow_overlap 
     max_appoint_time = int(CONFIG.max_appoint_time.total_seconds() // 3600) # 以小时计算
+    is_person = request.user.is_person()
 
     # 获取房间编号
     Rid = request.GET.get('Rid')

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -23,7 +23,10 @@ from Appointment.models import (
 )
 from Appointment.extern.wechat import MessageType, notify_appoint
 from Appointment.utils.utils import (
-    get_conflict_appoints, to_feedback_url,
+    get_conflict_appoints, 
+    to_feedback_url, 
+    get_total_appoint_time, 
+    get_overlap_appoints
 )
 from Appointment.utils.log import logger, get_user_logger
 import Appointment.utils.web_func as web_func
@@ -416,6 +419,10 @@ def arrange_time(request: HttpRequest):
     # 判断当前用户是否可以进行长期预约
     has_longterm_permission = get_participant(request.user).longterm
 
+    # 用于前端使用
+    allow_overlap = CONFIG.allow_overlap 
+    max_appoint_time = int(CONFIG.max_appoint_time.total_seconds() // 3600) # 以小时计算
+
     # 获取房间编号
     Rid = request.GET.get('Rid')
     try:
@@ -446,6 +453,13 @@ def arrange_time(request: HttpRequest):
 
     dayrange_list, start_day, end_next_day = web_func.get_dayrange(
         day_offset=start_week * 7)
+
+    # 获取每天剩余的可预约时长
+    available_hours = {}
+    for day in [start_day + timedelta(days=i) for i in range(7)]:
+        used_time = get_total_appoint_time(get_participant(request.user), day)
+        available_hour = CONFIG.max_appoint_time - used_time
+        available_hours[day.strftime('%a')] = int(available_hour.total_seconds() // 3600) # 以小时计算
 
     # 获取预约时间的最大时间块id
     max_stamp_id = web_func.get_time_id(room, room.Rfinish, mode="leftopen")
@@ -535,6 +549,7 @@ def arrange_time(request: HttpRequest):
 
     # 转换成方便前端使用的形式
     js_dayrange_list = json.dumps(dayrange_list)
+    js_available_hours = json.dumps(available_hours)
 
     # 获取房间信息，以支持房间切换的功能
     function_room_list = Room.objects.function_rooms().order_by('Rid')
@@ -895,6 +910,26 @@ def checkout_appoint(request: UserRequest):
         # TODO: 隔周预约的处理可优化，根据start_week调整实际预约时间
         start_time += timedelta(weeks=start_week)
         end_time += timedelta(weeks=start_week)
+        
+        # 预约时间检查
+        if (
+            applicant.Sid.is_person()
+            and not is_longterm 
+            and not is_interview
+            and get_total_appoint_time(applicant, start_time.date()) + (end_time - start_time) > CONFIG.max_appoint_time
+        ):
+            wrong('您预约的时长已超过每日最大预约时长', render_context)
+        
+        # 检查预约者是否有同时段的预约
+        if (
+            applicant.Sid.is_person()
+            and not CONFIG.allow_overlap 
+            and not is_longterm 
+            and not is_interview 
+            and get_overlap_appoints(applicant, start_time, end_time).exists()
+        ):
+            wrong(f'您在该时间段已经有预约', render_context)
+        
         if my_messages.get_warning(render_context)[0] is None:
             # 参数检查全部通过，下面开始创建预约
             appoint_type = Appoint.Type.NORMAL

--- a/app/admin.py
+++ b/app/admin.py
@@ -142,7 +142,7 @@ class NaturalPersonAdmin(admin.ModelAdmin):
     @as_action("设置 全部订阅")
     def all_subscribe(self, request, queryset):
         for org in queryset:
-            org.unsubscribers.clear()
+            org.unsubscribe_list.clear()
             org.save()
         return self.message_user(request=request,
                                  message='修改成功!')
@@ -152,7 +152,7 @@ class NaturalPersonAdmin(admin.ModelAdmin):
         orgs = list(Organization.objects.exclude(
             otype__otype_id=0).values_list('id', flat=True))
         for person in queryset:
-            person.unsubscribers.set(orgs)
+            person.unsubscribe_list.set(orgs)
             person.save()
         return self.message_user(request=request,
                                  message='修改成功!已经取消所有非官方组织的订阅!')

--- a/app/views.py
+++ b/app/views.py
@@ -1665,11 +1665,18 @@ def subscribeOrganization(request: UserRequest):
 
     me = get_person_or_org(request.user)
     # orgava_list = [(org, utils.get_user_ava(org, UTYPE_ORG)) for org in org_list]
-    otype_infos = [(
-        otype,
-        list(Organization.objects.activated().filter(otype=otype)
-             .select_related("organization_id")),
-    ) for otype in OrganizationType.objects.all().order_by('-otype_id')]
+    # 获取所有组织类型
+    organization_types = list(OrganizationType.objects.all().order_by('-otype_id'))
+
+    # 强制只执行一次查询，prefetch防止多次查询
+    organizations = list(Organization.objects.activated().select_related('otype').prefetch_related('organization_id'))
+
+    # 获取组织信息
+    otype_infos_dict = {otype: [] for otype in organization_types}
+    for org in organizations:
+        otype_infos_dict[org.otype].append(org)
+    otype_infos = [(otype, otype_infos_dict[otype]) for otype in organization_types]
+
 
     # 获取不订阅列表（数据库里的是不订阅列表）
     if request.user.is_person():

--- a/scripts/generate_testdata.py
+++ b/scripts/generate_testdata.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import django
+
+sys.path.append(os.path.abspath('.'))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'boot.settings')
+django.setup()
+
+from tqdm import tqdm
+from faker import Faker
+import faker as faker
+from app.models import NaturalPerson, User, Organization, OrganizationType
+
+
+# STOP SAVING THIS FILE AUTOMATICALLY
+# As it will mess up the import list
+
+
+USER_COUNT = 200
+ORGANIZATION_COUNT = 100
+ORGANIZATION_TYPE_COUNT = 10
+
+fk = faker.Faker(locale='zh_CN')
+fake = Faker('zh_CN')
+
+
+def create_fake_user_for_orgnizaiton():
+    username = fake.user_name()
+    email = fake.email()
+    password = fake.password()
+    stuid = fake.unique.random_number(digits=8)
+    user = User.objects.create_user(
+        username=stuid, name=username, email=email, password=password, usertype=User.Type.ORG)
+    return user
+
+
+def create_fake_user_for_natural_person():
+    username = fake.user_name()
+    email = fake.email()
+    password = fake.password()
+    stuid = fake.unique.random_number(digits=8)
+    user = User.objects.create_user(
+        username=stuid, name=username, email=email, password=password, usertype=User.Type.STUDENT)
+    return user
+
+
+def create_fake_natural_person():
+    user = create_fake_user_for_natural_person()
+    person = NaturalPerson(
+        person_id=user,
+        name=fake.unique.name(),
+        nickname=fake.first_name(),
+        gender=fake.random_element(elements=[0, 1]),
+        birthday=fake.date_of_birth(),
+        email=fake.email(),
+        telephone=fake.phone_number(),
+        biography=fake.text(max_nb_chars=200),
+        inform_share=fake.boolean(),
+        last_time_login=fake.date_time_this_year(),
+        identity=fake.random_element(elements=[0, 1]),
+        stu_class=fake.random_int(min=1, max=5),
+        stu_major=fake.text(max_nb_chars=25),
+        stu_grade=fake.random_int(min=1, max=5),
+        stu_dorm=fake.random_int(min=100, max=999),
+        status=0,
+        show_nickname=fake.boolean(),
+        show_birthday=fake.boolean(),
+        show_gender=fake.boolean(),
+        show_email=fake.boolean(),
+        show_tel=fake.boolean(),
+        show_major=fake.boolean(),
+        show_dorm=fake.boolean(),
+    )
+    person.save()
+
+
+def create_fake_organization_type(n: int):
+    otype = OrganizationType(
+        otype_id=n,
+        otype_name=fake.unique.company(),
+    )
+    otype.save()
+
+
+def create_fake_organization():
+    user = create_fake_user_for_orgnizaiton()
+    organization_type = OrganizationType.objects.get(
+        otype_id=fake.random_int(min=0, max=ORGANIZATION_TYPE_COUNT-1))
+    organization = Organization(
+        organization_id=user,
+        oname=fake.unique.company(),
+        otype=organization_type,
+    )
+    organization.save()
+
+
+if __name__ == '__main__':
+    print('Generating fake data...')
+    # 生成小组类型
+    for i in tqdm(range(ORGANIZATION_TYPE_COUNT), desc='Creating Organization Types'):
+        create_fake_organization_type(i)
+    actucal_user_count = 0
+    # 生成自然人
+    for _ in tqdm(range(USER_COUNT), desc='Creating Users'):
+        try:
+            create_fake_natural_person()
+            actucal_user_count += 1
+        except Exception as e:
+            pass  # We don't care about duplicate users
+    # 生成小组
+    for _ in tqdm(range(ORGANIZATION_COUNT), desc='Creating Organizations'):
+        create_fake_organization()
+    print('Done!')
+    print(f'Created {actucal_user_count} users, {ORGANIZATION_COUNT} organizations with {ORGANIZATION_TYPE_COUNT} organization types.')

--- a/templates/Appointment/booking.html
+++ b/templates/Appointment/booking.html
@@ -45,7 +45,7 @@
                             <div class="alert alert-info alert-dismissible fade show" role="alert">
                                 <strong>温馨提示：</strong> 
                                 点击【房间名称】可以选择【其他房间】进行预约。
-                                {% if not allow_overlapse %}
+                                {% if not allow_overlapse and is_person %}
                                 不可以预约同时段的多个房间。
                                 {% endif %}
                                 <button type="button" class="close" data-dismiss="alert">
@@ -55,7 +55,9 @@
                             <div class="alert alert-info alert-dismissible fade show" role="alert">
                                 <strong>温馨提示：</strong> 
                                 每个【时间块】表示自显示时刻起的 30 分钟使用时间，长于 30 分钟的预约只需点击【起始时间块】和【结束时间块】即可。
+                                {% if is_person %}
                                 每人每天常规预约时间不得超过 {{ max_appoint_time }} 小时。
+                                {% endif %}
                                 <button type="button" class="close" data-dismiss="alert">
                                     <span >&times;</span>
                                 </button>
@@ -437,7 +439,7 @@
 					if(endid - startid > 5){
                         return alert("常规预约时间不能超过3小时!");
 					}
-                    if(endid - startid + 1 > available_hours[weekday] * 2) {
+                    if({{ is_person | yesno:"true, false" }} && endid - startid + 1 > available_hours[weekday] * 2) {
                         return alert("每人每天常规预约时间不得超过" + {{ max_appoint_time }} + "小时!");
                     }
                     if(endid - startid === 1){

--- a/templates/Appointment/booking.html
+++ b/templates/Appointment/booking.html
@@ -43,13 +43,19 @@
                         {% comment %} replace js alert with bootstrap alert {% endcomment %}
                         <div class="col-12">
                             <div class="alert alert-info alert-dismissible fade show" role="alert">
-                                <strong>温馨提示：</strong> 点击【房间名称】可以选择【其他房间】进行预约。
+                                <strong>温馨提示：</strong> 
+                                点击【房间名称】可以选择【其他房间】进行预约。
+                                {% if not allow_overlapse %}
+                                不可以预约同时段的多个房间。
+                                {% endif %}
                                 <button type="button" class="close" data-dismiss="alert">
                                     <span >&times;</span>
                                 </button>
                             </div>
                             <div class="alert alert-info alert-dismissible fade show" role="alert">
-                                <strong>温馨提示：</strong> 每个【时间块】表示自显示时刻起的 30 分钟使用时间，长于 30 分钟的预约只需点击【起始时间块】和【结束时间块】即可。
+                                <strong>温馨提示：</strong> 
+                                每个【时间块】表示自显示时刻起的 30 分钟使用时间，长于 30 分钟的预约只需点击【起始时间块】和【结束时间块】即可。
+                                每人每天常规预约时间不得超过 {{ max_appoint_time }} 小时。
                                 <button type="button" class="close" data-dismiss="alert">
                                     <span >&times;</span>
                                 </button>
@@ -413,6 +419,7 @@
 				//document.getElementById(btn.id).textContent="hehe";
 			}
 			function submitfunc() {
+                let available_hours = {{ available_hours|safe }};
 				if (!(timestatus >= 1)) {
 					alert("请选择预约时段!");
 				}
@@ -430,6 +437,9 @@
 					if(endid - startid > 5){
                         return alert("常规预约时间不能超过3小时!");
 					}
+                    if(endid - startid + 1 > available_hours[weekday] * 2) {
+                        return alert("每人每天常规预约时间不得超过" + {{ max_appoint_time }} + "小时!");
+                    }
                     if(endid - startid === 1){
                         if(!confirm("时长30分钟的预约只需点击开始时间块即可。您确定要发起时长1小时的预约吗?")) return;
                     }


### PR DESCRIPTION
#866 添加对单日预约时长和同时段预约的限制，修改前端的提示信息

配置文件 `Appointment/config.py`
```python
    # 单人单日预约总时长上限
    max_appoint_time = timedelta(hours=6)
    # 是否允许单人同一时段预约两个房间
    allow_overlap = False
```
![image](https://github.com/user-attachments/assets/735368bf-c3b0-49be-94e4-ccd6a5a4e105)
![image](https://github.com/user-attachments/assets/373635a7-c29f-43d0-9503-f4f09fc78766)
![image](https://github.com/user-attachments/assets/b9570313-5a9b-46ef-887e-dfd31e46cde1)
![image](https://github.com/user-attachments/assets/d69b347d-04e2-4c5a-812e-9ed242951196)


