### PR TITLE
Fix race condition in registration_status_change

### DIFF
--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -583,8 +583,8 @@ def check_course_time_conflict(current_course: Course,
     '''
 
 
-@transaction.atomic
 @logger.secure_func()
+@transaction.atomic
 def registration_status_change(course_id: int, user: NaturalPerson,
                                action: str) -> MESSAGECONTEXT:
     """


### PR DESCRIPTION
把对应的`NaturalPerson`用`select_for_update()`锁起来，就可以避免在检查合法性和创建选课记录两个操作不原子导致的并发问题。

修改 `CourseParticipation` 的那个transaction没有去掉，因为[Django文档](https://docs.djangoproject.com/en/5.0/topics/db/transactions/#controlling-transactions-explicitly)说不应该在transaction里try/except，而应该放在`with transaction.atomic()`的外面，即使要引入一个新的transaction.