### PR TITLE
长期预约页面跳转的不良体验修复

### DIFF
--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -829,7 +829,7 @@ def checkout_appoint(request: UserRequest):
 
     except AssertionError:
         # Rid或start_week不合法，直接跳转到主页
-        return redirect('')
+        return redirect('/underground/index')
     except ValueError:
         # 参数类型转换失败时，重定向回arrange_time页面并显示错误信息
         redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={safe_start_week}'

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -798,9 +798,6 @@ def checkout_appoint(request: UserRequest):
         start_week = int(start_week)
         startid = int(startid)
         endid = int(endid)
-        if is_longterm and request.method == 'POST':
-            times = int(times) if times else 0
-            interval = int(interval) if interval else 0
         assert weekday in wklist, '星期几'
         assert startid >= 0, '起始时间'
         assert endid >= 0, '结束时间'
@@ -815,6 +812,12 @@ def checkout_appoint(request: UserRequest):
         if is_longterm:
             redirect_url += '&longterm=on'
         return redirect(message_url(wrong(f'参数不合法: {e}'), redirect_url))
+    except ValueError:
+        # 参数类型转换失败时，重定向回arrange_time页面并显示错误信息
+        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={start_week}'
+        if is_longterm:
+            redirect_url += '&longterm=on'
+        return redirect(message_url(wrong('参数格式错误，请检查输入'), redirect_url))
     except:
         # 参数不合法时，重定向回arrange_time页面并显示错误信息
         redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={start_week}'
@@ -871,6 +874,16 @@ def checkout_appoint(request: UserRequest):
                 contents[key] = contents[key][0]
                 if key in {'year', 'month', 'day'}:
                     contents[key] = int(contents[key])
+        # 处理长期预约的times和interval参数
+        if is_longterm:
+            try:
+                times = int(contents.get('times', 0)) if contents.get('times') else 0
+                interval = int(contents.get('interval', 0)) if contents.get('interval') else 0
+            except ValueError:
+                wrong("长期预约周数或间隔周数格式错误，请输入数字", render_context)
+                # 简化错误处理
+                render_context.update(contents=contents, show_clause=True)
+                return render(request, 'Appointment/checkout.html', render_context)
         # 处理外院人数
         if contents['non_yp_num'] == "":
             contents['non_yp_num'] = 0
@@ -898,10 +911,10 @@ def checkout_appoint(request: UserRequest):
         if is_longterm and not times:
             wrong("长期预约周数未填写", render_context)
         # 检查间隔周数
-        elif is_longterm and not (1 <= interval <= CONFIG.longterm_max_interval):
+        if is_longterm and not (1 <= interval <= CONFIG.longterm_max_interval):
             wrong("间隔周数不符合要求", render_context)
         # 检查预约次数
-        elif is_longterm and not (1 <= times <= CONFIG.longterm_max_time_once
+        if is_longterm and not (1 <= times <= CONFIG.longterm_max_time_once
                                 and 1 <= interval * times <= CONFIG.longterm_max_week):
             wrong("您填写的预约周数不符合要求", render_context)
 

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -800,10 +800,23 @@ def checkout_appoint(request: UserRequest):
 
     try:
         # 参数类型转换与合法性检查
-        # 在类型转换之前验证start_week是否为数字
+
+        # 由于预约url中存在Rid和start_week
+        # 故先进行Rid和start_week合法性检验
         if is_longterm and not str(start_week).isdigit():
             raise AssertionError(f'预约周数必须为0或1')
         start_week = int(start_week)
+        if start_week not in [0, 1]:
+            raise AssertionError(f'预约周数必须为0或1')
+        else:
+            safe_start_week = start_week
+        if not Room.objects.filter(Rid=Rid).exists():
+            raise AssertionError(f'房间{Rid}不存在')
+        room = Room.objects.get(Rid=Rid)
+        if not room.Rstatus == Room.Status.PERMITTED:
+            raise AssertionError(f'房间{Rid}不可预约')
+
+        # 其他参数的合法性检验
         startid = int(startid)
         endid = int(endid)
         assert weekday in wklist, '星期几'
@@ -813,40 +826,19 @@ def checkout_appoint(request: UserRequest):
         assert has_longterm_permission or not is_longterm, '没有长期预约权限'
         if is_interview:
             assert has_interview_permission, '没有面试权限'
-        # 验证房间是否存在且可预约
-        room = Room.objects.get(Rid=Rid)
-        if room.Rstatus == Room.Status.FORBIDDEN:
-            raise AssertionError(f'房间{Rid}不可预约')
-        # 验证start_week参数
-        if start_week not in [0, 1]:
-            raise AssertionError(f'预约周数必须为0或1')
-        else:
-            safe_start_week = start_week
 
-    except AssertionError as e:
-        # 参数不合法时，重定向回arrange_time页面并显示错误信息
-        safe_rid = room.Rid if room else "B107A"
-        redirect_url = f'/underground/arrange_time?Rid={safe_rid}&start_week={safe_start_week}'
-        if is_longterm:
-            redirect_url += '&longterm=on'
-        return redirect(message_url(wrong(f'参数不合法: {str(e)}'), redirect_url))
+    except AssertionError:
+        # Rid或start_week不合法，直接跳转到主页
+        return redirect('')
     except ValueError:
         # 参数类型转换失败时，重定向回arrange_time页面并显示错误信息
-        safe_rid = room.Rid if room else "B107A"
-        redirect_url = f'/underground/arrange_time?Rid={safe_rid}&start_week={safe_start_week}'
+        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={safe_start_week}'
         if is_longterm:
             redirect_url += '&longterm=on'
         return redirect(message_url(wrong('参数格式错误，请检查输入'), redirect_url))
-    except Room.DoesNotExist:
-        # 房间不存在时使用默认房间
-        redirect_url = f'/underground/arrange_time?Rid=B107A&start_week={safe_start_week}'
-        if is_longterm:
-            redirect_url += '&longterm=on'
-        return redirect(message_url(wrong(f'房间{Rid}不存在'), redirect_url))
     except:
         # 参数不合法时，重定向回arrange_time页面并显示错误信息
-        safe_rid = room.Rid if room else "B107A"
-        redirect_url = f'/underground/arrange_time?Rid={safe_rid}&start_week={safe_start_week}'
+        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={safe_start_week}'
         if is_longterm:
             redirect_url += '&longterm=on'
         return redirect(message_url(wrong('参数不合法'), redirect_url))
@@ -1022,7 +1014,7 @@ def checkout_appoint(request: UserRequest):
                     message_url(succeed(f"预约{room.Rtitle}成功!"),
                                 reverse("Appointment:account")))
             elif appoint is None:
-                wrong(err_msg, render_context)
+                return redirect('')
             else:
                 # 长期预约
                 try:

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -424,6 +424,11 @@ def arrange_time(request: HttpRequest):
     max_appoint_time = int(CONFIG.max_appoint_time.total_seconds() // 3600) # 以小时计算
     is_person = request.user.is_person()
 
+     # 处理从URL参数传递过来的错误信息
+    html_display = {}
+    html_display["warn_code"], html_display["warn_message"] = my_messages.get_request_message(
+        request)
+    
     # 获取房间编号
     Rid = request.GET.get('Rid')
     try:
@@ -794,10 +799,8 @@ def checkout_appoint(request: UserRequest):
         startid = int(startid)
         endid = int(endid)
         if is_longterm and request.method == 'POST':
-            assert times, '长期预约周数未填写'
-            times = int(times)
-            interval = int(interval)
-            assert 1 <= interval <= CONFIG.longterm_max_interval, '间隔周数'
+            times = int(times) if times else 0
+            interval = int(interval) if interval else 0
         assert weekday in wklist, '星期几'
         assert startid >= 0, '起始时间'
         assert endid >= 0, '结束时间'
@@ -807,9 +810,17 @@ def checkout_appoint(request: UserRequest):
         if is_interview:
             assert has_interview_permission, '没有面试权限'
     except AssertionError as e:
-        return redirect(message_url(wrong(f'参数不合法: {e}'), reverse('Appointment:index')))
+        # 参数不合法时，重定向回arrange_time页面并显示错误信息
+        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={start_week}'
+        if is_longterm:
+            redirect_url += '&longterm=on'
+        return redirect(message_url(wrong(f'参数不合法: {e}'), redirect_url))
     except:
-        return redirect(message_url(wrong('参数不合法'), reverse('Appointment:index')))
+        # 参数不合法时，重定向回arrange_time页面并显示错误信息
+        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={start_week}'
+        if is_longterm:
+            redirect_url += '&longterm=on'
+        return redirect(message_url(wrong('参数不合法'), redirect_url))
 
     appoint_params = {
         'Rid': Rid,
@@ -883,9 +894,14 @@ def checkout_appoint(request: UserRequest):
             lambda sid: User.objects.get(username = sid).active,
             contents['students']
         ))
-
+        # 检查长期预约周数是否填写
+        if is_longterm and not times:
+            wrong("长期预约周数未填写", render_context)
+        # 检查间隔周数
+        elif is_longterm and not (1 <= interval <= CONFIG.longterm_max_interval):
+            wrong("间隔周数不符合要求", render_context)
         # 检查预约次数
-        if is_longterm and not (1 <= times <= CONFIG.longterm_max_time_once
+        elif is_longterm and not (1 <= times <= CONFIG.longterm_max_time_once
                                 and 1 <= interval * times <= CONFIG.longterm_max_week):
             wrong("您填写的预约周数不符合要求", render_context)
 

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -763,6 +763,9 @@ def checkout_appoint(request: UserRequest):
     """
     提交预约表单，检查合法性，进行预约
     """
+    stu_list = []
+    json_context = {}
+
     if request.method == "GET":
         Rid = request.GET.get('Rid')
         weekday = request.GET.get('weekday')
@@ -792,9 +795,14 @@ def checkout_appoint(request: UserRequest):
     has_longterm_permission = applicant.longterm
     has_interview_permission = not (applicant.longterm or applicant.hidden)
     has_interview_permission &= Rid in Room.objects.interview_room_ids()
+    room = None
+    safe_start_week = 0
 
     try:
         # 参数类型转换与合法性检查
+        # 在类型转换之前验证start_week是否为数字
+        if is_longterm and not str(start_week).isdigit():
+            raise AssertionError(f'预约周数必须为0或1')
         start_week = int(start_week)
         startid = int(startid)
         endid = int(endid)
@@ -802,25 +810,43 @@ def checkout_appoint(request: UserRequest):
         assert startid >= 0, '起始时间'
         assert endid >= 0, '结束时间'
         assert endid >= startid, '起始时间晚于结束时间'
-        assert start_week == 0 or start_week == 1, '预约周数'
         assert has_longterm_permission or not is_longterm, '没有长期预约权限'
         if is_interview:
             assert has_interview_permission, '没有面试权限'
+        # 验证房间是否存在且可预约
+        room = Room.objects.get(Rid=Rid)
+        if room.Rstatus == Room.Status.FORBIDDEN:
+            raise AssertionError(f'房间{Rid}不可预约')
+        # 验证start_week参数
+        if start_week not in [0, 1]:
+            raise AssertionError(f'预约周数必须为0或1')
+        else:
+            safe_start_week = start_week
+
     except AssertionError as e:
         # 参数不合法时，重定向回arrange_time页面并显示错误信息
-        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={start_week}'
+        safe_rid = room.Rid if room else "B107A"
+        redirect_url = f'/underground/arrange_time?Rid={safe_rid}&start_week={safe_start_week}'
         if is_longterm:
             redirect_url += '&longterm=on'
-        return redirect(message_url(wrong(f'参数不合法: {e}'), redirect_url))
+        return redirect(message_url(wrong(f'参数不合法: {str(e)}'), redirect_url))
     except ValueError:
         # 参数类型转换失败时，重定向回arrange_time页面并显示错误信息
-        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={start_week}'
+        safe_rid = room.Rid if room else "B107A"
+        redirect_url = f'/underground/arrange_time?Rid={safe_rid}&start_week={safe_start_week}'
         if is_longterm:
             redirect_url += '&longterm=on'
         return redirect(message_url(wrong('参数格式错误，请检查输入'), redirect_url))
+    except Room.DoesNotExist:
+        # 房间不存在时使用默认房间
+        redirect_url = f'/underground/arrange_time?Rid=B107A&start_week={safe_start_week}'
+        if is_longterm:
+            redirect_url += '&longterm=on'
+        return redirect(message_url(wrong(f'房间{Rid}不存在'), redirect_url))
     except:
         # 参数不合法时，重定向回arrange_time页面并显示错误信息
-        redirect_url = f'/underground/arrange_time?Rid={Rid}&start_week={start_week}'
+        safe_rid = room.Rid if room else "B107A"
+        redirect_url = f'/underground/arrange_time?Rid={safe_rid}&start_week={safe_start_week}'
         if is_longterm:
             redirect_url += '&longterm=on'
         return redirect(message_url(wrong('参数不合法'), redirect_url))
@@ -833,7 +859,6 @@ def checkout_appoint(request: UserRequest):
         'longterm': is_longterm,
         'start_week': start_week,
     }
-    room = Room.objects.get(Rid=Rid)
     # 表单参数都统一为可预约的第一周，具体预约哪周根据POST的start_week判断
     dayrange_list = web_func.get_dayrange(day_offset=0)[0]
     for day in dayrange_list:
@@ -866,6 +891,19 @@ def checkout_appoint(request: UserRequest):
                           has_interview_permission=has_interview_permission,
                           interview_max_count=CONFIG.interview_max_num)
 
+    # 提供搜索功能的数据
+    search_users = User.objects.filter_type(User.Type.PERSON)
+    search_users = search_users.exclude(pk=request.user.pk)
+    # 保证都在预约人员列表中且不是隐藏用户
+    search_users = search_users.filter(
+        pk__in=Participant.objects.filter(hidden=False).values('Sid__pk'))
+    stu_list = to_search_indices(search_users, active=True)
+    member_ids = get_member_ids(request.user)
+
+    # 用于前端的JSON数据，由Django标签在渲染时转化为JSON格式
+    json_context = dict(user_infos=stu_list, member_ids=member_ids)
+    render_context.update(json_context=json_context)
+
     # 提交预约信息
     if request.method == 'POST':
         contents = dict(request.POST)
@@ -874,16 +912,6 @@ def checkout_appoint(request: UserRequest):
                 contents[key] = contents[key][0]
                 if key in {'year', 'month', 'day'}:
                     contents[key] = int(contents[key])
-        # 处理长期预约的times和interval参数
-        if is_longterm:
-            try:
-                times = int(contents.get('times', 0)) if contents.get('times') else 0
-                interval = int(contents.get('interval', 0)) if contents.get('interval') else 0
-            except ValueError:
-                wrong("长期预约周数或间隔周数格式错误，请输入数字", render_context)
-                # 简化错误处理
-                render_context.update(contents=contents, show_clause=True)
-                return render(request, 'Appointment/checkout.html', render_context)
         # 处理外院人数
         if contents['non_yp_num'] == "":
             contents['non_yp_num'] = 0
@@ -907,6 +935,22 @@ def checkout_appoint(request: UserRequest):
             lambda sid: User.objects.get(username = sid).active,
             contents['students']
         ))
+        # 处理长期预约的times和interval参数 - 移到这里
+        if is_longterm:
+            try:
+                times = int(contents.get('times', 0)
+                            ) if contents.get('times') else 0
+                interval = int(contents.get('interval', 0)
+                               ) if contents.get('interval') else 0
+            except ValueError:
+                wrong("长期预约周数或间隔周数格式错误，请输入数字", render_context)
+                # 预约失败。补充一些已有信息，以避免重复填写
+                selected_ids = set(contents.pop('students'))
+                selected_ids = [w['id']
+                                for w in stu_list if w['id'] in selected_ids]
+                json_context.update(selected_ids=selected_ids)
+                render_context.update(contents=contents, show_clause=True, json_context=json_context)
+                return render(request, 'Appointment/checkout.html', render_context)
         # 检查长期预约周数是否填写
         if is_longterm and not times:
             wrong("长期预约周数未填写", render_context)
@@ -1011,25 +1055,12 @@ def checkout_appoint(request: UserRequest):
                               + f"-{conflict_appoints[0].Afinish}的预约发生冲突",
                               render_context)
 
-    # 提供搜索功能的数据
-    search_users = User.objects.filter_type(User.Type.PERSON)
-    search_users = search_users.exclude(pk=request.user.pk)
-    # 保证都在预约人员列表中且不是隐藏用户
-    search_users = search_users.filter(
-        pk__in=Participant.objects.filter(hidden=False).values('Sid__pk'))
-    stu_list = to_search_indices(search_users, active=True)
-    member_ids = get_member_ids(request.user)
-
-    # 用于前端的JSON数据，由Django标签在渲染时转化为JSON格式
-    json_context = dict(user_infos=stu_list, member_ids=member_ids)
-    render_context.update(json_context=json_context)
-
     if request.method == 'POST':
         # 预约失败。补充一些已有信息，以避免重复填写
         selected_ids = set(contents.pop('students'))
         selected_ids = [w['id'] for w in stu_list if w['id'] in selected_ids]
         json_context.update(selected_ids=selected_ids)
-        render_context.update(contents=contents, show_clause=True)
+        render_context.update(contents=contents, show_clause=True, json_context=json_context) 
     return render(request, 'Appointment/checkout.html', render_context)
 
 

--- a/templates/Appointment/booking.html
+++ b/templates/Appointment/booking.html
@@ -39,6 +39,11 @@
             <!-- Page Content -->
             <div class="content">
                 <div class="container">
+                    {% if html_display.warn_code == 1 %}
+                        <div class="alert alert-warning text-center">{{ html_display.warn_message }}</div>
+                    {% elif html_display.warn_code == 2 %}
+                        <div class="alert alert-success text-center">{{ html_display.warn_message }}</div>
+                    {% endif %}
                     <div class="row">
                         {% comment %} replace js alert with bootstrap alert {% endcomment %}
                         <div class="col-12">


### PR DESCRIPTION
主要修改了Appointment/view.py/checkout_appoint函数，把一部分参数不合法的校验由POST之前放到POST过程中，并用wrong()作为弹窗抛出，避免了页面直接跳转回主页面的不良体验