### PR TITLE
Stop running basetest on AI-College

### DIFF
--- a/.github/workflows/basetest.yml
+++ b/.github/workflows/basetest.yml
@@ -2,9 +2,9 @@ name: basetest
 
 on:
   push:
-    branches: [ develop, AI-College ]
+    branches: [ develop ]
   pull_request:
-    branches: [ develop, AI-College ]
+    branches: [ develop ]
 
 jobs:
 


### PR DESCRIPTION
The base test only tests the correctness of some util functions.

On the other hand, the AI College code requires the Haikang SDK to run, and it's not easy to port the SDK onto Github actions.