### PR TITLE
单日内预约不再限制3h

### DIFF
--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -648,13 +648,6 @@ def _add_appoint(contents: dict, start: datetime, finish: datetime, non_yp_num: 
     if contents.get('longterm') != 'on' and 2 * len(students) < create_min:
         return _error('院内使用人数需要达到房间最小人数的一半！')
 
-    # 预约是否超过3小时
-    # 检查预约时间合法性由create_appoint完成
-    try:
-        assert finish <= start + timedelta(hours=3)
-    except:
-        return _error('预约时长不能超过3小时！')
-
     try:
         usage: str = contents['Ausage']
         announcement: str = contents['announcement']
@@ -693,7 +686,6 @@ def checkout_appoint(request: UserRequest):
         is_longterm = True if request.GET.get('longterm') == 'on' else False
         is_interview = False
     else:
-        print('checkout_appoint POST:', request.POST)
         Rid = request.POST.get('Rid')
         startid = request.POST.get('startid')
         endid = request.POST.get('endid')
@@ -853,7 +845,6 @@ def checkout_appoint(request: UserRequest):
                 _notify = False
             elif is_interview:
                 appoint_type = Appoint.Type.INTERVIEW
-            print('start time and end time:', start_time, end_time)
             response = _add_appoint(contents, start_time, end_time, non_yp_num=non_yp_num,
                                     type=appoint_type, notify_create=_notify)
             appoint, err_msg = response

--- a/templates/Appointment/booking.html
+++ b/templates/Appointment/booking.html
@@ -359,9 +359,6 @@
 					alert("请选择预约时段!");
 				}
 				else { //到这里 说明预约符合要求
-					if(endid - startid > 5){
-                        return alert("常规预约时间不能超过3小时!");
-					}
                     if(endid - startid === 1){
                         if(!confirm("时长30分钟的预约只需点击开始时间块即可。您确定要发起时长1小时的预约吗?")) return;
                     }


### PR DESCRIPTION
去除了检查一次预约时间不超过3h的限制。

由于创建预约的页面接受的 POST 参数形式为 日期 + 开始时间块 + 结束时间块，用户仍然不能创建跨天预约。