### PR TITLE
Fix web view ticket caching

### DIFF
--- a/boot/settings.py
+++ b/boot/settings.py
@@ -109,9 +109,11 @@ TEMPLATES = [
 
 
 # Cache (used for one-time webview tickets, etc.)
+# shared across processes
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
+        "LOCATION": "/var/tmp/django_cache",
     }
 }
 


### PR DESCRIPTION
之前cache到内存了，会导致多线程失效
需要保证/var/tmp/django_cache可读写