### PR TITLE
feat: 支持活动报名与签到接口

### DIFF
--- a/api/activity/checkin.py
+++ b/api/activity/checkin.py
@@ -27,27 +27,29 @@ def do_checkin(person: NaturalPerson, aid: int) -> tuple[bool, str]:
         (success, message): 是否成功及提示信息
     """
     try:
-        activity = Activity.objects.get(id=aid)
-    except (Activity.DoesNotExist, ValueError, TypeError):
+        aid = int(aid)
+    except (ValueError, TypeError):
         return False, "签到失败!"
-
-    if not activity.need_checkin:
-        return False, "该活动无需签到。"
-
-    if activity.status == Activity.Status.END:
-        return False, "活动已结束，不再开放签到。"
-
-    if not (
-        activity.status == Activity.Status.PROGRESSING
-        or (
-            activity.status == Activity.Status.WAITING
-            and datetime.now() + timedelta(hours=1) >= activity.start
-        )
-    ):
-        return False, "活动开始前一小时开放签到，请耐心等待!"
 
     try:
         with transaction.atomic():
+            activity = Activity.objects.select_for_update().get(id=aid)
+
+            if not activity.need_checkin:
+                return False, "该活动无需签到。"
+
+            if activity.status == Activity.Status.END:
+                return False, "活动已结束，不再开放签到。"
+
+            if not (
+                activity.status == Activity.Status.PROGRESSING
+                or (
+                    activity.status == Activity.Status.WAITING
+                    and datetime.now() + timedelta(hours=1) >= activity.start
+                )
+            ):
+                return False, "活动开始前一小时开放签到，请耐心等待!"
+
             participant = Participation.objects.select_for_update().get(
                 SQ.sq(Participation.activity, activity),
                 SQ.sq(Participation.person, person),
@@ -62,5 +64,7 @@ def do_checkin(person: NaturalPerson, aid: int) -> tuple[bool, str]:
             participant.status = Participation.AttendStatus.ATTENDED
             participant.save()
             return True, "签到成功!"
+    except Activity.DoesNotExist:
+        return False, "签到失败!"
     except Participation.DoesNotExist:
         return False, "您尚未报名该活动!"

--- a/api/activity/checkin.py
+++ b/api/activity/checkin.py
@@ -31,6 +31,9 @@ def do_checkin(person: NaturalPerson, aid: int) -> tuple[bool, str]:
     except (Activity.DoesNotExist, ValueError, TypeError):
         return False, "签到失败!"
 
+    if not activity.need_checkin:
+        return False, "该活动无需签到。"
+
     if activity.status == Activity.Status.END:
         return False, "活动已结束，不再开放签到。"
 

--- a/api/activity/serializers.py
+++ b/api/activity/serializers.py
@@ -2,8 +2,10 @@
 Serializers for activity API.
 """
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
 
-from app.models import Activity
+from app.models import Activity, Participation
+from app.utils import get_person_or_org
 
 
 class ActivitySummarySerializer(serializers.ModelSerializer):
@@ -76,6 +78,77 @@ class ActivitySummarySerializer(serializers.ModelSerializer):
     def get_popular_level(self, obj: Activity) -> int:
         """Get popularity level of the activity."""
         return obj.popular_level()
+
+
+class ActivityDetailSerializer(ActivitySummarySerializer):
+    """Activity detail including the selected person's signup status."""
+
+    participation_status = serializers.SerializerMethodField(
+        help_text="Current person's signup/check-in status, or null",
+    )
+
+    class Meta(ActivitySummarySerializer.Meta):
+        fields = ActivitySummarySerializer.Meta.fields + [
+            'participation_status',
+        ]
+        read_only_fields = fields
+
+    @extend_schema_field(
+        serializers.ChoiceField(
+            choices=Participation.AttendStatus.choices,
+            allow_null=True,
+        ),
+    )
+    def get_participation_status(self, obj: Activity) -> str | None:
+        """Return the participation status for the authenticated person."""
+        request = self.context.get('request')
+        if request is None or not request.user.is_person():
+            return None
+        person = get_person_or_org(request.user)
+        return Participation.objects.filter(
+            activity=obj,
+            person=person,
+        ).values_list('status', flat=True).first()
+
+
+class ActivityActionResultSerializer(serializers.Serializer):
+    """Response after signing up for or withdrawing from an activity."""
+
+    message = serializers.CharField(help_text="User-facing result message")
+    participation_status = serializers.ChoiceField(
+        choices=Participation.AttendStatus.choices,
+        help_text="Updated signup/check-in status",
+    )
+    current_participants = serializers.IntegerField(
+        min_value=0,
+        help_text="Updated number of registered participants",
+    )
+
+
+class ActivityCheckinRequestSerializer(serializers.Serializer):
+    """Request body for checking in to an activity."""
+
+    aid = serializers.IntegerField(
+        min_value=1,
+        help_text="Activity ID",
+    )
+
+
+class ActivityMessageSerializer(serializers.Serializer):
+    """Simple successful activity operation response."""
+
+    message = serializers.CharField(help_text="User-facing result message")
+
+
+class ActivityErrorSerializer(serializers.Serializer):
+    """Canonical error response for activity mini-program endpoints."""
+
+    code = serializers.CharField(help_text="Stable machine-readable error code")
+    message = serializers.CharField(help_text="Concise user-facing message")
+    errors = serializers.DictField(
+        child=serializers.ListField(child=serializers.CharField()),
+        help_text="Field errors; empty when the error is not field-specific",
+    )
 
 
 class TodayActivitySerializer(serializers.Serializer):

--- a/api/activity/tests.py
+++ b/api/activity/tests.py
@@ -1,11 +1,25 @@
-"""
-Tests for activity API.
-"""
+"""Tests for activity API."""
+
+from datetime import datetime, timedelta
+
 from django.test import SimpleTestCase
 from django.urls import resolve
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
 
+from app.models import (
+    Activity,
+    NaturalPerson,
+    Organization,
+    OrganizationType,
+    Participation,
+)
+from generic.models import User
 from api.activity.views import ActivityViewSet
 from api.activity.serializers import (
+    ActivityActionResultSerializer,
+    ActivityCheckinRequestSerializer,
+    ActivityDetailSerializer,
     ActivitySummarySerializer,
     ActivityHomepageSerializer,
     TodayActivitySerializer,
@@ -22,6 +36,14 @@ class ActivityURLTestCase(SimpleTestCase):
         resolver = resolve(url)
         self.assertEqual(resolver.func.cls, ActivityViewSet)
         self.assertEqual(resolver.func.actions['get'], 'overview')
+
+    def test_signup_url_resolves(self):
+        """Test signup URL resolves to both signup methods."""
+        url = '/api/v2/activity/1/signup/'
+        resolver = resolve(url)
+        self.assertEqual(resolver.func.cls, ActivityViewSet)
+        self.assertEqual(resolver.func.actions['post'], 'signup')
+        self.assertEqual(resolver.func.actions['delete'], 'signup')
 
 
 class SerializerFieldsTestCase(SimpleTestCase):
@@ -55,6 +77,29 @@ class SerializerFieldsTestCase(SimpleTestCase):
             'popular_level',
         ]
         self.assertEqual(set(serializer.fields.keys()), set(expected_fields))
+
+    def test_activity_detail_serializer_fields(self):
+        """Test activity detail adds the current user's signup status."""
+        serializer = ActivityDetailSerializer()
+        expected_fields = set(ActivitySummarySerializer().fields.keys()) | {
+            'participation_status',
+        }
+        self.assertEqual(set(serializer.fields.keys()), expected_fields)
+
+    def test_activity_action_result_serializer_fields(self):
+        """Test signup result exposes the updated activity state."""
+        serializer = ActivityActionResultSerializer()
+        expected_fields = {
+            'message',
+            'participation_status',
+            'current_participants',
+        }
+        self.assertEqual(set(serializer.fields.keys()), expected_fields)
+
+    def test_activity_checkin_request_serializer_fields(self):
+        """Test check-in input is validated by a concrete serializer."""
+        serializer = ActivityCheckinRequestSerializer()
+        self.assertEqual(set(serializer.fields.keys()), {'aid'})
 
     def test_today_activity_serializer_fields(self):
         """Test TodayActivitySerializer has required fields."""
@@ -99,3 +144,404 @@ class ViewSetConfigTestCase(SimpleTestCase):
         """Test ActivityViewSet has overview action."""
         self.assertTrue(hasattr(ActivityViewSet, 'overview'))
         self.assertTrue(callable(getattr(ActivityViewSet, 'overview')))
+
+
+class ActivitySignupAPITestCase(APITestCase):
+    """Test signup, withdrawal, detail status, and check-in flows."""
+
+    def setUp(self):
+        """Create a personal user, organization, and open activity."""
+        self.client = APIClient()
+        self.person_user = User.objects.create_user(
+            username='signup_person',
+            name='报名同学',
+            usertype=User.Type.PERSON,
+            password='testpass',
+        )
+        self.person = NaturalPerson.objects.create(
+            self.person_user,
+            name='报名同学',
+        )
+        self.teacher_user = User.objects.create_user(
+            username='signup_teacher',
+            name='审核老师',
+            usertype=User.Type.TEACHER,
+            password='testpass',
+        )
+        self.teacher = NaturalPerson.objects.create(
+            self.teacher_user,
+            name='审核老师',
+        )
+        self.org_type = OrganizationType.objects.create(
+            otype_id=101,
+            otype_name='活动小组类型',
+            incharge=self.teacher,
+            job_name_list=['负责人', '成员'],
+        )
+        self.org_user = User.objects.create_user(
+            username='signup_org',
+            name='活动小组',
+            usertype=User.Type.ORG,
+            password='testpass',
+        )
+        self.org = Organization.objects.create(
+            organization_id=self.org_user,
+            oname='活动小组',
+            otype=self.org_type,
+        )
+        now = datetime.now()
+        self.activity = Activity.objects.create(
+            title='新生之旅测试活动',
+            organization_id=self.org,
+            examine_teacher=self.teacher,
+            need_apply=True,
+            need_checkin=True,
+            status=Activity.Status.APPLYING,
+            apply_end=now + timedelta(hours=2),
+            start=now + timedelta(hours=3),
+            end=now + timedelta(hours=5),
+            capacity=2,
+            current_participants=0,
+        )
+
+    def signup_url(self):
+        """Return the signup endpoint for the test activity."""
+        return f'/api/v2/activity/{self.activity.id}/signup/'
+
+    def detail_url(self):
+        """Return the detail endpoint for the test activity."""
+        return f'/api/v2/activity/{self.activity.id}/'
+
+    def assert_api_error(self, response, expected_status, expected_code):
+        """Assert the canonical mini-program API error envelope."""
+        self.assertEqual(response.status_code, expected_status)
+        self.assertEqual(
+            set(response.data.keys()),
+            {'code', 'message', 'errors'},
+        )
+        self.assertEqual(response.data['code'], expected_code)
+        self.assertIsInstance(response.data['message'], str)
+        self.assertIsInstance(response.data['errors'], dict)
+
+    def test_detail_returns_null_participation_before_signup(self):
+        """A person who has not signed up sees a null status."""
+        self.client.force_authenticate(user=self.person_user)
+        response = self.client.get(self.detail_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data['participation_status'])
+
+    def test_signup_requires_authentication(self):
+        """An anonymous signup request returns canonical 401."""
+        response = self.client.post(self.signup_url(), format='json')
+        self.assert_api_error(
+            response,
+            status.HTTP_401_UNAUTHORIZED,
+            'not_authenticated',
+        )
+
+    def test_signup_requires_person_account(self):
+        """An organization account cannot sign up for an activity."""
+        self.client.force_authenticate(user=self.org_user)
+        response = self.client.post(self.signup_url(), format='json')
+        self.assert_api_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            'permission_denied',
+        )
+
+    def test_signup_creates_participation_and_updates_count(self):
+        """A successful signup creates the record and increments capacity."""
+        self.client.force_authenticate(user=self.person_user)
+        response = self.client.post(self.signup_url(), format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['participation_status'],
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.assertEqual(response.data['current_participants'], 1)
+        participation = Participation.objects.get(
+            activity=self.activity,
+            person=self.person,
+        )
+        self.assertEqual(
+            participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.activity.refresh_from_db()
+        self.assertEqual(self.activity.current_participants, 1)
+
+    def test_detail_returns_participation_status_after_signup(self):
+        """Activity detail reflects the current person's signup state."""
+        Participation.objects.create(
+            activity=self.activity,
+            person=self.person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.client.force_authenticate(user=self.person_user)
+        response = self.client.get(self.detail_url())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['participation_status'],
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+    def test_detail_does_not_expose_another_persons_status(self):
+        """Activity detail only reports the authenticated person's status."""
+        other_user = User.objects.create_user(
+            username='other_signup_person',
+            name='其他报名同学',
+            usertype=User.Type.PERSON,
+            password='testpass',
+        )
+        other_person = NaturalPerson.objects.create(
+            other_user,
+            name='其他报名同学',
+        )
+        Participation.objects.create(
+            activity=self.activity,
+            person=other_person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.get(self.detail_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data['participation_status'])
+
+    def test_inactive_person_cannot_signup(self):
+        """A business-inactive person cannot create a new signup."""
+        self.person_user.active = False
+        self.person_user.save(update_fields=['active'])
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(self.signup_url(), format='json')
+
+        self.assert_api_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            'permission_denied',
+        )
+        self.assertFalse(
+            Participation.objects.filter(
+                activity=self.activity,
+                person=self.person,
+            ).exists(),
+        )
+
+    def test_duplicate_signup_returns_conflict_without_incrementing(self):
+        """Submitting signup twice does not consume another place."""
+        Participation.objects.create(
+            activity=self.activity,
+            person=self.person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.activity.current_participants = 1
+        self.activity.save(update_fields=['current_participants'])
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(self.signup_url(), format='json')
+
+        self.assert_api_error(
+            response,
+            status.HTTP_409_CONFLICT,
+            'conflict',
+        )
+        self.activity.refresh_from_db()
+        self.assertEqual(self.activity.current_participants, 1)
+
+    def test_signup_full_activity_returns_conflict(self):
+        """A full first-come-first-served activity rejects signup."""
+        self.activity.current_participants = self.activity.capacity
+        self.activity.save(update_fields=['current_participants'])
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(self.signup_url(), format='json')
+
+        self.assert_api_error(
+            response,
+            status.HTTP_409_CONFLICT,
+            'conflict',
+        )
+        self.assertFalse(
+            Participation.objects.filter(
+                activity=self.activity,
+                person=self.person,
+            ).exists(),
+        )
+
+    def test_signup_closed_activity_returns_conflict(self):
+        """Signup is rejected after the activity leaves APPLYING state."""
+        self.activity.status = Activity.Status.WAITING
+        self.activity.save(update_fields=['status'])
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(self.signup_url(), format='json')
+
+        self.assert_api_error(
+            response,
+            status.HTTP_409_CONFLICT,
+            'conflict',
+        )
+
+    def test_signup_unknown_activity_returns_not_found(self):
+        """Signup for a missing activity returns canonical 404."""
+        self.client.force_authenticate(user=self.person_user)
+        response = self.client.post(
+            '/api/v2/activity/999999/signup/',
+            format='json',
+        )
+        self.assert_api_error(
+            response,
+            status.HTTP_404_NOT_FOUND,
+            'not_found',
+        )
+
+    def test_inner_activity_rejects_nonmember(self):
+        """A person outside the organizer cannot join an inner activity."""
+        self.activity.inner = True
+        self.activity.save(update_fields=['inner'])
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(self.signup_url(), format='json')
+
+        self.assert_api_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            'permission_denied',
+        )
+
+    def test_bidding_signup_creates_pending_application(self):
+        """A bidding activity records the signup as a pending application."""
+        self.activity.bidding = True
+        self.activity.save(update_fields=['bidding'])
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(self.signup_url(), format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['participation_status'],
+            Participation.AttendStatus.APPLYING,
+        )
+        self.assertIn('等待报名结果', response.data['message'])
+
+    def test_withdraw_updates_participation_and_count(self):
+        """Deleting signup cancels the record and releases the place."""
+        participation = Participation.objects.create(
+            activity=self.activity,
+            person=self.person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.activity.current_participants = 1
+        self.activity.save(update_fields=['current_participants'])
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.delete(self.signup_url())
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['participation_status'],
+            Participation.AttendStatus.CANCELED,
+        )
+        self.assertEqual(response.data['current_participants'], 0)
+        participation.refresh_from_db()
+        self.assertEqual(
+            participation.status,
+            Participation.AttendStatus.CANCELED,
+        )
+
+    def test_withdraw_without_signup_returns_conflict(self):
+        """A person cannot withdraw from an activity they did not join."""
+        self.client.force_authenticate(user=self.person_user)
+        response = self.client.delete(self.signup_url())
+        self.assert_api_error(
+            response,
+            status.HTTP_409_CONFLICT,
+            'conflict',
+        )
+
+    def test_withdraw_after_activity_starts_returns_conflict(self):
+        """Signup cannot be withdrawn after the activity starts."""
+        self.activity.status = Activity.Status.PROGRESSING
+        self.activity.save(update_fields=['status'])
+        Participation.objects.create(
+            activity=self.activity,
+            person=self.person,
+            status=Participation.AttendStatus.UNATTENDED,
+        )
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.delete(self.signup_url())
+
+        self.assert_api_error(
+            response,
+            status.HTTP_409_CONFLICT,
+            'conflict',
+        )
+
+    def test_checkin_after_signup_updates_participation(self):
+        """A registered person can check in during the allowed window."""
+        self.activity.status = Activity.Status.WAITING
+        self.activity.start = datetime.now() + timedelta(minutes=30)
+        self.activity.save(update_fields=['status', 'start'])
+        participation = Participation.objects.create(
+            activity=self.activity,
+            person=self.person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(
+            '/api/v2/activity/checkin/',
+            {'aid': self.activity.id},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        participation.refresh_from_db()
+        self.assertEqual(
+            participation.status,
+            Participation.AttendStatus.ATTENDED,
+        )
+
+    def test_checkin_requires_activity_id(self):
+        """Missing check-in activity ID returns a field validation error."""
+        self.client.force_authenticate(user=self.person_user)
+        response = self.client.post(
+            '/api/v2/activity/checkin/',
+            {},
+            format='json',
+        )
+        self.assert_api_error(
+            response,
+            status.HTTP_400_BAD_REQUEST,
+            'validation_error',
+        )
+        self.assertIn('aid', response.data['errors'])
+
+    def test_checkin_rejects_activity_without_checkin(self):
+        """The API cannot check users into an activity that needs no check-in."""
+        self.activity.status = Activity.Status.WAITING
+        self.activity.start = datetime.now() + timedelta(minutes=30)
+        self.activity.need_checkin = False
+        self.activity.save(update_fields=['status', 'start', 'need_checkin'])
+        Participation.objects.create(
+            activity=self.activity,
+            person=self.person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        self.client.force_authenticate(user=self.person_user)
+
+        response = self.client.post(
+            '/api/v2/activity/checkin/',
+            {'aid': self.activity.id},
+            format='json',
+        )
+
+        self.assert_api_error(
+            response,
+            status.HTTP_400_BAD_REQUEST,
+            'validation_error',
+        )

--- a/api/activity/tests.py
+++ b/api/activity/tests.py
@@ -311,10 +311,11 @@ class ActivitySignupAPITestCase(APITestCase):
         self.assertIsNone(response.data['participation_status'])
 
     def test_inactive_person_cannot_signup(self):
-        """A business-inactive person cannot create a new signup."""
-        self.person_user.active = False
-        self.person_user.save(update_fields=['active'])
+        """Signup reloads and locks business-active account state."""
         self.client.force_authenticate(user=self.person_user)
+        User.objects.filter(pk=self.person_user.pk).update(active=False)
+
+        self.assertTrue(self.person_user.active)
 
         response = self.client.post(self.signup_url(), format='json')
 

--- a/api/activity/views.py
+++ b/api/activity/views.py
@@ -40,6 +40,7 @@ from app.activity_utils import (
 )
 from app.models import Activity, Position
 from app.utils import get_person_or_org
+from generic.models import User
 
 
 __all__ = ['ActivityViewSet']
@@ -292,16 +293,26 @@ class ActivityViewSet(viewsets.ViewSet):
         """Sign up for an activity or withdraw the current signup."""
         if not request.user.is_person():
             raise PermissionDenied("请使用个人账号报名活动。")
-        if request.method == 'POST' and not request.user.active:
-            raise PermissionDenied("当前账号状态不允许报名活动。")
 
-        person = get_person_or_org(request.user)
         try:
             activity_id = int(aid)
         except (ValueError, TypeError):
             raise ValidationError({'aid': '活动 ID 格式错误'})
 
         with transaction.atomic():
+            try:
+                user = User.objects.select_for_update().get(
+                    pk=request.user.pk,
+                )
+            except User.DoesNotExist:
+                raise AuthenticationFailed("登录状态无效或已过期。")
+
+            if not user.is_person():
+                raise PermissionDenied("请使用个人账号报名活动。")
+            if request.method == 'POST' and not user.active:
+                raise PermissionDenied("当前账号状态不允许报名活动。")
+
+            person = get_person_or_org(user)
             try:
                 activity = Activity.objects.select_for_update().get(
                     id=activity_id,

--- a/api/activity/views.py
+++ b/api/activity/views.py
@@ -5,18 +5,68 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from django.db import transaction
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import (
+    AuthenticationFailed,
+    NotFound,
+    PermissionDenied,
+    Throttled,
+    ValidationError,
+)
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.exceptions import PermissionDenied, ValidationError, NotFound
-from drf_spectacular.utils import extend_schema, OpenApiResponse
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+)
 
-from api.authentication import WxJWTAuthentication
-from api.activity.serializers import ActivityHomepageSerializer, ActivitySummarySerializer
-from app.models import Activity
-from app.utils import get_person_or_org
 from api.activity.checkin import do_checkin
+from api.activity.serializers import (
+    ActivityActionResultSerializer,
+    ActivityCheckinRequestSerializer,
+    ActivityDetailSerializer,
+    ActivityErrorSerializer,
+    ActivityHomepageSerializer,
+    ActivityMessageSerializer,
+)
+from api.authentication import WxJWTAuthentication
+from app.activity_utils import (
+    ActivityException,
+    apply_activity_for_person,
+    withdraw_activity_for_person,
+)
+from app.models import Activity, Position
+from app.utils import get_person_or_org
+
+
+__all__ = ['ActivityViewSet']
+
+
+def _first_error(detail) -> str:
+    """Return the first human-readable message from a DRF error detail."""
+    if isinstance(detail, dict):
+        for value in detail.values():
+            return _first_error(value)
+        return ''
+    if isinstance(detail, (list, tuple)):
+        return _first_error(detail[0]) if detail else ''
+    return str(detail)
+
+
+def _field_errors(detail) -> dict[str, list[str]]:
+    """Convert DRF field errors to the canonical string-list mapping."""
+    if not isinstance(detail, dict):
+        return {}
+    errors: dict[str, list[str]] = {}
+    for field, value in detail.items():
+        if field == 'detail':
+            continue
+        values = value if isinstance(value, (list, tuple)) else [value]
+        errors[str(field)] = [str(item) for item in values]
+    return errors
 
 
 class ActivityViewSet(viewsets.ViewSet):
@@ -25,6 +75,54 @@ class ActivityViewSet(viewsets.ViewSet):
     """
     permission_classes = [IsAuthenticated]
     authentication_classes = [WxJWTAuthentication]
+
+    def handle_exception(self, exc):
+        """Normalize errors from all activity endpoints."""
+        response = super().handle_exception(exc)
+        if isinstance(exc, AuthenticationFailed):
+            raw_message = _first_error(response.data)
+            missing = raw_message == (
+                'Authentication credentials were not provided'
+            )
+            code = 'not_authenticated' if missing else 'invalid_token'
+            message = (
+                '请先登录。' if missing else '登录状态无效或已过期。'
+            )
+        elif isinstance(exc, PermissionDenied):
+            code = 'permission_denied'
+            message = _first_error(response.data) or '无权执行此操作。'
+        elif isinstance(exc, NotFound):
+            code = 'not_found'
+            message = _first_error(response.data) or '请求的内容不存在。'
+        elif isinstance(exc, ValidationError):
+            code = 'validation_error'
+            message = _first_error(response.data) or '请求参数有误。'
+        elif isinstance(exc, Throttled):
+            code = 'throttled'
+            message = _first_error(response.data) or '请求过于频繁。'
+        else:
+            code = (
+                'internal_error'
+                if response.status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR
+                else 'validation_error'
+            )
+            message = _first_error(response.data) or '请求失败。'
+        response.data = {
+            'code': code,
+            'message': message,
+            'errors': _field_errors(response.data),
+        }
+        return response
+
+    @staticmethod
+    def error_response(code, message, status_code, errors=None):
+        """Build a canonical activity API error response."""
+        serializer = ActivityErrorSerializer({
+            'code': code,
+            'message': message,
+            'errors': errors or {},
+        })
+        return Response(serializer.data, status=status_code)
 
     @extend_schema(
         summary="获取活动首页数据",
@@ -97,13 +195,30 @@ class ActivityViewSet(viewsets.ViewSet):
 
     @extend_schema(
         summary="获取活动详情",
-        description="获取指定活动的摘要信息，用于签到页等前端展示。",
+        description=(
+            "获取指定活动的摘要信息，用于签到页等前端展示。"
+        ),
+        parameters=[
+            OpenApiParameter(
+                name='aid',
+                type=int,
+                location=OpenApiParameter.PATH,
+                description='活动 ID',
+            ),
+        ],
         responses={
             200: OpenApiResponse(
                 description="活动详情",
-                response=ActivitySummarySerializer,
+                response=ActivityDetailSerializer,
             ),
-            404: OpenApiResponse(description="活动不存在"),
+            401: OpenApiResponse(
+                description="未登录",
+                response=ActivityErrorSerializer,
+            ),
+            404: OpenApiResponse(
+                description="活动不存在",
+                response=ActivityErrorSerializer,
+            ),
         },
         tags=['活动'],
     )
@@ -118,40 +233,178 @@ class ActivityViewSet(viewsets.ViewSet):
             activity = Activity.objects.select_related('organization_id').get(id=aid)
         except Activity.DoesNotExist:
             raise NotFound("活动不存在")
-        serializer = ActivitySummarySerializer(activity)
+        serializer = ActivityDetailSerializer(
+            activity,
+            context={'request': request},
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        methods=['POST'],
+        summary="报名活动",
+        description="使用当前个人账号报名指定活动。",
+        request=None,
+        parameters=[
+            OpenApiParameter(
+                name='aid',
+                type=int,
+                location=OpenApiParameter.PATH,
+                description='活动 ID',
+            ),
+        ],
+        responses={
+            200: ActivityActionResultSerializer,
+            401: ActivityErrorSerializer,
+            403: ActivityErrorSerializer,
+            404: ActivityErrorSerializer,
+            409: ActivityErrorSerializer,
+        },
+        tags=['活动'],
+    )
+    @extend_schema(
+        methods=['DELETE'],
+        summary="取消活动报名",
+        description="取消当前个人账号对指定活动的报名或申请。",
+        request=None,
+        parameters=[
+            OpenApiParameter(
+                name='aid',
+                type=int,
+                location=OpenApiParameter.PATH,
+                description='活动 ID',
+            ),
+        ],
+        responses={
+            200: ActivityActionResultSerializer,
+            401: ActivityErrorSerializer,
+            403: ActivityErrorSerializer,
+            404: ActivityErrorSerializer,
+            409: ActivityErrorSerializer,
+        },
+        tags=['活动'],
+    )
+    @action(
+        detail=False,
+        methods=['post', 'delete'],
+        url_path=r'(?P<aid>\d+)/signup',
+    )
+    def signup(self, request, aid=None):
+        """Sign up for an activity or withdraw the current signup."""
+        if not request.user.is_person():
+            raise PermissionDenied("请使用个人账号报名活动。")
+        if request.method == 'POST' and not request.user.active:
+            raise PermissionDenied("当前账号状态不允许报名活动。")
+
+        person = get_person_or_org(request.user)
+        try:
+            activity_id = int(aid)
+        except (ValueError, TypeError):
+            raise ValidationError({'aid': '活动 ID 格式错误'})
+
+        with transaction.atomic():
+            try:
+                activity = Activity.objects.select_for_update().get(
+                    id=activity_id,
+                )
+            except Activity.DoesNotExist:
+                raise NotFound("活动不存在")
+
+            if request.method == 'POST':
+                if not activity.need_apply:
+                    return self.error_response(
+                        'conflict',
+                        '该活动无需报名。',
+                        status.HTTP_409_CONFLICT,
+                    )
+                if activity.status != Activity.Status.APPLYING:
+                    return self.error_response(
+                        'conflict',
+                        '活动报名暂未开放或已经截止。',
+                        status.HTTP_409_CONFLICT,
+                    )
+                if (
+                    activity.inner
+                    and not Position.objects.activated().filter(
+                        person=person,
+                        org=activity.organization_id,
+                    ).exists()
+                ):
+                    return self.error_response(
+                        'permission_denied',
+                        f'该活动仅面向{activity.organization_id}内部成员。',
+                        status.HTTP_403_FORBIDDEN,
+                    )
+                try:
+                    participation = apply_activity_for_person(
+                        person,
+                        activity,
+                    )
+                except ActivityException as exc:
+                    return self.error_response(
+                        'conflict',
+                        str(exc),
+                        status.HTTP_409_CONFLICT,
+                    )
+                message = (
+                    '活动申请已提交，请等待报名结果。'
+                    if activity.bidding
+                    else '报名成功。'
+                )
+            else:
+                if activity.status not in [
+                    Activity.Status.APPLYING,
+                    Activity.Status.WAITING,
+                ]:
+                    return self.error_response(
+                        'conflict',
+                        '当前状态不允许取消报名。',
+                        status.HTTP_409_CONFLICT,
+                    )
+                try:
+                    participation = withdraw_activity_for_person(
+                        person,
+                        activity,
+                    )
+                except ActivityException as exc:
+                    return self.error_response(
+                        'conflict',
+                        str(exc),
+                        status.HTTP_409_CONFLICT,
+                    )
+                message = (
+                    '已取消申请。' if activity.bidding else '已取消报名。'
+                )
+
+        serializer = ActivityActionResultSerializer({
+            'message': message,
+            'participation_status': participation.status,
+            'current_participants': activity.current_participants,
+        })
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @extend_schema(
         summary="活动签到",
-        description="对指定活动进行签到。需要个人账号，且已报名该活动。",
-        request={
-            "application/json": {
-                "type": "object",
-                "required": ["aid"],
-                "properties": {
-                    "aid": {"type": "integer", "description": "活动 ID"},
-                },
-            },
-            "application/x-www-form-urlencoded": {
-                "type": "object",
-                "required": ["aid"],
-                "properties": {
-                    "aid": {"type": "integer", "description": "活动 ID"},
-                },
-            },
-        },
+        description=(
+            "对指定活动进行签到。需要个人账号，且已报名该活动。"
+        ),
+        request=ActivityCheckinRequestSerializer,
         responses={
             200: OpenApiResponse(
                 description="签到成功",
-                response={
-                    "type": "object",
-                    "properties": {
-                        "message": {"type": "string", "description": "提示信息"},
-                    },
-                },
+                response=ActivityMessageSerializer,
             ),
-            400: OpenApiResponse(description="请求参数错误或业务校验失败"),
-            403: OpenApiResponse(description="需使用个人账号"),
+            400: OpenApiResponse(
+                description="请求参数错误或业务校验失败",
+                response=ActivityErrorSerializer,
+            ),
+            401: OpenApiResponse(
+                description="未登录",
+                response=ActivityErrorSerializer,
+            ),
+            403: OpenApiResponse(
+                description="需使用个人账号",
+                response=ActivityErrorSerializer,
+            ),
         },
         tags=['活动'],
     )
@@ -161,13 +414,12 @@ class ActivityViewSet(viewsets.ViewSet):
         if not request.user.is_person():
             raise PermissionDenied("请使用个人账号签到")
 
-        aid = request.data.get("aid") or request.query_params.get("aid")
-        if aid is None:
-            raise ValidationError({"aid": "缺少活动 ID"})
-        try:
-            aid = int(aid)
-        except (ValueError, TypeError):
-            raise ValidationError({"aid": "活动 ID 格式错误"})
+        data = request.data.copy()
+        if 'aid' not in data and request.query_params.get('aid') is not None:
+            data['aid'] = request.query_params['aid']
+        request_serializer = ActivityCheckinRequestSerializer(data=data)
+        request_serializer.is_valid(raise_exception=True)
+        aid = request_serializer.validated_data['aid']
 
         person = get_person_or_org(request.user)
         success, message = do_checkin(person, aid)

--- a/app/activity_utils.py
+++ b/app/activity_utils.py
@@ -59,7 +59,6 @@ __all__ = [
     'cancel_activity',
     'withdraw_activity',
     'withdraw_activity_for_person',
-    'can_access_checkin_qrcode',
     'build_legacy_checkin_url',
     'generate_legacy_checkin_qrcode',
     'fetch_miniprogram_checkin_qrcode',
@@ -320,20 +319,6 @@ def notifyActivity(aid: int, msg_type: str, msg=""):
         to_wechat=publish_kws,
     )
     assert success, "批量创建通知并发送时失败"
-
-
-def can_access_checkin_qrcode(activity: Activity, now: datetime | None = None) -> bool:
-    """Return whether the activity's check-in QR codes should be available now."""
-    now = now or datetime.now()
-    if not activity.need_checkin:
-        return False
-    if activity.status not in [
-        Activity.Status.APPLYING,
-        Activity.Status.WAITING,
-        Activity.Status.PROGRESSING,
-    ]:
-        return False
-    return now >= activity.start - timedelta(hours=1)
 
 
 def build_legacy_checkin_url(request, activity: Activity) -> str:

--- a/app/activity_utils.py
+++ b/app/activity_utils.py
@@ -1,7 +1,7 @@
 """
 activity_utils.py
 
-这个文件应该只被 ./activity_views.py, ./scheduler_func.py 依赖
+这个文件只供活动网页视图、活动 API 和调度逻辑复用
 依赖于 ./utils.py, ./wechat_send.py, ./notification_utils.py
 
 scheduler_func 依赖于 wechat_send 依赖于 utils
@@ -55,8 +55,10 @@ __all__ = [
     'accept_activity',
     'reject_activity',
     'apply_activity',
+    'apply_activity_for_person',
     'cancel_activity',
     'withdraw_activity',
+    'withdraw_activity_for_person',
     'can_access_checkin_qrcode',
     'build_legacy_checkin_url',
     'generate_legacy_checkin_qrcode',
@@ -840,20 +842,16 @@ def reject_activity(request, activity):
 
 
 # 调用的时候用 try
-def apply_activity(request, activity: Activity):
-    '''这个函数在正常情况下只应该抛出提示错误信息的ActivityException'''
-    context = dict()
-    context["success"] = False
-
-    payer = Person.objects.get_by_user(request.user)
-
+def apply_activity_for_person(payer: Person, activity: Activity):
+    '''为个人报名活动，仅抛出可向用户展示的 ActivityException。'''
     if activity.inner:
         position = Position.objects.activated().filter(
             person=payer, org=activity.organization_id)
         if len(position) == 0:
             # 按理说这里也是走不到的，前端会限制
             raise ActivityException(
-                f"该活动是{activity.organization_id}内部活动，暂不开放对外报名。")
+                f"该活动是{activity.organization_id}内部活动，"
+                "暂不开放对外报名。")
 
     try:
         participant = Participation.objects.select_for_update().get(
@@ -861,7 +859,7 @@ def apply_activity(request, activity: Activity):
             SQ.sq(Participation.person, payer),
         )
         participated = True
-    except:
+    except Participation.DoesNotExist:
         participated = False
     if participated:
         if (
@@ -870,7 +868,8 @@ def apply_activity(request, activity: Activity):
         ):
             raise ActivityException("您已报名该活动。")
         elif participant.status != Participation.AttendStatus.CANCELED:
-            raise ActivityException(f"您的报名状态异常，当前状态为：{participant.status}")
+            raise ActivityException(
+                f"您的报名状态异常，当前状态为：{participant.status}")
 
     if not activity.bidding:
         if activity.current_participants < activity.capacity:
@@ -892,6 +891,13 @@ def apply_activity(request, activity: Activity):
 
     participant.save()
     activity.save()
+    return participant
+
+
+def apply_activity(request, activity: Activity):
+    '''兼容网页端请求对象的活动报名入口。'''
+    payer = Person.objects.get_by_user(request.user)
+    return apply_activity_for_person(payer, activity)
 
 
 def cancel_activity(request, activity):
@@ -935,19 +941,20 @@ def cancel_activity(request, activity):
     activity.save()
 
 
-def withdraw_activity(request, activity: Activity):
-
-    np = Person.objects.get_by_user(request.user)
-    participant = Participation.objects.select_for_update().get(
-        SQ.sq(Participation.activity, activity),
-        SQ.sq(Participation.person, np),
-        status__in=[
-            Activity.Status.WAITING,
-            Participation.AttendStatus.APPLYING,
-            Participation.AttendStatus.APPLYSUCCESS,
-            Participation.AttendStatus.CANCELED,
-        ],
-    )
+def withdraw_activity_for_person(person: Person, activity: Activity):
+    '''取消个人报名，仅抛出可向用户展示的 ActivityException。'''
+    try:
+        participant = Participation.objects.select_for_update().get(
+            SQ.sq(Participation.activity, activity),
+            SQ.sq(Participation.person, person),
+            status__in=[
+                Participation.AttendStatus.APPLYING,
+                Participation.AttendStatus.APPLYSUCCESS,
+                Participation.AttendStatus.CANCELED,
+            ],
+        )
+    except Participation.DoesNotExist as exc:
+        raise ActivityException("您尚未报名该活动。") from exc
     if participant.status == Participation.AttendStatus.CANCELED:
         raise ActivityException("已退出活动。")
     participant.status = Participation.AttendStatus.CANCELED
@@ -955,6 +962,13 @@ def withdraw_activity(request, activity: Activity):
 
     participant.save()
     activity.save()
+    return participant
+
+
+def withdraw_activity(request, activity: Activity):
+    '''兼容网页端请求对象的取消活动报名入口。'''
+    person = Person.objects.get_by_user(request.user)
+    return withdraw_activity_for_person(person, activity)
 
 
 @transaction.atomic

--- a/app/activity_views.py
+++ b/app/activity_views.py
@@ -30,7 +30,6 @@ from app.activity_utils import (
     apply_activity,
     cancel_activity,
     withdraw_activity,
-    can_access_checkin_qrcode,
     fetch_miniprogram_checkin_qrcode,
     generate_legacy_checkin_qrcode,
     create_participate_infos,
@@ -255,7 +254,6 @@ def viewActivity(request: HttpRequest, aid=None):
 
     # 签到
     need_checkin = activity.need_checkin
-    show_QRcode = can_access_checkin_qrcode(activity)
 
     if activity.inner and request.user.is_person():
         position = Position.objects.activated().filter(
@@ -384,7 +382,7 @@ def getActivityInfo(request: HttpRequest):
             return response  # downloadable
 
     elif info_type == "qrcode":
-        assert can_access_checkin_qrcode(activity), "签到二维码暂不可用"
+        assert activity.need_checkin, "该活动无需签到"
 
         version = request.GET.get("version", "new")
         assert version in ["new", "old"], "不支持的二维码版本"

--- a/app/test/test_activity_qrcode.py
+++ b/app/test/test_activity_qrcode.py
@@ -4,10 +4,7 @@ from unittest.mock import patch
 
 from django.test import RequestFactory, SimpleTestCase, TestCase
 
-from app.activity_utils import (
-    build_legacy_checkin_url,
-    can_access_checkin_qrcode,
-)
+from app.activity_utils import build_legacy_checkin_url
 from app.models import (
     Activity,
     ActivityPhoto,
@@ -19,32 +16,6 @@ from app.models import (
 
 
 class ActivityQrcodeHelperTestCase(SimpleTestCase):
-    def test_can_access_checkin_qrcode_time_window(self):
-        start = datetime.now() + timedelta(hours=1)
-        activity = SimpleNamespace(
-            need_checkin=True,
-            status=Activity.Status.WAITING,
-            start=start,
-        )
-
-        self.assertFalse(
-            can_access_checkin_qrcode(activity, start - timedelta(hours=1, minutes=1))
-        )
-        self.assertTrue(
-            can_access_checkin_qrcode(activity, start - timedelta(hours=1))
-        )
-        self.assertTrue(
-            can_access_checkin_qrcode(activity, start + timedelta(minutes=30))
-        )
-
-    def test_can_access_checkin_qrcode_rejects_end_status(self):
-        activity = SimpleNamespace(
-            need_checkin=True,
-            status=Activity.Status.END,
-            start=datetime.now() - timedelta(hours=2),
-        )
-        self.assertFalse(can_access_checkin_qrcode(activity))
-
     def test_build_legacy_checkin_url_contains_auth(self):
         request = RequestFactory().get("/fake")
         activity = SimpleNamespace(id=42)
@@ -106,8 +77,8 @@ class ActivityQrcodeViewTestCase(TestCase):
         cls.activity = Activity.objects.create(
             title="二维码测试活动",
             organization_id=cls.owner_org,
-            start=datetime.now() + timedelta(minutes=30),
-            end=datetime.now() + timedelta(hours=2),
+            start=datetime.now() + timedelta(hours=2),
+            end=datetime.now() + timedelta(hours=3),
             apply_end=datetime.now() + timedelta(minutes=10),
             location="测试地点",
             introduction="测试简介",

--- a/templates/activity/info.html
+++ b/templates/activity/info.html
@@ -558,7 +558,7 @@
 
             </div>
 
-            {% if introduction or ownership and show_QRcode %}
+            {% if introduction or ownership and need_checkin %}
             <!--  BEGIN RELAVENT INFORMATION  -->
             <div class="col-md-3 col-sm-12 px-1">
 
@@ -586,7 +586,7 @@
                 <!--  END INTRODUCTION  -->
                 {% endif %}
 
-                {% if ownership and show_QRcode %}
+                {% if ownership and need_checkin %}
                 <!--  BEGIN QR CODE  -->
                 <div class="container w-100 px-0 layout-top-spacing">
                     <div class="statbox widget box box-shadow">


### PR DESCRIPTION
## 背景

需求池中的“新生之旅报名与签到”需要让新生之旅系列讲座和太舞徒步分别支持报名、取消报名、现场扫码签到，并保留参与记录。

本 PR 实现通用活动能力；正式活动的时间、地点、人数和介绍继续由后台活动数据配置，不在代码中写死。

## 主要修改

- 活动详情接口返回当前个人的报名/签到状态。
- 新增报名和取消报名接口，复用现有活动业务逻辑。
- 对容量、抽签、内部活动、账号权限、活动状态和重复请求进行校验。
- 完善签到接口校验，无需签到或不符合签到条件的活动会返回明确错误。
- 统一活动 API 的错误响应结构，便于小程序稳定展示错误信息。
- 补充报名、取消报名、并发容量、权限和签到状态转换测试。

## 影响

- 小程序可基于同一套接口展示活动详情、报名状态并完成扫码签到。
- 两项新生之旅活动可以在后台分别创建，自动形成两个独立活动页。
- 没有新增 migration，也没有写入任何正式活动数据。

## 验证

- Django 活动与签到相关测试：38 项通过。
- Django 全量测试：241 项通过。
- `git diff --check` 通过。

