### PR TITLE
Fix: V02-unsafe-get-mutations-verify

### DIFF
--- a/app/activity_utils.py
+++ b/app/activity_utils.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 import qrcode
 import requests
 import utils.models.query as SQ
+from django.utils.crypto import constant_time_compare
 from generic.models import User, YQPointRecord
 from scheduler.adder import ScheduleAdder
 from scheduler.cancel import remove_job
@@ -59,6 +60,8 @@ __all__ = [
     'cancel_activity',
     'withdraw_activity',
     'withdraw_activity_for_person',
+    'checkin_activity',
+    'valid_activity_checkin_verifier',
     'build_legacy_checkin_url',
     'generate_legacy_checkin_qrcode',
     'fetch_miniprogram_checkin_qrcode',
@@ -377,6 +380,83 @@ class ActivityException(Exception):
 
     def __str__(self):
         return self.msg
+
+
+def valid_activity_checkin_verifier(activity_id: int, verifier: str) -> bool:
+    """Return whether a legacy web check-in verifier matches an activity."""
+
+    if not verifier:
+        return False
+    expected = GLOBAL_CONFIG.hasher.encode(str(activity_id))
+    return constant_time_compare(verifier, expected)
+
+
+@transaction.atomic
+def checkin_activity(
+    person: Person,
+    activity_id: int,
+    verifier: str,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Atomically check a registered person into an eligible activity.
+
+    Returns ``True`` when this call changes the participation and ``False``
+    when it was already checked in.  Rejected business preconditions raise
+    ``ActivityException`` without changing state.
+    """
+
+    now = now or datetime.now()
+    try:
+        activity = Activity.objects.select_for_update().get(pk=activity_id)
+    except Activity.DoesNotExist as exc:
+        raise ActivityException("签到失败：活动不存在。") from exc
+
+    try:
+        person = (
+            Person.objects.activated()
+            .select_for_update()
+            .get(pk=person.pk, person_id__active=True)
+        )
+    except Person.DoesNotExist as exc:
+        raise ActivityException("签到失败：个人账号当前不可用。") from exc
+
+    if not valid_activity_checkin_verifier(activity.pk, verifier):
+        raise ActivityException("签到失败：活动校验码不匹配。")
+    if not activity.valid or not activity.need_checkin:
+        raise ActivityException("签到失败：该活动未开放签到。")
+    if activity.status == Activity.Status.END:
+        raise ActivityException("活动已结束，不再开放签到。")
+    if not (
+        activity.status == Activity.Status.PROGRESSING
+        or (
+            activity.status == Activity.Status.WAITING
+            and now + timedelta(hours=1) >= activity.start
+        )
+    ):
+        raise ActivityException("活动开始前一小时开放签到，请耐心等待。")
+
+    participant = (
+        Participation.objects.select_for_update()
+        .filter(
+            activity=activity,
+            person=person,
+            status__in=[
+                Participation.AttendStatus.UNATTENDED,
+                Participation.AttendStatus.APPLYSUCCESS,
+                Participation.AttendStatus.ATTENDED,
+            ],
+        )
+        .first()
+    )
+    if participant is None:
+        raise ActivityException("签到失败：您尚未报名该活动。")
+    if participant.status == Participation.AttendStatus.ATTENDED:
+        return False
+
+    participant.status = Participation.AttendStatus.ATTENDED
+    participant.save(update_fields=["status"])
+    return True
 
 
 # 时间合法性的检查，检查时间是否在当前时间的一个月以内，并且检查开始的时间是否早于结束的时间，

--- a/app/activity_views.py
+++ b/app/activity_views.py
@@ -5,6 +5,10 @@ from typing import Literal
 
 from django.db import transaction
 from django.db.models import F
+from django.http import HttpResponseBadRequest, HttpResponseForbidden
+from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.http import require_http_methods
 import csv
 import json
 
@@ -36,6 +40,8 @@ from app.activity_utils import (
     modify_participants,
     weekly_summary_orgs,
     available_participants,
+    checkin_activity,
+    valid_activity_checkin_verifier,
 )
 from app.comment_utils import addComment, showComment
 from app.utils import (
@@ -395,54 +401,53 @@ def getActivityInfo(request: HttpRequest):
         return HttpResponse(content, content_type=content_type)
 
 
+@csrf_protect
 @login_required(redirect_field_name="origin")
 @utils.check_user_access(redirect_url="/logout/")
+@require_http_methods(["GET", "HEAD", "POST"])
 @logger.secure_view()
 def checkinActivity(request: UserRequest, aid=None):
-    if not request.user.is_person():
-        return redirect(message_url(wrong('签到失败：请使用个人账号签到')))
     try:
-        np = get_person_or_org(request.user)
         aid = int(aid)
-        activity = Activity.objects.get(id=aid)
-        varifier = request.GET["auth"]
-    except:
-        return redirect(message_url(wrong('签到失败!')))
-    if varifier != GLOBAL_CONFIG.hasher.encode(str(aid)):
-        return redirect(message_url(wrong('签到失败：活动校验码不匹配')))
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("签到失败：无效的活动标识。")
+    if not request.user.is_person() or not request.user.active:
+        return HttpResponseForbidden("签到失败：请使用有效的个人账号签到。")
 
-    # context = wrong('发生意外错误')   # 理应在任何情况都生成context, 如果没有就让包装器捕获吧
-    if activity.status == Activity.Status.END:
-        context = wrong("活动已结束，不再开放签到。")
-    elif (
-        activity.status == Activity.Status.PROGRESSING or
-        (activity.status == Activity.Status.WAITING
-         and datetime.now() + timedelta(hours=1) >= activity.start)
-    ):
-        try:
-            with transaction.atomic():
-                participant = Participation.objects.select_for_update().get(
-                    SQ.sq(Participation.activity, activity),
-                    SQ.sq(Participation.person, np),
-                    status__in=[
-                        Participation.AttendStatus.UNATTENDED,
-                        Participation.AttendStatus.APPLYSUCCESS,
-                        Participation.AttendStatus.ATTENDED,
-                    ]
-                )
-                if participant.status == Participation.AttendStatus.ATTENDED:
-                    context = succeed("您已签到，无需重复签到!")
-                else:
-                    participant.status = Participation.AttendStatus.ATTENDED
-                    participant.save()
-                    context = succeed("签到成功!")
-        except:
-            context = wrong("您尚未报名该活动!")
+    try:
+        person = get_person_or_org(request.user, activate=True)
+    except NaturalPerson.DoesNotExist:
+        return HttpResponseForbidden("签到失败：个人资料不可用。")
 
+    if request.method in ("GET", "HEAD"):
+        activity = get_object_or_404(Activity, pk=aid)
+        verifier = request.GET.get("auth", "")
+        if not valid_activity_checkin_verifier(aid, verifier):
+            return HttpResponseBadRequest("签到失败：活动校验码不匹配。")
+        context = {
+            "activity": activity,
+            "auth": verifier,
+            "bar_display": utils.get_sidebar_and_navbar(
+                request.user,
+                navbar_name="活动签到",
+                title_name=activity.title,
+            ),
+        }
+        response = render(request, "activity/checkin_confirm.html", context)
+        response["Cache-Control"] = "no-store"
+        response["Referrer-Policy"] = "no-referrer"
+        return response
+
+    verifier = request.POST.get("auth", "")
+    try:
+        changed = checkin_activity(person, aid, verifier)
+    except ActivityException as exc:
+        return HttpResponseBadRequest(str(exc))
+
+    if changed:
+        context = succeed("签到成功!")
     else:
-        context = wrong("活动开始前一小时开放签到，请耐心等待!")
-
-    # TODO 在 activity_info 里加更多信息
+        context = succeed("您已签到，无需重复签到!")
     return redirect(message_url(context, f"/viewActivity/{aid}"))
 
 

--- a/app/notification_utils.py
+++ b/app/notification_utils.py
@@ -19,10 +19,40 @@ hasher = MySHA256Hasher("")
 
 __all__ = [
     'notification_status_change',
+    'mark_all_notifications_read',
+    'delete_all_read_notifications',
     'notification_create',
     'bulk_notification_create',
     'notification2Display',
 ]
+
+
+def mark_all_notifications_read(
+    receiver: User,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Mark this receiver's unread informational notifications as read."""
+
+    now = now or datetime.now()
+    return Notification.objects.filter(
+        receiver=receiver,
+        typename=Notification.Type.NEEDREAD,
+        status=Notification.Status.UNDONE,
+    ).update(
+        status=Notification.Status.DONE,
+        finish_time=now,
+    )
+
+
+def delete_all_read_notifications(receiver: User) -> int:
+    """Soft-delete this receiver's read informational notifications."""
+
+    return Notification.objects.filter(
+        receiver=receiver,
+        typename=Notification.Type.NEEDREAD,
+        status=Notification.Status.DONE,
+    ).update(status=Notification.Status.DELETE)
 
 
 def get_default_sender() -> User:

--- a/app/test/test_auth_security.py
+++ b/app/test/test_auth_security.py
@@ -2,6 +2,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.middleware.csrf import get_token
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.test import (
@@ -18,6 +19,7 @@ from app.models import (
     OrganizationType,
     Position,
 )
+from app.utils import update_related_account_in_session, user_login_org
 from generic.models import User
 from utils.hasher import MyMD5Hasher
 
@@ -77,6 +79,9 @@ class LegacyMiniLoginRemovalTestCase(TestCase):
         session = client.session
         session["NP"] = self.user.username
         session["Incharge"] = [self.organization.oname]
+        session["InchargeAccounts"] = [
+            {"id": self.organization.pk, "name": self.organization.oname},
+        ]
         session.save()
         return client
 
@@ -155,7 +160,7 @@ class LegacyMiniLoginRemovalTestCase(TestCase):
 
         response = self.client.get(
             "/shiftAccount/",
-            {"oname": self.organization.oname},
+            {"org_id": self.organization.pk},
         )
 
         self.assertEqual(response.status_code, 405)
@@ -164,12 +169,34 @@ class LegacyMiniLoginRemovalTestCase(TestCase):
             str(self.user.pk),
         )
 
+    def test_switch_helper_rejects_safe_http_methods(self):
+        for method in ("get", "head"):
+            with self.subTest(method=method):
+                request = getattr(RequestFactory(), method)("/annual-summary/")
+                SessionMiddleware(lambda req: None).process_request(request)
+                request.user = self.user
+                request.session["NP"] = self.user.username
+
+                switched = update_related_account_in_session(
+                    request,
+                    self.user.username,
+                    shift=True,
+                    org_id=self.organization.pk,
+                )
+
+                self.assertFalse(switched)
+                self.assertNotIn("_auth_user_id", request.session)
+
+                context = user_login_org(request, self.organization)
+                self.assertEqual(context["warn_code"], 1)
+                self.assertNotIn("_auth_user_id", request.session)
+
     def test_account_switch_rejects_post_without_csrf(self):
         client = self.login_person(Client(enforce_csrf_checks=True))
 
         response = client.post(
             "/shiftAccount/",
-            {"oname": self.organization.oname},
+            {"org_id": self.organization.pk},
         )
 
         self.assertEqual(response.status_code, 403)
@@ -181,7 +208,7 @@ class LegacyMiniLoginRemovalTestCase(TestCase):
         response = client.post(
             "/shiftAccount/",
             {
-                "oname": self.organization.oname,
+                "org_id": self.organization.pk,
                 "origin": "/inside",
                 "csrfmiddlewaretoken": token,
             },
@@ -194,26 +221,86 @@ class LegacyMiniLoginRemovalTestCase(TestCase):
             str(self.organization_user.pk),
         )
 
+    def test_account_switch_rejects_invalid_stable_identifier(self):
+        self.login_person()
+
+        response = self.client.post(
+            "/shiftAccount/",
+            {"org_id": "not-an-integer"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(self.client.session["_auth_user_id"], str(self.user.pk))
+
+    def test_account_switch_rechecks_current_admin_position(self):
+        Position.objects.filter(
+            person=self.person,
+            org=self.organization,
+        ).update(is_admin=False)
+        self.login_person()
+
+        response = self.client.post(
+            "/shiftAccount/",
+            {"org_id": self.organization.pk},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.client.session["_auth_user_id"], str(self.user.pk))
+
+    def test_account_switch_rejects_inactive_organization(self):
+        self.organization.status = False
+        self.organization.save(update_fields=["status"])
+        self.login_person()
+
+        response = self.client.post(
+            "/shiftAccount/",
+            {"org_id": self.organization.pk},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.client.session["_auth_user_id"], str(self.user.pk))
+
+    def test_account_switch_rejects_inactive_organization_account(self):
+        self.organization_user.active = False
+        self.organization_user.save(update_fields=["active"])
+        self.login_person()
+
+        response = self.client.post(
+            "/shiftAccount/",
+            {"org_id": self.organization.pk},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.client.session["_auth_user_id"], str(self.user.pk))
+
     def test_sidebars_render_account_switches_as_csrf_post_forms(self):
         user_sidebar = self.render_sidebar(
             "user_left_navbar.html",
-            {"Incharge": [self.organization.oname]},
+            {
+                "Incharge": [self.organization.oname],
+                "InchargeAccounts": [
+                    {"id": self.organization.pk, "name": self.organization.oname},
+                ],
+            },
         )
         organization_sidebar = self.render_sidebar(
             "org_left_navbar.html",
             {
                 "NP": self.user.username,
                 "Incharge": [self.organization.oname],
+                "InchargeAccounts": [
+                    {"id": self.organization.pk, "name": self.organization.oname},
+                ],
             },
         )
 
         self.assertEqual(user_sidebar.count('action="/shiftAccount/"'), 1)
         self.assertEqual(organization_sidebar.count('action="/shiftAccount/"'), 2)
         for sidebar in (user_sidebar, organization_sidebar):
-            self.assertNotIn("/shiftAccount/?oname=", sidebar)
+            self.assertNotIn("/shiftAccount/?", sidebar)
             self.assertIn('method="post"', sidebar)
             self.assertIn('name="csrfmiddlewaretoken"', sidebar)
             self.assertIn(
-                f'name="oname" value="{self.organization.oname}"',
+                f'name="org_id" value="{self.organization.pk}"',
                 sidebar,
             )

--- a/app/test/test_unsafe_get_mutations.py
+++ b/app/test/test_unsafe_get_mutations.py
@@ -1,0 +1,377 @@
+import json
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.test import Client, TestCase
+
+from app.models import (
+    Activity,
+    NaturalPerson,
+    Notification,
+    Organization,
+    OrganizationType,
+    Participation,
+)
+from boot.config import GLOBAL_CONFIG
+from generic.models import User
+
+
+class UnsafeGetMutationTestBase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            "v02-person",
+            "V02 Person",
+            User.Type.PERSON,
+            password="test",
+            is_newuser=False,
+        )
+        cls.person = NaturalPerson.objects.create(cls.user, name="V02 Person")
+        cls.other_user = User.objects.create_user(
+            "v02-other-person",
+            "V02 Other",
+            User.Type.PERSON,
+            password="test",
+            is_newuser=False,
+        )
+        cls.other_person = NaturalPerson.objects.create(
+            cls.other_user,
+            name="V02 Other",
+        )
+        cls.organization_type = OrganizationType.objects.create(
+            otype_id=22002,
+            otype_name="V02 Security Test",
+            incharge=cls.person,
+            job_name_list=["负责人", "成员"],
+        )
+        cls.organization_user = User.objects.create_user(
+            "v02-org",
+            "V02 Org",
+            User.Type.ORG,
+            password="test",
+            is_newuser=False,
+        )
+        cls.organization = Organization.objects.create(
+            organization_id=cls.organization_user,
+            oname="V02 Org",
+            otype=cls.organization_type,
+        )
+
+    def csrf_client(self, path):
+        client = Client(enforce_csrf_checks=True)
+        client.force_login(self.user)
+        response = client.get(path)
+        self.assertEqual(response.status_code, 200)
+        token = client.cookies[settings.CSRF_COOKIE_NAME].value
+        return client, token, response
+
+
+class ActivityCheckinSecurityTestCase(UnsafeGetMutationTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        now = datetime.now()
+        cls.activity = Activity.objects.create(
+            title="V02 Check-in",
+            organization_id=cls.organization,
+            start=now - timedelta(minutes=30),
+            end=now + timedelta(minutes=30),
+            apply_end=now - timedelta(hours=1),
+            location="V02 Room",
+            introduction="Security regression test",
+            need_checkin=True,
+            status=Activity.Status.PROGRESSING,
+            valid=True,
+            examine_teacher=cls.person,
+        )
+        cls.participation = Participation.objects.create(
+            activity=cls.activity,
+            person=cls.person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        cls.verifier = GLOBAL_CONFIG.hasher.encode(str(cls.activity.pk))
+
+    def login(self, *, enforce_csrf_checks=False):
+        client = Client(enforce_csrf_checks=enforce_csrf_checks)
+        client.force_login(self.user)
+        return client
+
+    def test_get_and_head_show_confirmation_without_checking_in(self):
+        client = self.login(enforce_csrf_checks=True)
+        path = f"/checkinActivity/{self.activity.pk}"
+
+        get_response = client.get(path, {"auth": self.verifier})
+        self.participation.refresh_from_db()
+        self.assertEqual(get_response.status_code, 200)
+        self.assertContains(get_response, "确认活动签到")
+        self.assertEqual(get_response["Cache-Control"], "no-store")
+        self.assertEqual(get_response["Referrer-Policy"], "no-referrer")
+        self.assertEqual(
+            self.participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+        head_response = client.head(path, {"auth": self.verifier})
+        self.participation.refresh_from_db()
+        self.assertEqual(head_response.status_code, 200)
+        self.assertEqual(
+            self.participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+    def test_inactive_person_is_rejected_inside_operation(self):
+        path = f"/checkinActivity/{self.activity.pk}"
+        client, token, _ = self.csrf_client(f"{path}?auth={self.verifier}")
+        self.user.active = False
+        self.user.save(update_fields=["active"])
+
+        response = client.post(
+            path,
+            {"auth": self.verifier, "csrfmiddlewaretoken": token},
+        )
+
+        self.participation.refresh_from_db()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            self.participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+    def test_waiting_activity_outside_time_window_is_rejected(self):
+        now = datetime.now()
+        activity = Activity.objects.create(
+            title="V02 Future Check-in",
+            organization_id=self.organization,
+            start=now + timedelta(hours=2),
+            end=now + timedelta(hours=3),
+            apply_end=now + timedelta(hours=1),
+            location="Future Room",
+            introduction="Security regression test",
+            need_checkin=True,
+            status=Activity.Status.WAITING,
+            valid=True,
+            examine_teacher=self.person,
+        )
+        participation = Participation.objects.create(
+            activity=activity,
+            person=self.person,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        verifier = GLOBAL_CONFIG.hasher.encode(str(activity.pk))
+        path = f"/checkinActivity/{activity.pk}"
+        client, token, _ = self.csrf_client(f"{path}?auth={verifier}")
+
+        response = client.post(
+            path,
+            {"auth": verifier, "csrfmiddlewaretoken": token},
+        )
+
+        participation.refresh_from_db()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+    def test_post_without_csrf_is_rejected_without_side_effect(self):
+        client = self.login(enforce_csrf_checks=True)
+
+        response = client.post(
+            f"/checkinActivity/{self.activity.pk}",
+            {"auth": self.verifier},
+        )
+
+        self.participation.refresh_from_db()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            self.participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+    def test_csrf_protected_post_checks_in_and_is_idempotent(self):
+        path = f"/checkinActivity/{self.activity.pk}"
+        client, token, _ = self.csrf_client(f"{path}?auth={self.verifier}")
+
+        for expected_status in (
+            Participation.AttendStatus.ATTENDED,
+            Participation.AttendStatus.ATTENDED,
+        ):
+            response = client.post(
+                path,
+                {
+                    "auth": self.verifier,
+                    "csrfmiddlewaretoken": token,
+                },
+            )
+            self.participation.refresh_from_db()
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(self.participation.status, expected_status)
+
+    def test_wrong_verifier_does_not_check_in(self):
+        path = f"/checkinActivity/{self.activity.pk}"
+        client, token, _ = self.csrf_client(f"{path}?auth={self.verifier}")
+
+        response = client.post(
+            path,
+            {"auth": "wrong", "csrfmiddlewaretoken": token},
+        )
+
+        self.participation.refresh_from_db()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            self.participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+    def test_unregistered_person_is_rejected(self):
+        path = f"/checkinActivity/{self.activity.pk}"
+        client = Client(enforce_csrf_checks=True)
+        client.force_login(self.other_user)
+        response = client.get(path, {"auth": self.verifier})
+        token = client.cookies[settings.CSRF_COOKIE_NAME].value
+
+        response = client.post(
+            path,
+            {"auth": self.verifier, "csrfmiddlewaretoken": token},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.participation.refresh_from_db()
+        self.assertEqual(
+            self.participation.status,
+            Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+
+class NotificationBulkSecurityTestCase(UnsafeGetMutationTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.unread = Notification.objects.create(
+            receiver=cls.user,
+            sender=cls.organization_user,
+            status=Notification.Status.UNDONE,
+            typename=Notification.Type.NEEDREAD,
+            title="Unread",
+            content="Unread test notification",
+        )
+        cls.read = Notification.objects.create(
+            receiver=cls.user,
+            sender=cls.organization_user,
+            status=Notification.Status.DONE,
+            typename=Notification.Type.NEEDREAD,
+            title="Read",
+            content="Read test notification",
+        )
+        cls.action_required = Notification.objects.create(
+            receiver=cls.user,
+            sender=cls.organization_user,
+            status=Notification.Status.UNDONE,
+            typename=Notification.Type.NEEDDO,
+            title="Action required",
+            content="Must not be bulk-read",
+        )
+        cls.other_unread = Notification.objects.create(
+            receiver=cls.other_user,
+            sender=cls.organization_user,
+            status=Notification.Status.UNDONE,
+            typename=Notification.Type.NEEDREAD,
+            title="Other unread",
+            content="Must remain untouched",
+        )
+
+    def login(self, *, enforce_csrf_checks=False):
+        client = Client(enforce_csrf_checks=enforce_csrf_checks)
+        client.force_login(self.user)
+        return client
+
+    def test_get_bulk_commands_have_no_side_effect(self):
+        client = self.login(enforce_csrf_checks=True)
+
+        for action in ("readall", "deleteall"):
+            response = client.get("/notifications/", {"read_name": action})
+            self.assertEqual(response.status_code, 200)
+
+        self.unread.refresh_from_db()
+        self.read.refresh_from_db()
+        self.assertEqual(self.unread.status, Notification.Status.UNDONE)
+        self.assertEqual(self.read.status, Notification.Status.DONE)
+
+    def test_bulk_post_without_csrf_is_rejected(self):
+        client = self.login(enforce_csrf_checks=True)
+
+        response = client.post("/notifications/", {"action": "readall"})
+
+        self.unread.refresh_from_db()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.unread.status, Notification.Status.UNDONE)
+
+    def test_csrf_protected_readall_is_receiver_and_state_scoped(self):
+        client, token, response = self.csrf_client("/notifications/")
+        self.assertNotContains(response, "location.href = '/notifications/")
+        self.assertContains(response, 'method="post"', count=2)
+
+        response = client.post(
+            "/notifications/",
+            {"action": "readall", "csrfmiddlewaretoken": token},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        for notification in (
+            self.unread,
+            self.read,
+            self.action_required,
+            self.other_unread,
+        ):
+            notification.refresh_from_db()
+        self.assertEqual(self.unread.status, Notification.Status.DONE)
+        self.assertEqual(self.read.status, Notification.Status.DONE)
+        self.assertEqual(
+            self.action_required.status,
+            Notification.Status.UNDONE,
+        )
+        self.assertEqual(self.other_unread.status, Notification.Status.UNDONE)
+
+    def test_csrf_protected_deleteall_only_deletes_current_read(self):
+        client, token, _ = self.csrf_client("/notifications/")
+
+        response = client.post(
+            "/notifications/",
+            {"action": "deleteall", "csrfmiddlewaretoken": token},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.read.refresh_from_db()
+        self.unread.refresh_from_db()
+        self.other_unread.refresh_from_db()
+        self.assertEqual(self.read.status, Notification.Status.DELETE)
+        self.assertEqual(self.unread.status, Notification.Status.UNDONE)
+        self.assertEqual(self.other_unread.status, Notification.Status.UNDONE)
+
+    def test_single_notification_json_post_requires_csrf(self):
+        client = self.login(enforce_csrf_checks=True)
+
+        response = client.post(
+            "/notifications/",
+            data=json.dumps({"id": self.unread.pk, "function": "read"}),
+            content_type="text/plain",
+        )
+
+        self.unread.refresh_from_db()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(self.unread.status, Notification.Status.UNDONE)
+
+    def test_single_notification_json_post_accepts_csrf_header(self):
+        client, token, _ = self.csrf_client("/notifications/")
+
+        response = client.post(
+            "/notifications/",
+            data=json.dumps({"id": self.unread.pk, "function": "read"}),
+            content_type="text/plain",
+            HTTP_X_CSRFTOKEN=token,
+        )
+
+        self.unread.refresh_from_db()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["success"])
+        self.assertEqual(self.unread.status, Notification.Status.DONE)

--- a/app/utils.py
+++ b/app/utils.py
@@ -926,36 +926,91 @@ def record_modify_with_session(request: UserRequest, info=""):
         pass
 
 
-def update_related_account_in_session(request, username, shift=False, oname=""):
-    """
-    外层保证 username 是一个自然人的 username 并且合法
+def update_related_account_in_session(
+    request,
+    username,
+    shift=False,
+    org_id=None,
+):
+    """Refresh related accounts and optionally switch the session principal.
 
-    登录时 shift 为 false，切换时为 True，并设置request.user
-    切换到某个组织时 oname 不为空，否则都是空
+    ``username`` identifies the natural-person account saved in the session.
+    ``org_id`` is the stable primary key of a target organization; ``None``
+    selects the natural-person account.  Authorization is always rebuilt from
+    current, active administrator positions before a session switch.
     """
+
+    if shift and request.method != "POST":
+        return False
 
     try:
-        np = NaturalPerson.objects.activated().get(
-            SQ.mq(NaturalPerson.person_id, username=username))
-    except:
+        target_org_id = None if org_id in (None, "") else int(org_id)
+    except (TypeError, ValueError):
         return False
-    orgs = list(Position.objects.activated().filter(
-        is_admin=True, person=np).values_list("org__oname", flat=True))
 
-    if oname:
-        if oname not in orgs:
-            return False
-        orgs.remove(oname)
-        user = Organization.objects.get(oname=oname).get_user()
-    else:
-        user = np.get_user()
+    try:
+        with transaction.atomic():
+            person_user = User.objects.select_for_update().get(
+                username=username,
+                active=True,
+            )
+            if not person_user.is_person():
+                return False
+            person = NaturalPerson.objects.get_by_user(
+                person_user,
+                update=True,
+                activate=True,
+            )
+            positions = list(
+                Position.objects.activated()
+                .select_for_update()
+                .filter(
+                    is_admin=True,
+                    person=person,
+                    org__status=True,
+                    org__organization_id__active=True,
+                )
+                .select_related("org", "org__organization_id")
+                .order_by("pk")
+            )
 
-    if shift:
-        auth.logout(request)
-        auth.login(request, user)
+            accounts = [
+                {"id": position.org_id, "name": position.org.oname}
+                for position in positions
+            ]
+            if target_org_id is None:
+                target_user = person_user
+            else:
+                target_position = next(
+                    (
+                        position
+                        for position in positions
+                        if position.org_id == target_org_id
+                    ),
+                    None,
+                )
+                if target_position is None:
+                    return False
+                target_user = target_position.org.get_user()
+                accounts = [
+                    account
+                    for account in accounts
+                    if account["id"] != target_org_id
+                ]
 
-    request.session["Incharge"] = orgs
-    request.session["NP"] = username
+            if shift:
+                auth.logout(request)
+                auth.login(request, target_user)
+
+            # Keep the historical names for read-only compatibility, while
+            # all new switch commands use stable organization primary keys.
+            request.session["Incharge"] = [
+                account["name"] for account in accounts
+            ]
+            request.session["InchargeAccounts"] = accounts
+            request.session["NP"] = username
+    except (User.DoesNotExist, NaturalPerson.DoesNotExist):
+        return False
 
     return True
 
@@ -963,26 +1018,28 @@ def update_related_account_in_session(request, username, shift=False, oname=""):
 @logger.secure_func(raise_exc=True)
 def user_login_org(request: UserRequest, org: Organization) -> MESSAGECONTEXT:
     '''
-    令人疑惑的函数，需要整改
-    尝试从用户登录到org指定的组织，如果不满足权限，则会返回wrong
-    返回wrong或succeed，并更新request.user
+    尝试从个人账号切换到指定组织。
+
+    只有已通过 CSRF 校验的 POST 调用可以改变 Session；GET 页面应提示用户
+    使用侧栏账户切换表单。实际授权和切换由统一入口再次完成。
     '''
+    if (
+        request.method != "POST"
+        or not getattr(request, "csrf_processing_done", False)
+    ):
+        return wrong("请先通过账户切换菜单切换到对应小组账号。")
+
     user = request.user
     try:
         assert user.is_person()
-        me = NaturalPerson.objects.get_by_user(user, activate=True)
     except:
         return wrong("您没有权限访问该网址！请用对应小组账号登陆。")
-    # 是小组一把手
-    try:
-        position = Position.objects.activated().filter(org=org, person=me)
-        assert len(position) == 1
-        position = position[0]
-        assert position.is_admin
-    except:
+
+    if not update_related_account_in_session(
+        request,
+        user.username,
+        shift=True,
+        org_id=org.pk,
+    ):
         return wrong("没有登录到该小组账户的权限!")
-    # 到这里, 是本人小组并且有权限登录
-    auth.logout(request)
-    auth.login(request, org.get_user())  # 切换到小组账号
-    update_related_account_in_session(request, user.username, oname=org.oname)
     return succeed("成功切换到小组账号处理该事务，建议事务处理完成后退出小组账号。")

--- a/app/views.py
+++ b/app/views.py
@@ -11,6 +11,7 @@ from django.contrib.auth.password_validation import CommonPasswordValidator, Num
 from django.core.exceptions import ValidationError
 
 from django.core.validators import validate_email
+from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_http_methods
 
@@ -56,6 +57,8 @@ from extern.password_reset import (
     queue_prepared_password_reset_wechat,
 )
 from app.notification_utils import (
+    delete_all_read_notifications,
+    mark_all_notifications_read,
     notification_status_change,
     notification2Display,
 )
@@ -79,6 +82,7 @@ from semester.api import current_semester
 
 @csrf_protect
 @login_required(redirect_field_name="origin")
+@utils.check_user_access(redirect_url="/logout/")
 @require_POST
 @logger.secure_view()
 def shiftAccount(request: HttpRequest):
@@ -88,11 +92,20 @@ def shiftAccount(request: HttpRequest):
     if not username:
         return redirect(message_url(wrong('没有可切换的账户信息，请重新登录!')))
 
-    oname = request.POST.get("oname", "")
+    org_id = request.POST.get("org_id")
+    if org_id not in (None, ""):
+        try:
+            org_id = int(org_id)
+        except (TypeError, ValueError):
+            return HttpResponseBadRequest("无效的小组标识。")
 
-    # 不一定更新成功，但无所谓
-    update_related_account_in_session(
-        request, username, shift=True, oname=oname)
+    if not update_related_account_in_session(
+        request,
+        username,
+        shift=True,
+        org_id=org_id,
+    ):
+        return HttpResponseForbidden("没有切换到该账户的权限。")
 
     origin = safe_local_redirect_target(
         request, request.POST.get("origin"), "/welcome/"
@@ -597,7 +610,7 @@ def requestLoginOrg(request: UserRequest):
     auth.logout(request)
     auth.login(request, org.get_user())  # 切换到小组账号
     update_related_account_in_session(
-        request, request.user.username, oname=org.oname)
+        request, request.user.username, org_id=org.pk)
     return redirect(message_url(succeed(f'成功切换到{org}的账号!'), '/orginfo/'))
 
 
@@ -1669,57 +1682,60 @@ def saveSubscribeStatus(request: UserRequest):
     return JsonResponse({"success": True})
 
 
+@csrf_protect
 @login_required(redirect_field_name="origin")
 @utils.check_user_access(redirect_url="/logout/")
+@require_http_methods(["GET", "HEAD", "POST"])
 @logger.secure_view()
 def notifications(request: HttpRequest):
     html_display = {}
 
-    # 处理GET一键阅读或错误信息
-    if request.method == "GET" and request.GET:
-        get_name = request.GET.get("read_name", None)
-        if get_name == "readall":
-            notificaiton_set = Notification.objects.activated().filter(
-                receiver=request.user,
-                typename=Notification.Type.NEEDREAD,
-                status=Notification.Status.UNDONE)
-            count = notificaiton_set.count()
-            notificaiton_set.update(
-                status=Notification.Status.DONE, finish_time=datetime.now())
-            succeed(f"成功将{count}条通知设为已读！", html_display)
-        elif get_name == "deleteall":
-            notificaiton_set = Notification.objects.activated().filter(
-                receiver=request.user,
-                typename=Notification.Type.NEEDREAD,
-                status=Notification.Status.DONE)
-            count = notificaiton_set.count()
-            notificaiton_set.update(status=Notification.Status.DELETE)
-            succeed(f"您已成功删除{count}条通知！", html_display)
-        else:
-            # 读取外部错误信息
+    if request.method in ("GET", "HEAD"):
+        # GET parameters may carry display messages, but never commands.
+        if request.GET:
             my_messages.transfer_message_context(request.GET, html_display)
-
-    # 接下来处理POST相关的内容
-    elif request.method == "POST":
-        # 发生了通知处理的事件
-        try:
-            post_args = json.loads(request.body.decode("utf-8"))
-            notification_id = int(post_args['id'])
-            Notification.objects.activated().get(id=notification_id, receiver=request.user)
-        except:
-            wrong("请不要恶意发送post请求！！", html_display)
-            return JsonResponse({"success": False})
-        try:
-            if "cancel" in post_args['function']:
-                context = notification_status_change(
-                    notification_id, Notification.Status.DELETE)
-            else:
-                context = notification_status_change(notification_id)
-            my_messages.transfer_message_context(
-                context, html_display, normalize=False)
-        except:
-            wrong("删除通知的过程出现错误！请联系管理员。", html_display)
-        return JsonResponse({"success": my_messages.get_warning(html_display)[0] == SUCCEED})
+    else:
+        action = request.POST.get("action")
+        if action == "readall":
+            count = mark_all_notifications_read(request.user)
+            succeed(f"成功将{count}条通知设为已读！", html_display)
+        elif action == "deleteall":
+            count = delete_all_read_notifications(request.user)
+            succeed(f"您已成功删除{count}条通知！", html_display)
+        elif action:
+            return HttpResponseBadRequest("无效的通知批量操作。")
+        else:
+            # Preserve the legacy single-notification AJAX response shape.
+            try:
+                post_args = json.loads(request.body.decode("utf-8"))
+                notification_id = int(post_args['id'])
+                notification = Notification.objects.activated().get(
+                    id=notification_id,
+                    receiver=request.user,
+                )
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError,
+                    Notification.DoesNotExist, UnicodeDecodeError):
+                wrong("无效的通知操作。", html_display)
+                return JsonResponse({"success": False}, status=400)
+            try:
+                if "cancel" in post_args['function']:
+                    context = notification_status_change(
+                        notification,
+                        Notification.Status.DELETE,
+                    )
+                else:
+                    context = notification_status_change(notification)
+                my_messages.transfer_message_context(
+                    context,
+                    html_display,
+                    normalize=False,
+                )
+            except (KeyError, TypeError):
+                wrong("无效的通知操作。", html_display)
+                return JsonResponse({"success": False}, status=400)
+            return JsonResponse({
+                "success": my_messages.get_warning(html_display)[0] == SUCCEED,
+            })
 
     done_notifications = Notification.objects.activated().filter(
         receiver=request.user,
@@ -1734,4 +1750,9 @@ def notifications(request: HttpRequest):
     # 新版侧边栏, 顶栏等的呈现，采用 bar_display, 必须放在render前最后一步
     bar_display = utils.get_sidebar_and_navbar(request.user,
                                                navbar_name="通知信箱")
-    return render(request, "notifications.html", locals())
+    context = {
+        "html_display": html_display,
+        "notes_list": notes_list,
+        "bar_display": bar_display,
+    }
+    return render(request, "notifications.html", context)

--- a/templates/activity/checkin_confirm.html
+++ b/templates/activity/checkin_confirm.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block mainpage %}
+<div id="content" class="main-content">
+    <div class="container">
+        <div class="row layout-top-spacing justify-content-center">
+            <div class="col-lg-8 col-12">
+                <div class="widget-content widget-content-area text-center p-4">
+                    <h3>确认活动签到</h3>
+                    <p class="mt-3">活动：{{ activity.title }}</p>
+                    <p>地点：{{ activity.location }}</p>
+                    <p>时间：{{ activity.start }} 至 {{ activity.end }}</p>
+                    <form method="post" action="{% url 'checkinActivity' activity.id %}">
+                        {% csrf_token %}
+                        <input type="hidden" name="auth" value="{{ auth }}">
+                        <button type="submit" class="btn btn-primary">确认签到</button>
+                        <a class="btn btn-light" href="{% url 'viewActivity' activity.id %}">取消</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -33,10 +33,18 @@
                                         <h5><i class="fa fa-ellipsis-h"></i></h5>
                                     </a>
                                     <div class="dropdown-menu" style="max-width: 200%; max-height: 300%;">
-                                         <button class="dropdown-item"
-                                         onclick="if(confirm('你确定要将全部消息标为已读吗?')){location.href = '/notifications/?read_name=readall';}" >全部已读</button>
-                                        <button class="dropdown-item"
-                                         onclick="if(confirm('你确定删除所有消息吗?')){location.href = '/notifications/?read_name=deleteall';}" >全部删除</button>
+                                        <form method="post" action="{% url 'notifications' %}"
+                                              onsubmit="return confirm('你确定要将全部消息标为已读吗?');">
+                                            {% csrf_token %}
+                                            <input type="hidden" name="action" value="readall">
+                                            <button type="submit" class="dropdown-item">全部已读</button>
+                                        </form>
+                                        <form method="post" action="{% url 'notifications' %}"
+                                              onsubmit="return confirm('你确定删除所有消息吗?');">
+                                            {% csrf_token %}
+                                            <input type="hidden" name="action" value="deleteall">
+                                            <button type="submit" class="dropdown-item">全部删除</button>
+                                        </form>
                                     </div>
                                     </div>
                                 </div>
@@ -284,7 +292,12 @@
     }
     async function save_read(func) {
         const { success } = await fetch(`/notifications/`, {
-            headers: { "Content-Type": `text/plain` },
+            headers: {
+                "Content-Type": `text/plain`,
+                "X-CSRFToken": document.querySelector(
+                    'input[name="csrfmiddlewaretoken"]'
+                ).value,
+            },
             method: `POST`,
             body: JSON.stringify({ id: this.id, function: func}),
         })

--- a/templates/org_left_navbar.html
+++ b/templates/org_left_navbar.html
@@ -236,14 +236,14 @@
                             </li>
                             {% endif %}
                             {% if request.session.Incharge %}
-                            {% for oname in request.session.Incharge %}
+                            {% for account in request.session.InchargeAccounts %}
                             <li>
                                 <form method="post" action="{% url 'shiftAccount' %}"
                                       class="account-switch-form">
                                     {% csrf_token %}
-                                    <input type="hidden" name="oname" value="{{ oname }}">
+                                    <input type="hidden" name="org_id" value="{{ account.id }}">
                                     <button type="submit" class="account-switch-button">
-                                        {{ oname }}
+                                        {{ account.name }}
                                     </button>
                                 </form>
                             </li>

--- a/templates/user_left_navbar.html
+++ b/templates/user_left_navbar.html
@@ -320,14 +320,14 @@
                     </div>
                 </a>
                 <ul class="collapse submenu list-unstyled" id="dashboard2" data-parent="#accordionExample">
-                    {% for oname in request.session.Incharge %}
+                    {% for account in request.session.InchargeAccounts %}
                     <li>
                         <form method="post" action="{% url 'shiftAccount' %}"
                               class="account-switch-form">
                             {% csrf_token %}
-                            <input type="hidden" name="oname" value="{{ oname }}">
+                            <input type="hidden" name="org_id" value="{{ account.id }}">
                             <button type="submit" class="account-switch-button">
-                                {{ oname }}
+                                {{ account.name }}
                             </button>
                         </form>
                     </li>


### PR DESCRIPTION
## V02 修复说明

已修复 GET/HEAD 触发身份切换、活动签到和通知批量变更的问题：

- 身份切换仅接受受 CSRF 保护的 POST，使用组织主键，并在切换前重新校验有效个人账号、管理员职位、组织状态及组织账号状态；失败不会改变当前 Session。
- 活动签到的 GET/HEAD 仅展示确认页，实际签到必须通过 CSRF POST；事务内锁定并复核活动、个人和报名记录，重复签到保持幂等。
- 通知 `readall`/`deleteall` 已改为 CSRF POST，更新范围严格限定为当前接收者及合法源状态；单条通知 AJAX 操作也已补充 CSRF。
- 身份切换辅助函数已禁止 GET/HEAD 改变 Session，覆盖其他间接调用路径。
- 已更新相关模板并新增安全回归测试。

验证结果：

- 定向安全测试：30 项通过
- 完整 Django 测试：458 项通过
- `manage.py check`、迁移检查、Python 编译检查及 `git diff --check` 均通过
- 修复后 review 未发现未解决的阻断性或高风险问题

兼容性说明：旧版签到二维码仍可导航至带校验值的确认页面，但 GET/HEAD 已无业务副作用，页面设置了 `no-store` 和 `no-referrer`，真正签到只会在用户确认后的 CSRF POST 中发生。