### PR TITLE
fix(course): 同步补选及成员申请学生至课程活动名单

### DIFF
--- a/app/activity_utils.py
+++ b/app/activity_utils.py
@@ -927,8 +927,12 @@ def cancel_activity(request, activity):
     activity.save()
 
 
+@transaction.atomic
 def withdraw_activity_for_person(person: Person, activity: Activity):
-    '''取消个人报名，仅抛出可向用户展示的 ActivityException。'''
+    '''按 Activity -> Participation 锁定；业务拒绝抛出 ActivityException。'''
+    # 此操作不再获取 Course 或学生锁，兼容课程退选的锁顺序。
+    caller_activity = activity
+    activity = Activity.objects.select_for_update().get(pk=activity.pk)
     try:
         participant = Participation.objects.select_for_update().get(
             SQ.sq(Participation.activity, activity),
@@ -946,8 +950,10 @@ def withdraw_activity_for_person(person: Person, activity: Activity):
     participant.status = Participation.AttendStatus.CANCELED
     activity.current_participants -= 1
 
-    participant.save()
-    activity.save()
+    participant.save(update_fields=["status"])
+    activity.save(update_fields=["current_participants"])
+    # 保留调用方用传入对象构造响应的接口约定。
+    caller_activity.current_participants = activity.current_participants
     return participant
 
 

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -559,10 +559,60 @@ def _add_student_to_future_course_activities(
     return created_activities
 
 
+def _remove_student_from_future_course_activities(
+        course: Course, student: NaturalPerson,
+        now: datetime) -> int:
+    """将补退选学生移出未来自动报名的课程活动。"""
+    participation_activity_ids = Participation.objects.filter(
+        person=student,
+        status__in=[
+            Participation.AttendStatus.APPLYSUCCESS,
+            Participation.AttendStatus.CANCELED,
+        ],
+    ).values("activity_id")
+    activities = list(
+        Activity.objects.select_for_update().filter(
+            pk__in=participation_activity_ids,
+            organization_id=course.organization,
+            category=Activity.ActivityCategory.COURSE,
+            need_apply=False,
+            start__gt=now,
+            status__in=[
+                Activity.Status.UNPUBLISHED,
+                Activity.Status.WAITING,
+            ],
+        ).order_by("pk")
+    )
+    removed = 0
+    for activity in activities:
+        participation = Participation.objects.filter(
+            activity=activity,
+            person=student,
+            status__in=[
+                Participation.AttendStatus.APPLYSUCCESS,
+                Participation.AttendStatus.CANCELED,
+            ],
+        ).first()
+        if participation is None:
+            continue
+        if participation.status == Participation.AttendStatus.APPLYSUCCESS:
+            activity.current_participants -= 1
+        participation.delete()
+        # 自动报名课程活动的 capacity 表示名单人数。
+        activity.capacity -= 1
+        activity.save(update_fields=["current_participants", "capacity"])
+        removed += 1
+    return removed
+
+
 def _notify_student_of_nearest_course_activity(
         student: NaturalPerson,
         activities: list[Activity]) -> None:
-    """向补选学生补发最近一场未开始课程活动的通知。"""
+    """向补选学生补发最近一场已发布、未开始课程活动的通知。"""
+    activities = [
+        activity for activity in activities
+        if activity.status == Activity.Status.WAITING
+    ]
     if not activities:
         return
     activity = min(activities, key=lambda item: (item.start, item.pk))
@@ -758,6 +808,9 @@ def registration_status_change(course_id: int, user: NaturalPerson,
     try:
         with transaction.atomic():
             if to_status == CourseParticipant.Status.UNSELECT:
+                if course_status == Course.Status.STAGE2:
+                    _remove_student_from_future_course_activities(
+                        course, user, now)
                 Course.objects.filter(id=course_id).select_for_update().update(
                     current_participants=F("current_participants") - 1)
                 CourseParticipant.objects.filter(course_id=course_id,

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -16,6 +16,7 @@ from app.utils_dependency import *
 from app.models import (
     User,
     NaturalPerson,
+    Organization,
     Activity,
     Notification,
     ActivityPhoto,
@@ -41,7 +42,11 @@ from app.activity_utils import (
     notifyActivity,
     create_participate_infos,
 )
-from app.extern.wechat import WechatApp, WechatMessageLevel
+from app.extern.wechat import (
+    WechatApp,
+    WechatMessageLevel,
+    publish_notification,
+)
 from app.log import logger
 
 import openpyxl
@@ -68,6 +73,7 @@ __all__ = [
     'modify_course_activity',
     'cancel_course_activity',
     'registration_status_change',
+    'sync_course_member_to_future_activities',
     'course_to_display',
     'change_course_status',
     'course_base_check',
@@ -171,7 +177,9 @@ def create_single_course_activity(request: HttpRequest) -> Tuple[int, bool]:
 
     # 获取组织和课程
     org = get_person_or_org(request.user, UTYPE_ORG)
-    course = Course.objects.activated().get(organization=org)
+    # 与补选名单同步共用课程行锁，避免并发生成不完整的名单快照。
+    course = Course.objects.activated().select_for_update().get(
+        organization=org)
 
     # 查找是否有类似活动存在
     old_ones = Activity.objects.activated().filter(
@@ -512,6 +520,90 @@ def registration_status_check(course_status: Course.Status,
                     and to_status == CourseParticipant.Status.SUCCESS))
 
 
+def _add_student_to_future_course_activities(
+        course: Course, student: NaturalPerson,
+        now: datetime) -> list[Activity]:
+    """将补选成功的学生加入未来自动报名的课程活动。
+
+    调用方必须持有 ``course`` 的行锁。创建课程活动时会在读取课程名单前
+    获取同一把锁，从而避免在查询已有活动与更新选课记录之间并发创建活动。
+    """
+    activities = list(
+        Activity.objects.select_for_update().filter(
+            organization_id=course.organization,
+            category=Activity.ActivityCategory.COURSE,
+            need_apply=False,
+            start__gt=now,
+            status__in=[
+                Activity.Status.UNPUBLISHED,
+                Activity.Status.WAITING,
+            ],
+        ).order_by("pk")
+    )
+    created_activities = []
+    for activity in activities:
+        if Participation.objects.filter(
+                activity=activity, person=student).exists():
+            continue
+        Participation.objects.create(
+            activity=activity,
+            person=student,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+        activity.current_participants += 1
+        # 自动报名的课程活动目前使用 capacity 表示名单人数。
+        activity.capacity = max(
+            activity.capacity, activity.current_participants)
+        activity.save(update_fields=["current_participants", "capacity"])
+        created_activities.append(activity)
+    return created_activities
+
+
+def _notify_student_of_nearest_course_activity(
+        student: NaturalPerson,
+        activities: list[Activity]) -> None:
+    """向补选学生补发最近一场未开始课程活动的通知。"""
+    if not activities:
+        return
+    activity = min(activities, key=lambda item: (item.start, item.pk))
+    content = f"课程{activity.organization_id.oname}发布了新的课程活动。"
+    content += f"\n开始时间: {activity.start.strftime('%Y-%m-%d %H:%M')}"
+    content += f"\n活动地点: {activity.location}"
+    notification = notification_create(
+        receiver=student.get_user(),
+        sender=activity.organization_id.get_user(),
+        typename=Notification.Type.NEEDREAD,
+        title=activity.title,
+        content=content,
+        URL=f"/viewActivity/{activity.id}",
+        relate_instance=activity,
+    )
+    transaction.on_commit(
+        lambda notification_id=notification.id: publish_notification(
+            notification_id, app=WechatApp.TO_PARTICIPANT))
+
+
+@transaction.atomic
+def sync_course_member_to_future_activities(
+        organization: Organization, student: NaturalPerson,
+        now: datetime | None = None) -> int:
+    """将新加入课程组织的成员同步到未来自动报名的课程活动。"""
+    if now is None:
+        now = datetime.now()
+    courses = list(
+        Course.objects.activated().select_for_update().filter(
+            organization=organization,
+            status=Course.Status.SELECT_END,
+        ).order_by("pk")
+    )
+    created_activities = []
+    for course in courses:
+        created_activities.extend(
+            _add_student_to_future_course_activities(course, student, now))
+    _notify_student_of_nearest_course_activity(student, created_activities)
+    return len(created_activities)
+
+
 def check_course_time_conflict(current_course: Course,
                                user: NaturalPerson) -> Tuple[bool, str]:
     """
@@ -600,13 +692,14 @@ def registration_status_change(course_id: int, user: NaturalPerson,
     :rtype: MESSAGECONTEXT
     """
     context = wrong("在修改选课状态的过程中发生错误，请联系管理员！")
+    now = datetime.now()
 
     # 如果不把 user 锁起来，前面做的检查到后面更新数据库时可能已经无效了，会让用户选上超过6门或者时间冲突的课。
     # 最后get是为了强制对QuerySet求值，起到上锁的效果
     NaturalPerson.objects.select_for_update().get(id=user.id)
 
-    # 在外部保证课程ID是存在的
-    course = Course.objects.get(id=course_id)
+    # 锁定课程状态和名额；课程活动创建也使用同一把锁，避免名单快照竞态。
+    course = Course.objects.select_for_update().get(id=course_id)
     course_status = course.status
 
     if (course_status != Course.Status.STAGE1
@@ -637,9 +730,6 @@ def registration_status_change(course_id: int, user: NaturalPerson,
         if is_conflict:
             return wrong(message)
             # return wrong(f'与{is_conflict}门已选课程时间冲突: {message}')
-
-        # 解锁成就-首次报名书院课程
-        unlock_achievement(user, '首次报名书院课程')
 
     else:
         # action为取消预选或退选
@@ -675,7 +765,6 @@ def registration_status_change(course_id: int, user: NaturalPerson,
                 succeed("成功取消选课！", context)
             else:
                 # 处理并发问题
-                course = Course.objects.select_for_update().get(id=course_id)
                 if (course_status == Course.Status.STAGE2
                         and course.current_participants >= course.capacity):
                     wrong("选课人数已满！", context)
@@ -688,6 +777,13 @@ def registration_status_change(course_id: int, user: NaturalPerson,
                         person = user,
                         defaults = {"status": to_status}
                     )
+                    if course_status == Course.Status.STAGE2:
+                        created_activities = _add_student_to_future_course_activities(
+                            course, user, now)
+                        _notify_student_of_nearest_course_activity(
+                            user, created_activities)
+                    # 只有选课及活动名单同步全部成功后才解锁成就。
+                    unlock_achievement(user, '首次报名书院课程')
                     succeed("选课成功！", context)
     except:
         return context
@@ -920,10 +1016,12 @@ def change_course_status(cur_status: Course.Status, to_status: Course.Status) ->
             raise AssertionError("选课已经结束，不能再变化状态")
     else:
         raise AssertionError("未提供当前状态，不允许进行选课状态修改")
-    courses = Course.objects.activated().filter(status=cur_status)
-    if to_status == Course.Status.SELECT_END:
-        courses = courses.select_related('organization')
     with transaction.atomic():
+        # 在读取选课名单前锁定课程，避免阶段结束与最后一刻补选交错，
+        # 导致学生已有选课和活动参与记录却没有课程 Position。
+        courses = Course.objects.activated().select_for_update().filter(
+            status=cur_status).order_by("pk")
+        courses = list(courses)
         for course in courses:
             if to_status == Course.Status.SELECT_END:
                 # 选课结束，将选课成功的同学批量加入小组
@@ -955,8 +1053,9 @@ def change_course_status(cur_status: Course.Status, to_status: Course.Status) ->
                 if positions:
                     with transaction.atomic():
                         Position.objects.bulk_create(positions)
-        # 更新目标状态
-        courses.select_for_update().update(status=to_status)
+        # 课程行仍由当前事务持锁，完成名单转换后再更新目标状态。
+        Course.objects.filter(pk__in=[course.pk for course in courses]).update(
+            status=to_status)
 
 
 @logger.secure_func()

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -413,6 +413,9 @@ def cancel_course_activity(request: HttpRequest, activity: Activity, cancel_all:
     """
     取消课程活动，是cancel_activity的简化版，在聚合页面被调用
 
+    调用方须在同一事务内按 Course -> CourseTime -> Activity 锁定长期活动，
+    避免取消时段与编辑时段反向加锁；单次活动只需锁定 Activity。
+
     在聚合页面中，应确保activity是课程活动，并且应检查activity.status，
     如果不是WAITING或PROGRESSING，不应调用本函数
 
@@ -468,7 +471,7 @@ def cancel_course_activity(request: HttpRequest, activity: Activity, cancel_all:
     if cancel_all:
         # 设置结束 若cur_week >= end_week 则每周定时任务无需执行
         activity.course_time.end_week = activity.course_time.cur_week
-        activity.course_time.save()
+        activity.course_time.save(update_fields=["end_week"])
 
 
 def remaining_willingness_point(user: NaturalPerson) -> int:

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -20,6 +20,9 @@ remaining_willingness_point（暂不启用）: 计算学生剩余的意愿点数
 process_time: 把datetime对象转换成人类可读的时间表示
 check_course_time_conflict: 检查当前选择的课是否与已选的课上课时间冲突
 """
+from functools import partial
+
+from django.core.exceptions import PermissionDenied
 from app.utils_dependency import *
 from app.models import (
     User,
@@ -78,6 +81,7 @@ __all__ = [
     'check_ac_time_course',
     'course_activity_base_check',
     'create_single_course_activity',
+    'lock_course_activity',
     'modify_course_activity',
     'cancel_course_activity',
     'registration_status_change',
@@ -171,10 +175,12 @@ def course_activity_base_check(request: HttpRequest) -> dict:
     return context
 
 
+@transaction.atomic
 def create_single_course_activity(request: HttpRequest) -> Tuple[int, bool]:
     """
     创建单次课程活动，是create_activity的简化版
     错误提示通过AssertionError抛出
+    函数自身建立事务，先锁课程；调度及微信发送在提交后执行。
 
     :param request: 发起单次课程活动的请求
     :type request: HttpRequest
@@ -257,26 +263,30 @@ def create_single_course_activity(request: HttpRequest) -> Tuple[int, bool]:
         activity.capacity = len(person_pos)
         activity.save()
 
-    # 在活动发布时通知参与成员,创建定时任务并修改活动状态
-    if activity.need_apply:
-        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.APPLYING}",
-                      run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.APPLYING)  # OK
-        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
-                      run_time=activity.start - timedelta(hours=1))(activity.id, Activity.Status.APPLYING, Activity.Status.WAITING)  # OK
-    else:
-        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
-                      run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.WAITING)  # OK
+    def schedule_activity():
+        # 在活动发布时通知参与成员,创建定时任务并修改活动状态
+        if activity.need_apply:
+            ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.APPLYING}",
+                          run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.APPLYING)  # OK
+            ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
+                          run_time=activity.start - timedelta(hours=1))(activity.id, Activity.Status.APPLYING, Activity.Status.WAITING)  # OK
+        else:
+            ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
+                          run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.WAITING)  # OK
 
-    ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_newCourseActivity",
-                  run_time=activity.publish_time)(activity.id, "newCourseActivity")  # OK
+        ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_newCourseActivity",
+                      run_time=activity.publish_time)(activity.id, "newCourseActivity")  # OK
 
-    # 引入定时任务：提前15min提醒、活动状态由WAITING变PROGRESSING再变END
-    ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_remind",
-                  run_time=activity.start - timedelta(minutes=15))(activity.id, "remind")  # OK
-    ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.PROGRESSING}",
-                  run_time=activity.start)(activity.id, Activity.Status.WAITING, Activity.Status.PROGRESSING)
-    ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.END}",
-                  run_time=activity.end)(activity.id, Activity.Status.PROGRESSING, Activity.Status.END)
+        # 引入定时任务：提前15min提醒、活动状态由WAITING变PROGRESSING再变END
+        ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_remind",
+                      run_time=activity.start - timedelta(minutes=15))(activity.id, "remind")  # OK
+        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.PROGRESSING}",
+                      run_time=activity.start)(activity.id, Activity.Status.WAITING, Activity.Status.PROGRESSING)
+        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.END}",
+                      run_time=activity.end)(activity.id, Activity.Status.PROGRESSING, Activity.Status.END)
+
+    transaction.on_commit(schedule_activity)
+
     activity.save()
 
     # 设置活动照片
@@ -284,7 +294,7 @@ def create_single_course_activity(request: HttpRequest) -> Tuple[int, bool]:
         image=image, type=ActivityPhoto.PhotoType.ANNOUNCE, activity=activity)
 
     # 通知审核老师
-    notification_create(
+    notification = notification_create(
         receiver=examine_teacher.person_id,
         sender=request.user,
         typename=Notification.Type.NEEDDO,
@@ -292,28 +302,58 @@ def create_single_course_activity(request: HttpRequest) -> Tuple[int, bool]:
         content="您有一个单次课程活动待审批",
         URL=f"/examineActivity/{activity.id}",
         relate_instance=activity,
-        to_wechat=dict(app=WechatApp.AUDIT),
     )
+    transaction.on_commit(partial(
+        publish_notification, notification.pk, app=WechatApp.AUDIT))
 
     return activity.id, True
 
 
+def lock_course_activity(activity: Activity, organization: Organization) -> Activity:
+    """在调用方事务内按 Course -> CourseTime -> Activity 锁定并检查归属。
+
+    锁前的 activity 仅用于定位。编辑和取消长期活动共用此顺序，避免
+    一方持有 Activity 等待 CourseTime，而另一方反向等待。
+    """
+    course_time_id = activity.course_time_id
+    if course_time_id is not None:
+        course_id = CourseTime.objects.values_list(
+            "course_id", flat=True).get(pk=course_time_id)
+        course = Course.objects.select_for_update().get(pk=course_id)
+        if course.organization_id != organization.pk:
+            raise PermissionDenied("无法修改其他课程小组的课程!")
+        course_time = CourseTime.objects.select_for_update().get(pk=course_time_id)
+        if course_time.course_id != course.pk:
+            raise ValueError("课程时段已变更，请刷新后重试。")
+    locked_activity = Activity.objects.select_for_update().get(pk=activity.pk)
+    if locked_activity.organization_id_id != organization.pk:
+        raise PermissionDenied("无法修改其他课程小组的活动!")
+    if (locked_activity.course_time_id != course_time_id
+            or locked_activity.category != Activity.ActivityCategory.COURSE):
+        raise ValueError("课程活动已变更，请刷新后重试。")
+    return locked_activity
+
+
+@transaction.atomic
 def modify_course_activity(request: HttpRequest, activity: Activity):
     """
     修改单次课程活动信息，是modify_activity的简化版
     错误提示通过AssertionError抛出
 
-    调用方须在同一事务内锁定 Activity；长期活动须先按
-    Course -> CourseTime -> Activity 顺序锁定，并重新检查归属及状态。
+    本函数在事务内按 Course -> CourseTime -> Activity 锁定并检查归属。
+    调用方若已持锁，必须遵循同样的顺序。
 
     :param request: 修改单次课程活动的请求
     :type request: HttpRequest
     :param activity: 待修改的活动
     :type activity: Activity
     """
+    activity = lock_course_activity(
+        activity, get_person_or_org(request.user, UTYPE_ORG))
+
     # 课程活动仅在待发布状态下可以修改
-    assert activity.status == Activity.Status.UNPUBLISHED, \
-        "课程活动只有在待发布状态才能修改。"
+    if activity.status != Activity.Status.UNPUBLISHED:
+        raise ValueError("课程活动只有在待发布状态才能修改。")
 
     context = course_activity_base_check(request)
 
@@ -382,39 +422,43 @@ def modify_course_activity(request: HttpRequest, activity: Activity):
     #     to_participants.append(
     #         f"活动开始时间调整为{activity.start.strftime('%Y-%m-%d %H:%M')}")
 
-    # 更新定时任务
-    if old_need_apply:
-        # 删除报名中的状态阶段
-        remove_job(job_id=f"activity_{activity.id}_{Activity.Status.APPLYING}")
+    def schedule_activity():
+        # 更新定时任务
+        if old_need_apply:
+            # 删除报名中的状态阶段
+            remove_job(job_id=f"activity_{activity.id}_{Activity.Status.APPLYING}")
 
-    if activity.need_apply:
-        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.APPLYING}",
-                      run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.APPLYING)  # OK
-        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
-                      run_time=activity.start - timedelta(hours=1))(activity.id, Activity.Status.APPLYING, Activity.Status.WAITING)  # OK
-    else:
-        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
-                      run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.WAITING)  # OK
+        if activity.need_apply:
+            ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.APPLYING}",
+                          run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.APPLYING)  # OK
+            ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
+                          run_time=activity.start - timedelta(hours=1))(activity.id, Activity.Status.APPLYING, Activity.Status.WAITING)  # OK
+        else:
+            ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.WAITING}",
+                          run_time=activity.publish_time)(activity.id, Activity.Status.UNPUBLISHED, Activity.Status.WAITING)  # OK
 
-    ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_newCourseActivity",
-                  run_time=activity.publish_time)(activity.id, "newCourseActivity")  # OK
-    ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_remind",
-                  run_time=activity.start - timedelta(minutes=15))(activity.id, "remind")  # OK
-    ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.PROGRESSING}",
-                  run_time=activity.start)(activity.id, Activity.Status.WAITING, Activity.Status.PROGRESSING)  # OK
-    ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.END}",
-                  run_time=activity.end)(activity.id, Activity.Status.PROGRESSING, Activity.Status.END)  # OK
+        ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_newCourseActivity",
+                      run_time=activity.publish_time)(activity.id, "newCourseActivity")  # OK
+        ScheduleAdder(notifyActivity, id=f"activity_{activity.id}_remind",
+                      run_time=activity.start - timedelta(minutes=15))(activity.id, "remind")  # OK
+        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.PROGRESSING}",
+                      run_time=activity.start)(activity.id, Activity.Status.WAITING, Activity.Status.PROGRESSING)  # OK
+        ScheduleAdder(changeActivityStatus, id=f"activity_{activity.id}_{Activity.Status.END}",
+                      run_time=activity.end)(activity.id, Activity.Status.PROGRESSING, Activity.Status.END)  # OK
+
+    transaction.on_commit(schedule_activity)
 
     # 发通知
     # notifyActivity(activity.id, "modification_par", "\n".join(to_participants))
 
 
+@transaction.atomic
 def cancel_course_activity(request: HttpRequest, activity: Activity, cancel_all: bool = False):
     """
     取消课程活动，是cancel_activity的简化版，在聚合页面被调用
 
-    调用方须在同一事务内按 Course -> CourseTime -> Activity 锁定长期活动，
-    避免取消时段与编辑时段反向加锁；单次活动只需锁定 Activity。
+    本函数在事务内按 Course -> CourseTime -> Activity 锁定长期活动；
+    单次活动只需锁定 Activity。调用方若已持锁，必须遵循同样的顺序。
 
     在聚合页面中，应确保activity是课程活动，并且应检查activity.status，
     如果不是WAITING或PROGRESSING，不应调用本函数
@@ -431,6 +475,10 @@ def cancel_course_activity(request: HttpRequest, activity: Activity, cancel_all:
     :return: 取消失败的话返回错误信息
     :rtype: string
     """
+    activity = lock_course_activity(
+        activity, get_person_or_org(request.user, UTYPE_ORG))
+    now = datetime.now()
+
     # 只有UNPUBLISHED,WAITING和PROGRESSING允许取消
     if activity.status not in [
         Activity.Status.UNPUBLISHED,
@@ -441,14 +489,15 @@ def cancel_course_activity(request: HttpRequest, activity: Activity, cancel_all:
 
     # 课程活动已于一天前开始则不能取消，这一点也可以在聚合页面进行判断
     if activity.status == Activity.Status.PROGRESSING:
-        if activity.start.day != datetime.now().day:
+        if activity.start.day != now.day:
             return "课程活动已于一天前开始，不能取消。"
 
     # 取消活动
     activity.status = Activity.Status.CANCELED
     # 目前只要取消了活动信息，无论活动处于什么状态，都通知全体选课同学
-    notifyActivity(activity.id, "modification_par",
-                   f"您报名的书院课程活动{activity.title}已取消（活动原定开始于{activity.start.strftime('%Y-%m-%d %H:%M')}）。")
+    transaction.on_commit(partial(
+        notifyActivity, activity.id, "modification_par",
+        f"您报名的书院课程活动{activity.title}已取消（活动原定开始于{activity.start.strftime('%Y-%m-%d %H:%M')}）。"))
 
     # 删除老师的审核通知（如果有）
     notification = Notification.objects.get(
@@ -458,12 +507,12 @@ def cancel_course_activity(request: HttpRequest, activity: Activity, cancel_all:
     notification_status_change(notification, Notification.Status.DELETE)
 
     # 取消定时任务（需要先判断一下是否已经被执行了）
-    if activity.start - timedelta(minutes=15) > datetime.now():
-        remove_job(f"activity_{activity.id}_remind")
-    if activity.start > datetime.now():
-        remove_job(f"activity_{activity.id}_{Activity.Status.PROGRESSING}")
-    if activity.end > datetime.now():
-        remove_job(f"activity_{activity.id}_{Activity.Status.END}")
+    if activity.start - timedelta(minutes=15) > now:
+        transaction.on_commit(partial(remove_job, f"activity_{activity.id}_remind"))
+    if activity.start > now:
+        transaction.on_commit(partial(remove_job, f"activity_{activity.id}_{Activity.Status.PROGRESSING}"))
+    if activity.end > now:
+        transaction.on_commit(partial(remove_job, f"activity_{activity.id}_{Activity.Status.END}"))
 
     activity.save()
 
@@ -508,7 +557,7 @@ def registration_status_check(course_status: Course.Status,
     检查选课状态的变化是否合法
 
     1. 预选阶段允许的状态变化: SELECT <-> UNSELECT
-    2. 补退选阶段允许的状态变化: SUCCESS -> UNSELECT; FAILED -> SUCCESS; UNSELECT -> SUCCESS  
+    2. 补退选阶段允许的状态变化: SUCCESS -> UNSELECT; FAILED -> SUCCESS; UNSELECT -> SUCCESS
 
     异常: 抛出AssertionError，在调用处解决
 
@@ -913,7 +962,7 @@ def course_to_display(courses: QuerySet[Course],
         for time in course.time_set.all():
             course_time.append(process_time(time.start, time.end))
         course_info["time_set"] = course_time
-        
+
         def linebreak(str):
             from re import sub
             return sub("((\r|\\\)+n)|((\r|\\\)+\n)", "\n", str)
@@ -1050,8 +1099,8 @@ def change_course_status(cur_status: Course.Status, to_status: Course.Status) ->
     """
     作为定时任务，在课程设定的时间改变课程的选课阶段
 
-    example: 
-    scheduler.add_job(change_course_status, "date", 
+    example:
+    scheduler.add_job(change_course_status, "date",
                       id=f"course_{course_id}_{to_status}, run_date, args)
 
     :param cur_status: 课程的当前选课阶段
@@ -1603,8 +1652,8 @@ def download_course_record(course: Course = None, year: int = None, semester: Se
 
     for person in person_record.select_related(SQ.f(NaturalPerson.person_id)):
         line = [person.person_id.username, person.name,
-                person.record_hours or 0, 
-                person.invalid_hours or 0] 
+                person.record_hours or 0,
+                person.invalid_hours or 0]
         # 学生状态
         line.append(NaturalPerson.GraduateStatus.labels[person.status])
         valid_records = SQ.sfilter(CourseRecord.person, person).exclude(invalid=True)
@@ -1613,7 +1662,7 @@ def download_course_record(course: Course = None, year: int = None, semester: Se
             line.append(_sum_hours(valid_records.filter(course__type=course_type)))
         # 计算没有对应Course的学时
         line.append(_sum_hours(valid_records.filter(course__isnull=True)))
-       
+
         total_sheet.append(line)
 
     # 详细信息
@@ -1653,7 +1702,7 @@ def download_select_info(single_course: Course | None = None):
                       .values_list("person", flat=True)
         )
         for info in class_members.values_list(
-            SQ.f(NaturalPerson.name), 
+            SQ.f(NaturalPerson.name),
             SQ.f(NaturalPerson.person_id, User.username)
         ):
             person_info = [

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -303,6 +303,9 @@ def modify_course_activity(request: HttpRequest, activity: Activity):
     修改单次课程活动信息，是modify_activity的简化版
     错误提示通过AssertionError抛出
 
+    调用方须在同一事务内锁定 Activity；长期活动须先按
+    Course -> CourseTime -> Activity 顺序锁定，并重新检查归属及状态。
+
     :param request: 修改单次课程活动的请求
     :type request: HttpRequest
     :param activity: 待修改的活动
@@ -363,8 +366,8 @@ def modify_course_activity(request: HttpRequest, activity: Activity):
         course.classroom = context["location"]
         course.need_apply = context["need_apply"]
         course.publish_day = context["publish_day"]
-        course.save()
-        course_time.save()
+        course.save(update_fields=["classroom", "need_apply", "publish_day"])
+        course_time.save(update_fields=["start", "end"])
     # 目前只要编辑了活动信息，无论活动处于什么状态，都通知全体选课同学
     # if activity.status != Activity.Status.APPLYING and activity.status != Activity.Status.WAITING:
     #     return

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -3,6 +3,14 @@ course_utils.py
 
 course_views.py的依赖函数
 
+课程工作流锁顺序（包括调用方持有的锁）：
+先锁全部需要的 Course，再锁学生或修改从属记录；同时需要 CourseTime 和
+Activity 时，按 Course -> CourseTime -> Activity 加锁。同类多行按主键升序
+锁定，并在进入下一步前求值。锁前查询仅用于定位，业务检查必须在锁后进行。
+Participation / Position 的外键校验也会隐式获取 NaturalPerson 共享锁，
+因此插入这些记录后不得再获取新的 Course 锁。此约定不覆盖所有活动业务，
+也不保证消除数据库内部的全部死锁。
+
 registration_status_check: 检查学生选课状态变化的合法性
 registration_status_change: 改变学生选课状态
 course_to_display: 把课程信息转换为方便前端呈现的形式
@@ -177,7 +185,7 @@ def create_single_course_activity(request: HttpRequest) -> Tuple[int, bool]:
 
     # 获取组织和课程
     org = get_person_or_org(request.user, UTYPE_ORG)
-    # 与补选名单同步共用课程行锁，避免并发生成不完整的名单快照。
+    # 先锁课程再创建活动/参与记录；参与记录的外键校验会隐式锁定学生。
     course = Course.objects.activated().select_for_update().get(
         organization=org)
 
@@ -629,7 +637,10 @@ def _notify_student_of_nearest_course_activity(
 def sync_course_member_to_future_activities(
         organization: Organization, student: NaturalPerson,
         now: datetime | None = None) -> int:
-    """将新加入课程组织的成员同步到未来自动报名的课程活动。"""
+    """将新加入课程组织的成员同步到未来自动报名的课程活动。
+
+    先获取全部课程锁，再插入参与记录或由调用方更新 Position；不得反向加锁。
+    """
     if now is None:
         now = datetime.now()
     courses = list(
@@ -736,17 +747,17 @@ def registration_status_change(course_id: int, user: NaturalPerson,
     context = wrong("在修改选课状态的过程中发生错误，请联系管理员！")
     now = datetime.now()
 
-    # 如果不把 user 锁起来，前面做的检查到后面更新数据库时可能已经无效了，会让用户选上超过6门或者时间冲突的课。
-    # 最后get是为了强制对QuerySet求值，起到上锁的效果
-    NaturalPerson.objects.select_for_update().get(id=user.id)
-
-    # 锁定课程状态和名额；课程活动创建也使用同一把锁，避免名单快照竞态。
+    # Course 必须先于学生锁：活动/成员批量插入会在持有课程锁时校验学生外键。
     course = Course.objects.select_for_update().get(id=course_id)
     course_status = course.status
 
     if (course_status != Course.Status.STAGE1
             and course_status != Course.Status.STAGE2):
         return wrong("在非选课阶段不能选课！")
+
+    # 保留学生锁直到提交，串行化同一学生跨课程的限额和时间冲突检查。
+    # 检查其他已选课程时只做普通读取，不再获取其他 Course 锁。
+    NaturalPerson.objects.select_for_update().get(id=user.id)
 
     if action == "select":
         if CourseParticipant.objects.filter(course_id=course_id,
@@ -948,14 +959,19 @@ def draw_lots():
     courses = Course.objects.activated().filter(status=Course.Status.DRAWING)
     for course in courses:
         with transaction.atomic():
-            participants = CourseParticipant.objects.filter(
-                course=course, status=CourseParticipant.Status.SELECT)
-
-            participants_num = participants.count()
+            # 候选列表可能已过期；按 Course -> CourseParticipant 锁定后重新检查。
+            course = Course.objects.select_for_update().get(pk=course.pk)
+            if course.status != Course.Status.DRAWING:
+                continue
+            participants_id = list(
+                CourseParticipant.objects.select_for_update().filter(
+                    course=course, status=CourseParticipant.Status.SELECT,
+                ).order_by("pk").values_list("pk", flat=True)
+            )
+            participants_num = len(participants_id)
             if participants_num <= 0:
                 continue
 
-            participants_id = list(participants.values_list("id", flat=True))
             capacity = course.capacity
 
             if participants_num <= capacity:
@@ -1064,6 +1080,7 @@ def change_course_status(cur_status: Course.Status, to_status: Course.Status) ->
     with transaction.atomic():
         # 在读取选课名单前锁定课程，避免阶段结束与最后一刻补选交错，
         # 导致学生已有选课和活动参与记录却没有课程 Position。
+        # 一次获取全部课程锁；后续 Position 插入会隐式锁定学生外键。
         courses = Course.objects.activated().select_for_update().filter(
             status=cur_status).order_by("pk")
         courses = list(courses)

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -563,16 +563,8 @@ def _remove_student_from_future_course_activities(
         course: Course, student: NaturalPerson,
         now: datetime) -> int:
     """将补退选学生移出未来自动报名的课程活动。"""
-    participation_activity_ids = Participation.objects.filter(
-        person=student,
-        status__in=[
-            Participation.AttendStatus.APPLYSUCCESS,
-            Participation.AttendStatus.CANCELED,
-        ],
-    ).values("activity_id")
     activities = list(
         Activity.objects.select_for_update().filter(
-            pk__in=participation_activity_ids,
             organization_id=course.organization,
             category=Activity.ActivityCategory.COURSE,
             need_apply=False,

--- a/app/course_utils.py
+++ b/app/course_utils.py
@@ -734,7 +734,7 @@ def check_course_time_conflict(current_course: Course,
     '''
 
 
-@logger.secure_func()
+@logger.secure_func(raise_exc=True)
 @transaction.atomic
 def registration_status_change(course_id: int, user: NaturalPerson,
                                action: str) -> MESSAGECONTEXT:
@@ -799,7 +799,7 @@ def registration_status_change(course_id: int, user: NaturalPerson,
             participant_info = CourseParticipant.objects.get(
                 course_id=course_id, person=user)
             cur_status = participant_info.status
-        except:
+        except CourseParticipant.DoesNotExist:
             return context
 
     # 检查当前选课状态、选课阶段和操作的一致性
@@ -813,42 +813,38 @@ def registration_status_change(course_id: int, user: NaturalPerson,
     #         and remaining_willingness_point(user) < course.bidding):
     #     context["warn_message"] = "剩余意愿点不足"
 
-    # 更新选课状态
-    try:
-        with transaction.atomic():
-            if to_status == CourseParticipant.Status.UNSELECT:
-                if course_status == Course.Status.STAGE2:
-                    _remove_student_from_future_course_activities(
-                        course, user, now)
-                Course.objects.filter(id=course_id).select_for_update().update(
-                    current_participants=F("current_participants") - 1)
-                CourseParticipant.objects.filter(course_id=course_id,
-                                                 person=user).delete()
-                succeed("成功取消选课！", context)
-            else:
-                # 处理并发问题
-                if (course_status == Course.Status.STAGE2
-                        and course.current_participants >= course.capacity):
-                    wrong("选课人数已满！", context)
-                else:
-                    course.current_participants += 1
-                    course.save()
+    # 锁、校验及名单同步属于同一事务，异常必须传播并回滚。
+    if to_status == CourseParticipant.Status.UNSELECT:
+        if course_status == Course.Status.STAGE2:
+            _remove_student_from_future_course_activities(
+                course, user, now)
+        Course.objects.filter(id=course_id).update(
+            current_participants=F("current_participants") - 1)
+        CourseParticipant.objects.filter(course_id=course_id,
+                                         person=user).delete()
+        succeed("成功取消选课！", context)
+    else:
+        # 处理并发问题
+        if (course_status == Course.Status.STAGE2
+                and course.current_participants >= course.capacity):
+            wrong("选课人数已满！", context)
+        else:
+            Course.objects.filter(pk=course.pk).update(
+                current_participants=F("current_participants") + 1)
 
-                    CourseParticipant.objects.update_or_create(
-                        course_id = course_id,
-                        person = user,
-                        defaults = {"status": to_status}
-                    )
-                    if course_status == Course.Status.STAGE2:
-                        created_activities = _add_student_to_future_course_activities(
-                            course, user, now)
-                        _notify_student_of_nearest_course_activity(
-                            user, created_activities)
-                    # 只有选课及活动名单同步全部成功后才解锁成就。
-                    unlock_achievement(user, '首次报名书院课程')
-                    succeed("选课成功！", context)
-    except:
-        return context
+            CourseParticipant.objects.update_or_create(
+                course_id = course_id,
+                person = user,
+                defaults = {"status": to_status}
+            )
+            if course_status == Course.Status.STAGE2:
+                created_activities = _add_student_to_future_course_activities(
+                    course, user, now)
+                _notify_student_of_nearest_course_activity(
+                    user, created_activities)
+            # 只有选课及活动名单同步全部成功后才解锁成就。
+            unlock_achievement(user, '首次报名书院课程')
+            succeed("选课成功！", context)
     return context
 
 

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -11,6 +11,7 @@ from app.models import (
     Activity,
     Course,
     CourseRecord,
+    CourseTime,
 )
 from app.course_utils import (
     cancel_course_activity,
@@ -30,6 +31,9 @@ from app.utils import get_person_or_org
 from datetime import datetime
 
 from django.db import transaction
+from django.http import HttpResponseForbidden
+from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.http import require_http_methods
 
 from utils.config.cast import str_to_time
 
@@ -48,8 +52,10 @@ __all__ = [
 APP_CONFIG = CONFIG.course
 
 
+@csrf_protect
 @login_required(redirect_field_name="origin")
 @utils.check_user_access(redirect_url="/logout/")
+@require_http_methods(["GET", "POST"])
 @logger.secure_view()
 def editCourseActivity(request: HttpRequest, aid: int):
     """
@@ -65,7 +71,7 @@ def editCourseActivity(request: HttpRequest, aid: int):
     try:
         aid = int(aid)
         activity = Activity.objects.get(id=aid)
-    except:
+    except (ValueError, Activity.DoesNotExist):
         return redirect(message_url(wrong("活动不存在!")))
 
     # 检查用户身份
@@ -102,8 +108,27 @@ def editCourseActivity(request: HttpRequest, aid: int):
         try:
             # 只能修改自己的活动
             with transaction.atomic():
+                # 锁前仅定位；与每周生成任务共用 Course -> CourseTime -> Activity 顺序。
+                course_time_id = activity.course_time_id
+                if course_time_id is not None:
+                    course_id = CourseTime.objects.values_list(
+                        "course_id", flat=True).get(pk=course_time_id)
+                    course = Course.objects.select_for_update().get(pk=course_id)
+                    if course.organization_id != me.pk:
+                        return HttpResponseForbidden("无法修改其他课程小组的课程!")
+                    course_time = CourseTime.objects.select_for_update().get(
+                        pk=course_time_id)
+                    if course_time.course_id != course.pk:
+                        return redirect(message_url(
+                            wrong("课程时段已变更，请刷新后重试。"), request.path))
                 activity = Activity.objects.select_for_update().get(id=aid)
-                assert activity.organization_id == me, "无法修改其他课程小组的活动!"
+                if activity.organization_id_id != me.pk:
+                    return HttpResponseForbidden("无法修改其他课程小组的活动!")
+                if (activity.course_time_id != course_time_id
+                        or activity.category != Activity.ActivityCategory.COURSE
+                        or activity.status != Activity.Status.UNPUBLISHED):
+                    return redirect(message_url(
+                        wrong("课程活动已变更，请刷新后重试。"), request.path))
                 modify_course_activity(request, activity)
             succeed("修改成功。", html_display)
         except AssertionError as err_info:
@@ -131,7 +156,14 @@ def editCourseActivity(request: HttpRequest, aid: int):
     # 判断本活动是否为长期定时活动
     course_time_tag = (activity.course_time is not None)
 
-    return render(request, "course/lesson_add.html", locals())
+    context = {
+        "html_display": html_display, "bar_display": bar_display,
+        "title": title, "location": location, "start": start, "end": end,
+        "edit": edit, "publish_day": publish_day, "need_apply": need_apply,
+        "course_time_tag": course_time_tag,
+        "activity": activity,
+    }
+    return render(request, "course/lesson_add.html", context)
 
 
 @login_required(redirect_field_name="origin")

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -155,8 +155,10 @@ def editCourseActivity(request: HttpRequest, aid: int):
     return render(request, "course/lesson_add.html", context)
 
 
+@csrf_protect
 @login_required(redirect_field_name="origin")
 @utils.check_user_access(redirect_url="/logout/")
+@require_http_methods(["GET", "POST"])
 @logger.secure_view()
 def addSingleCourseActivity(request: HttpRequest):
     """

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -7,6 +7,7 @@ course_views.py
 from app.views_dependency import *
 from app.models import (
     NaturalPerson,
+    Organization,
     Semester,
     Activity,
     Course,
@@ -31,6 +32,7 @@ from app.utils import get_person_or_org
 from datetime import datetime
 
 from django.db import transaction
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseForbidden
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_http_methods
@@ -50,6 +52,31 @@ __all__ = [
 ]
 
 APP_CONFIG = CONFIG.course
+
+
+def _lock_course_activity(activity: Activity, organization: Organization) -> Activity:
+    """在调用方事务内按 Course -> CourseTime -> Activity 锁定并检查归属。
+
+    锁前的 activity 仅用于定位。编辑和取消长期活动共用此顺序，避免
+    一方持有 Activity 等待 CourseTime，而另一方反向等待。
+    """
+    course_time_id = activity.course_time_id
+    if course_time_id is not None:
+        course_id = CourseTime.objects.values_list(
+            "course_id", flat=True).get(pk=course_time_id)
+        course = Course.objects.select_for_update().get(pk=course_id)
+        if course.organization_id != organization.pk:
+            raise PermissionDenied("无法修改其他课程小组的课程!")
+        course_time = CourseTime.objects.select_for_update().get(pk=course_time_id)
+        if course_time.course_id != course.pk:
+            raise ValueError("课程时段已变更，请刷新后重试。")
+    locked_activity = Activity.objects.select_for_update().get(pk=activity.pk)
+    if locked_activity.organization_id_id != organization.pk:
+        raise PermissionDenied("无法修改其他课程小组的活动!")
+    if (locked_activity.course_time_id != course_time_id
+            or locked_activity.category != Activity.ActivityCategory.COURSE):
+        raise ValueError("课程活动已变更，请刷新后重试。")
+    return locked_activity
 
 
 @csrf_protect
@@ -108,30 +135,15 @@ def editCourseActivity(request: HttpRequest, aid: int):
         try:
             # 只能修改自己的活动
             with transaction.atomic():
-                # 锁前仅定位；与每周生成任务共用 Course -> CourseTime -> Activity 顺序。
-                course_time_id = activity.course_time_id
-                if course_time_id is not None:
-                    course_id = CourseTime.objects.values_list(
-                        "course_id", flat=True).get(pk=course_time_id)
-                    course = Course.objects.select_for_update().get(pk=course_id)
-                    if course.organization_id != me.pk:
-                        return HttpResponseForbidden("无法修改其他课程小组的课程!")
-                    course_time = CourseTime.objects.select_for_update().get(
-                        pk=course_time_id)
-                    if course_time.course_id != course.pk:
-                        return redirect(message_url(
-                            wrong("课程时段已变更，请刷新后重试。"), request.path))
-                activity = Activity.objects.select_for_update().get(id=aid)
-                if activity.organization_id_id != me.pk:
-                    return HttpResponseForbidden("无法修改其他课程小组的活动!")
-                if (activity.course_time_id != course_time_id
-                        or activity.category != Activity.ActivityCategory.COURSE
-                        or activity.status != Activity.Status.UNPUBLISHED):
+                activity = _lock_course_activity(activity, me)
+                if activity.status != Activity.Status.UNPUBLISHED:
                     return redirect(message_url(
                         wrong("课程活动已变更，请刷新后重试。"), request.path))
                 modify_course_activity(request, activity)
             succeed("修改成功。", html_display)
-        except AssertionError as err_info:
+        except PermissionDenied as err_info:
+            return HttpResponseForbidden(str(err_info))
+        except (AssertionError, ValueError) as err_info:
             return redirect(message_url(wrong(str(err_info)),
                                         request.get_full_path()))
         except Exception as e:
@@ -226,8 +238,10 @@ def addSingleCourseActivity(request: HttpRequest):
     return render(request, "course/lesson_add.html", locals())
 
 
+@csrf_protect
 @login_required(redirect_field_name='origin')
 @utils.check_user_access(redirect_url="/logout/")
+@require_http_methods(["GET", "POST"])
 @logger.secure_view()
 def showCourseActivity(request: HttpRequest):
     """
@@ -303,15 +317,17 @@ def showCourseActivity(request: HttpRequest):
         ]:
             return redirect(message_url(wrong('该课程活动已结束，不可取消!'), request.path))
 
-        assert activity.status not in [
-            Activity.Status.REVIEWING,
-            # Activity.Status.APPLYING,
-        ], "课程活动状态非法"  # 课程活动不应出现审核状态
-
         # 取消活动
-        with transaction.atomic():
-            activity = Activity.objects.select_for_update().get(id=aid)
-            error = cancel_course_activity(request, activity, cancel_all)
+        try:
+            with transaction.atomic():
+                activity = _lock_course_activity(activity, me)
+                if cancel_all and activity.course_time_id is None:
+                    raise ValueError("单次活动没有可取消的长期课程时段。")
+                error = cancel_course_activity(request, activity, cancel_all)
+        except PermissionDenied as err_info:
+            return HttpResponseForbidden(str(err_info))
+        except ValueError as err_info:
+            return redirect(message_url(wrong(str(err_info)), request.path))
 
         # 无返回值表示取消成功，有则失败
         if error is None:
@@ -320,7 +336,12 @@ def showCourseActivity(request: HttpRequest):
         else:
             return redirect(message_url(wrong(error)), request.path)
 
-    return render(request, "course/show_course_activity.html", locals())
+    context = {
+        "html_display": html_display, "bar_display": bar_display,
+        "future_activity_list": future_activity_list,
+        "finished_activity_list": finished_activity_list,
+    }
+    return render(request, "course/show_course_activity.html", context)
 
 
 @login_required(redirect_field_name="origin")

--- a/app/course_views.py
+++ b/app/course_views.py
@@ -15,6 +15,7 @@ from app.models import (
     CourseTime,
 )
 from app.course_utils import (
+    lock_course_activity as _lock_course_activity,
     cancel_course_activity,
     create_single_course_activity,
     modify_course_activity,
@@ -52,31 +53,6 @@ __all__ = [
 ]
 
 APP_CONFIG = CONFIG.course
-
-
-def _lock_course_activity(activity: Activity, organization: Organization) -> Activity:
-    """在调用方事务内按 Course -> CourseTime -> Activity 锁定并检查归属。
-
-    锁前的 activity 仅用于定位。编辑和取消长期活动共用此顺序，避免
-    一方持有 Activity 等待 CourseTime，而另一方反向等待。
-    """
-    course_time_id = activity.course_time_id
-    if course_time_id is not None:
-        course_id = CourseTime.objects.values_list(
-            "course_id", flat=True).get(pk=course_time_id)
-        course = Course.objects.select_for_update().get(pk=course_id)
-        if course.organization_id != organization.pk:
-            raise PermissionDenied("无法修改其他课程小组的课程!")
-        course_time = CourseTime.objects.select_for_update().get(pk=course_time_id)
-        if course_time.course_id != course.pk:
-            raise ValueError("课程时段已变更，请刷新后重试。")
-    locked_activity = Activity.objects.select_for_update().get(pk=activity.pk)
-    if locked_activity.organization_id_id != organization.pk:
-        raise PermissionDenied("无法修改其他课程小组的活动!")
-    if (locked_activity.course_time_id != course_time_id
-            or locked_activity.category != Activity.ActivityCategory.COURSE):
-        raise ValueError("课程活动已变更，请刷新后重试。")
-    return locked_activity
 
 
 @csrf_protect
@@ -140,6 +116,7 @@ def editCourseActivity(request: HttpRequest, aid: int):
                     return redirect(message_url(
                         wrong("课程活动已变更，请刷新后重试。"), request.path))
                 modify_course_activity(request, activity)
+                activity.refresh_from_db()
             succeed("修改成功。", html_display)
         except PermissionDenied as err_info:
             return HttpResponseForbidden(str(err_info))

--- a/app/jobs.py
+++ b/app/jobs.py
@@ -167,15 +167,16 @@ def add_week_course_activity(course_id: int, weektime_id: int, cur_week: int, co
     """
     添加每周的课程活动
     """
-    course: Course = Course.objects.get(id=course_id)
-    examine_teacher = NaturalPerson.objects.get_teacher(
-        CONFIG.course.audit_teachers[0])
-    # 当前课程在学期已举办的活动
-    conducted_num = Activity.objects.activated().filter(
-        organization_id=course.organization,
-        category=Activity.ActivityCategory.COURSE).count()
     # 发起活动，并设置报名
     with transaction.atomic():
+        # 与补选名单同步共用课程行锁，避免并发生成不完整的名单快照。
+        course: Course = Course.objects.select_for_update().get(id=course_id)
+        examine_teacher = NaturalPerson.objects.get_teacher(
+            CONFIG.course.audit_teachers[0])
+        # 当前课程在学期已举办的活动
+        conducted_num = Activity.objects.activated().filter(
+            organization_id=course.organization,
+            category=Activity.ActivityCategory.COURSE).count()
         week_time = CourseTime.objects.select_for_update().get(id=weektime_id)
         if week_time.cur_week != cur_week:
             return False

--- a/app/jobs.py
+++ b/app/jobs.py
@@ -169,7 +169,8 @@ def add_week_course_activity(course_id: int, weektime_id: int, cur_week: int, co
     """
     # 发起活动，并设置报名
     with transaction.atomic():
-        # 与补选名单同步共用课程行锁，避免并发生成不完整的名单快照。
+        # 遵循 course_utils 的 Course -> CourseTime -> Activity 顺序。
+        # 课程锁先于参与记录插入时隐式获取的学生外键锁，避免与退选互锁。
         course: Course = Course.objects.select_for_update().get(id=course_id)
         examine_teacher = NaturalPerson.objects.get_teacher(
             CONFIG.course.audit_teachers[0])

--- a/app/org_utils.py
+++ b/app/org_utils.py
@@ -437,11 +437,22 @@ def update_pos_application(application: ModifyPosition, me: ClassifiedUser,
                     否则就不应该通过这条创建
                 '''
                 try:
+                    if application.apply_type == ModifyPosition.ApplyType.JOIN:
+                        from app.course_utils import (
+                            sync_course_member_to_future_activities,
+                        )
+                        sync_course_member_to_future_activities(
+                            application.org, application.person,
+                            now=datetime.now())
+                    # 课程同步先锁课程，再创建或恢复 Position；与课程阶段
+                    # 转换保持相同锁顺序，避免 course/position 互相等待。
                     application.accept_submit()
                     context = succeed("成功通过来自" + application.person.name + "的申请!")
                     context["application_id"] = application.id
                     return context
-                except:
+                except Exception:
+                    transaction.set_rollback(True)
+                    logger.exception("通过成员申请失败")
                     return wrong("出现系统意料之外的行为，请联系管理员处理!")
 
 

--- a/app/test/course_fixtures.py
+++ b/app/test/course_fixtures.py
@@ -1,0 +1,75 @@
+"""Shared fixtures for course transaction tests."""
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from django.db import transaction
+from django.test import RequestFactory
+
+from app import course_utils, jobs
+from app.models import Activity, Course, CourseTime
+from app.test import test_course_late_enrollment as enrollment_tests
+
+
+class CourseFixtures:
+    """Reuse the small enrollment fixture without inheriting its test methods."""
+    now = datetime(2026, 9, 6, 12)
+
+    def setUp(self):
+        super().setUp()
+        enrollment_tests.CourseLateEnrollmentTestCase.setUpTestData.__func__(type(self))
+        self.course.photo = "course/test.jpg"
+        self.course.save(update_fields=["photo"])
+        self.org_user = self.organization.get_user()
+        self.org_user.is_newuser = False
+        self.org_user.save(update_fields=["is_newuser"])
+        self.course_time = CourseTime.objects.create(
+            course=self.course, start=self.now + timedelta(days=1),
+            end=self.now + timedelta(days=1, hours=2))
+        for module in (course_utils, jobs):
+            mocked_time = self.enterContext(patch.object(module, "datetime", wraps=datetime))
+            mocked_time.now.return_value = self.now
+        for target in (
+                "app.course_utils.unlock_achievement", "app.course_utils.ScheduleAdder",
+                "app.course_utils.remove_job", "app.course_utils.notification_create",
+                "app.course_utils.publish_notification", "app.course_utils.bulk_notification_create",
+                "app.jobs.MultipleAdder", "app.jobs.notification_create"):
+            self.enterContext(patch(target))
+        config = self.enterContext(patch("app.course_utils.APP_CONFIG"))
+        config.audit_teachers = [self.teacher.get_user().username]
+        config = self.enterContext(patch("app.jobs.CONFIG"))
+        config.course.audit_teachers = [self.teacher.get_user().username]
+        self.enterContext(patch("app.course_views.utils.get_sidebar_and_navbar", return_value={}))
+
+    def activity(self):
+        return Activity.objects.create(
+            title="Course lesson", organization_id=self.organization,
+            examine_teacher=self.teacher, course_time=self.course_time,
+            category=Activity.ActivityCategory.COURSE,
+            status=Activity.Status.UNPUBLISHED, need_apply=False,
+            start=self.course_time.start, end=self.course_time.end,
+            publish_time=self.now, location="Room", capacity=0, current_participants=0)
+
+    def request(self, activity=None, csrf=True):
+        path = f"/editCourseActivity/{activity.pk}" if activity else "/addSingleCourseActivity/"
+        request = RequestFactory().post(path, {
+            "title": "Edited lesson", "location": "New room",
+            "lesson_start": self.course_time.start.strftime("%Y-%m-%d %H:%M"),
+            "lesson_end": self.course_time.end.strftime("%Y-%m-%d %H:%M"),
+            "publish_day": "instant", "need_apply": "False", "post_type": "modify_all",
+        })
+        request.user = self.org_user
+        if csrf:
+            request.COOKIES["csrftoken"] = "a" * 32
+            request.META["HTTP_X_CSRFTOKEN"] = "a" * 32
+        return request
+
+    def enroll(self):
+        result = course_utils.registration_status_change(self.course.pk, self.student, "select")
+        self.assertEqual(result["warn_code"], 2, result)
+
+    def weekly(self):
+        return jobs.add_week_course_activity(self.course.pk, self.course_time.pk, 0, True)
+
+    def single(self):
+        with transaction.atomic():
+            return course_utils.create_single_course_activity(self.request())

--- a/app/test/course_fixtures.py
+++ b/app/test/course_fixtures.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.test import RequestFactory
 
 from app import course_utils, jobs
-from app.models import Activity, Course, CourseTime
+from app.models import Activity, Course, CourseTime, Notification
 from app.test import test_course_late_enrollment as enrollment_tests
 
 
@@ -32,22 +32,30 @@ class CourseFixtures:
                 "app.course_utils.unlock_achievement", "app.course_utils.ScheduleAdder",
                 "app.course_utils.remove_job", "app.course_utils.notification_create",
                 "app.course_utils.publish_notification", "app.course_utils.bulk_notification_create",
+                "app.course_utils.notifyActivity", "app.course_utils.notification_status_change",
                 "app.jobs.MultipleAdder", "app.jobs.notification_create"):
             self.enterContext(patch(target))
         config = self.enterContext(patch("app.course_utils.APP_CONFIG"))
         config.audit_teachers = [self.teacher.get_user().username]
         config = self.enterContext(patch("app.jobs.CONFIG"))
         config.course.audit_teachers = [self.teacher.get_user().username]
+        config = self.enterContext(patch("app.course_views.APP_CONFIG"))
+        config.type_name = self.organization.otype.otype_name
         self.enterContext(patch("app.course_views.utils.get_sidebar_and_navbar", return_value={}))
 
     def activity(self):
-        return Activity.objects.create(
+        activity = Activity.objects.create(
             title="Course lesson", organization_id=self.organization,
             examine_teacher=self.teacher, course_time=self.course_time,
             category=Activity.ActivityCategory.COURSE,
             status=Activity.Status.UNPUBLISHED, need_apply=False,
             start=self.course_time.start, end=self.course_time.end,
             publish_time=self.now, location="Room", capacity=0, current_participants=0)
+        Notification.objects.create(
+            relate_instance=activity, receiver=self.teacher.get_user(),
+            sender=self.org_user, typename=Notification.Type.NEEDDO,
+            title="Review course activity")
+        return activity
 
     def request(self, activity=None, csrf=True):
         path = f"/editCourseActivity/{activity.pk}" if activity else "/addSingleCourseActivity/"
@@ -61,6 +69,13 @@ class CourseFixtures:
         if csrf:
             request.COOKIES["csrftoken"] = "a" * 32
             request.META["HTTP_X_CSRFTOKEN"] = "a" * 32
+        return request
+
+    def cancellation_request(self, activity, csrf=True):
+        request = self.request(activity, csrf=csrf)
+        request.POST = request.POST.copy()
+        request.POST["cancel-action"] = str(activity.pk)
+        request.POST["post_type"] = "cancel_all"
         return request
 
     def enroll(self):

--- a/app/test/test_course_activity_locking.py
+++ b/app/test/test_course_activity_locking.py
@@ -92,3 +92,19 @@ class CourseActivityLockingTests(CourseFixtures, TestCase):
         self.assertEqual(response.status_code, 200)
         activity.refresh_from_db()
         self.assertEqual(activity.location, "New room")
+
+    def test_cancel_all_requires_csrf(self):
+        activity = self.activity()
+        response = course_views.showCourseActivity(self.cancellation_request(activity, csrf=False))
+        self.assertEqual(response.status_code, 403)
+        activity.refresh_from_db()
+        self.assertEqual(activity.status, Activity.Status.UNPUBLISHED)
+
+    def test_cancel_all_rejects_standalone_activity(self):
+        activity = self.activity()
+        activity.course_time = None
+        activity.save(update_fields=["course_time"])
+        response = course_views.showCourseActivity(self.cancellation_request(activity))
+        self.assertEqual(response.status_code, 302)
+        activity.refresh_from_db()
+        self.assertEqual(activity.status, Activity.Status.UNPUBLISHED)

--- a/app/test/test_course_activity_locking.py
+++ b/app/test/test_course_activity_locking.py
@@ -1,0 +1,94 @@
+"""Recurring course edit locking and request protection regressions."""
+from django.db import connection
+from django.test import TestCase
+
+from app import course_views
+from app.models import Activity, Course, CourseTime, Organization, User
+from app.test.course_fixtures import CourseFixtures
+
+
+class CourseActivityLockingTests(CourseFixtures, TestCase):
+    def test_edit_preserves_course_counters_and_renders_form(self):
+        activity = self.activity()
+        self.enroll()
+        response = course_views.editCourseActivity(self.request(activity), str(activity.pk))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "csrfmiddlewaretoken")
+        self.assertContains(response, "New room")
+        self.course.refresh_from_db()
+        activity.refresh_from_db()
+        self.assertEqual(self.course.classroom, "New room")
+        self.assertEqual(self.course.current_participants, 1)
+        self.assertEqual(activity.current_participants, 1)
+
+    def test_edit_requires_csrf_and_rejects_other_methods(self):
+        activity = self.activity()
+        self.assertEqual(course_views.editCourseActivity(
+            self.request(activity, csrf=False), str(activity.pk)).status_code, 403)
+        request = self.request(activity)
+        request.method = "PUT"
+        self.assertEqual(course_views.editCourseActivity(request, str(activity.pk)).status_code, 405)
+
+    def assert_edit_rejected_after_change(self, mutate, expected_status=302):
+        activity = self.activity()
+        changed = False
+
+        def change_status(execute, sql, params, many, context):
+            nonlocal changed
+            result = execute(sql, params, many, context)
+            if not changed and "FOR UPDATE" in sql and "FROM `app_course`" in sql:
+                changed = True
+                mutate(activity)
+            return result
+
+        with connection.execute_wrapper(change_status):
+            response = course_views.editCourseActivity(self.request(activity), str(activity.pk))
+        self.assertTrue(changed)
+        self.assertEqual(response.status_code, expected_status)
+        activity.refresh_from_db()
+        self.assertEqual(activity.location, "Room")
+
+    def test_edit_rechecks_activity_after_locking_course(self):
+        for changes in (
+                {"status": Activity.Status.WAITING},
+                {"category": Activity.ActivityCategory.NORMAL},
+                {"course_time": None}):
+            with self.subTest(changes=changes):
+                self.assert_edit_rejected_after_change(
+                    lambda activity: Activity.objects.filter(pk=activity.pk).update(**changes))
+
+    def test_edit_rechecks_owner_after_locking_course(self):
+        other_user = User.objects.create_user("other_course_org", "Other org", User.Type.ORG)
+        other_org = Organization.objects.create(
+            organization_id=other_user, oname="Other org", otype=self.organization.otype)
+        self.assert_edit_rejected_after_change(
+            lambda activity: Activity.objects.filter(pk=activity.pk).update(
+                organization_id=other_org), expected_status=403)
+
+    def test_edit_rechecks_course_time_relationship(self):
+        other_course = Course.objects.create(
+            name="Other course", organization=self.organization,
+            type=Course.CourseType.INTELLECTUAL)
+        self.assert_edit_rejected_after_change(
+            lambda activity: CourseTime.objects.filter(pk=self.course_time.pk).update(
+                course=other_course))
+
+    def test_edit_rejects_course_owned_by_another_organization(self):
+        activity = self.activity()
+        other_user = User.objects.create_user("other_course_org", "Other org", User.Type.ORG)
+        other_org = Organization.objects.create(
+            organization_id=other_user, oname="Other org", otype=self.organization.otype)
+        Course.objects.filter(pk=self.course.pk).update(organization=other_org)
+        response = course_views.editCourseActivity(self.request(activity), str(activity.pk))
+        self.assertEqual(response.status_code, 403)
+        activity.refresh_from_db()
+        self.assertEqual(activity.location, "Room")
+
+    def test_standalone_edit_does_not_require_course_time(self):
+        activity = self.activity()
+        activity.course_time = None
+        activity.save(update_fields=["course_time"])
+        response = course_views.editCourseActivity(self.request(activity), str(activity.pk))
+        self.assertEqual(response.status_code, 200)
+        activity.refresh_from_db()
+        self.assertEqual(activity.location, "New room")

--- a/app/test/test_course_activity_locking.py
+++ b/app/test/test_course_activity_locking.py
@@ -8,6 +8,22 @@ from app.test.course_fixtures import CourseFixtures
 
 
 class CourseActivityLockingTests(CourseFixtures, TestCase):
+    def test_add_requires_csrf(self):
+        for token in (None, "b" * 32):
+            with self.subTest(token=token):
+                request = self.request(csrf=False)
+                request.COOKIES["csrftoken"] = "a" * 32
+                if token is not None:
+                    request.META["HTTP_X_CSRFTOKEN"] = token
+                with self.assertNumQueries(0):
+                    response = course_views.addSingleCourseActivity(request)
+                self.assertEqual(response.status_code, 403)
+
+    def test_add_rejects_other_methods(self):
+        request = self.request()
+        request.method = "PUT"
+        self.assertEqual(course_views.addSingleCourseActivity(request).status_code, 405)
+
     def test_edit_preserves_course_counters_and_renders_form(self):
         activity = self.activity()
         self.enroll()

--- a/app/test/test_course_concurrency.py
+++ b/app/test/test_course_concurrency.py
@@ -115,6 +115,18 @@ class CourseConcurrencyTests(CourseFixtures, TransactionTestCase):
         self.assertEqual(results["second"].status_code, 200)
         self.assert_withdrawn()
 
+    def test_recurring_edit_overlaps_cancel_all(self):
+        activity = self.activity()
+        results = self.overlap(
+            lambda: course_views.editCourseActivity(self.request(activity), str(activity.pk)),
+            lambda: course_views.showCourseActivity(self.cancellation_request(activity)))
+        self.assertEqual(results["first"].status_code, 200)
+        self.assertEqual(results["second"].status_code, 200)
+        activity.refresh_from_db()
+        self.course_time.refresh_from_db()
+        self.assertEqual(activity.status, Activity.Status.CANCELED)
+        self.assertEqual(self.course_time.end_week, self.course_time.cur_week)
+
     def test_closing_overlaps_withdrawal(self):
         self.enroll()
         results = self.overlap(lambda: course_utils.change_course_status(

--- a/app/test/test_course_concurrency.py
+++ b/app/test/test_course_concurrency.py
@@ -102,6 +102,20 @@ class CourseConcurrencyTests(CourseFixtures, TransactionTestCase):
         self.overlap(self.withdraw, withdraw_activity, table="app_activity")
         self.assert_withdrawn()
 
+    def test_single_creation_owns_transaction(self):
+        activity_id, created = course_utils.create_single_course_activity(self.request())
+        self.assertTrue(created)
+        self.assertTrue(Activity.objects.filter(pk=activity_id).exists())
+
+    def test_direct_edit_and_cancel_own_transactions(self):
+        activity = self.activity()
+        course_utils.modify_course_activity(self.request(activity), activity)
+        course_utils.cancel_course_activity(self.request(activity), activity, cancel_all=True)
+        activity.refresh_from_db()
+        self.course_time.refresh_from_db()
+        self.assertEqual(activity.status, Activity.Status.CANCELED)
+        self.assertEqual(self.course_time.end_week, self.course_time.cur_week)
+
     def test_weekly_creation_overlaps_withdrawal(self):
         self.enroll()
         results = self.overlap(self.weekly, self.withdraw)

--- a/app/test/test_course_concurrency.py
+++ b/app/test/test_course_concurrency.py
@@ -1,0 +1,158 @@
+"""Real MySQL transaction interleavings for course workflows."""
+from threading import Event, Thread
+
+from django.db import close_old_connections, connection
+from django.test import TransactionTestCase
+
+from app import course_utils, course_views
+from app.models import Activity, Course, CourseParticipant, CourseTime, Participation, Position
+from app.test.course_fixtures import CourseFixtures
+
+
+class CourseConcurrencyTests(CourseFixtures, TransactionTestCase):
+    """Pause one transaction holding Course until another attempts that lock."""
+
+    def setUp(self):
+        super().setUp()
+        if connection.vendor != "mysql":
+            self.skipTest("Requires MySQL row and foreign-key locks")
+
+    def overlap(self, first, second, table="app_course"):
+        locked, attempted = Event(), Event()
+        results, errors = {}, []
+
+        def worker(name, operation):
+            close_old_connections()
+            intercepted = False
+
+            def coordinate(execute, sql, params, many, context):
+                nonlocal intercepted
+                is_target_lock = "FOR UPDATE" in sql and f"FROM `{table}`" in sql
+                if intercepted or not is_target_lock:
+                    return execute(sql, params, many, context)
+                intercepted = True
+                if name == "second":
+                    attempted.set()
+                    return execute(sql, params, many, context)
+                result = execute(sql, params, many, context)
+                locked.set()
+                if not attempted.wait(10):
+                    raise TimeoutError(f"Competing operation did not attempt its {table} lock")
+                return result
+
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SET SESSION innodb_lock_wait_timeout = 5")
+                with connection.execute_wrapper(coordinate):
+                    results[name] = operation()
+            except Exception as exc:
+                errors.append(exc)
+            finally:
+                close_old_connections()
+
+        threads = [Thread(target=worker, args=("first", first), daemon=True),
+                   Thread(target=worker, args=("second", second), daemon=True)]
+        threads[0].start()
+        try:
+            self.assertTrue(locked.wait(10), f"First operation did not lock {table}")
+            threads[1].start()
+        finally:
+            for thread in threads:
+                if thread.ident is not None:
+                    thread.join(20)
+            self.assertFalse(any(thread.is_alive() for thread in threads), "Transaction did not finish")
+        if errors:
+            raise errors[0]
+        self.assertTrue(attempted.is_set())
+        return results
+
+    def withdraw(self):
+        return course_utils.registration_status_change(self.course.pk, self.student, "unselect")
+
+    def assert_withdrawn(self):
+        self.assertFalse(CourseParticipant.objects.filter(course=self.course, person=self.student).exists())
+        self.assertFalse(Participation.objects.filter(person=self.student).exists())
+        for activity in Activity.objects.filter(organization_id=self.organization):
+            self.assertEqual(activity.current_participants, 0)
+            self.assertEqual(activity.capacity, 0)
+
+    def test_single_creation_overlaps_withdrawal(self):
+        self.enroll()
+        results = self.overlap(self.single, self.withdraw)
+        self.assertEqual(results["second"]["warn_code"], 2)
+        self.assert_withdrawn()
+
+    def test_weekly_creation_overlaps_withdrawal(self):
+        self.enroll()
+        results = self.overlap(self.weekly, self.withdraw)
+        self.assertEqual(results["second"]["warn_code"], 2)
+        self.assert_withdrawn()
+
+    def test_weekly_creation_overlaps_recurring_edit(self):
+        activity = self.activity()
+        results = self.overlap(self.weekly, lambda: course_views.editCourseActivity(
+            self.request(activity), str(activity.pk)))
+        self.assertEqual(results["second"].status_code, 200)
+        self.course_time.refresh_from_db()
+        self.assertEqual(self.course_time.cur_week, 1)
+        self.course.refresh_from_db()
+        self.assertEqual(self.course.classroom, "New room")
+
+    def test_selection_overlaps_recurring_edit(self):
+        activity = self.activity()
+        results = self.overlap(self.enroll, lambda: course_views.editCourseActivity(
+            self.request(activity), str(activity.pk)))
+        self.assertEqual(results["second"].status_code, 200)
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 1)
+
+    def test_withdrawal_overlaps_recurring_edit(self):
+        activity = self.activity()
+        self.enroll()
+        results = self.overlap(self.withdraw, lambda: course_views.editCourseActivity(
+            self.request(activity), str(activity.pk)))
+        self.assertEqual(results["first"]["warn_code"], 2)
+        self.assertEqual(results["second"].status_code, 200)
+        self.assert_withdrawn()
+
+    def test_closing_overlaps_withdrawal(self):
+        self.enroll()
+        results = self.overlap(lambda: course_utils.change_course_status(
+            Course.Status.STAGE2, Course.Status.SELECT_END), self.withdraw)
+        self.assertEqual(results["second"]["warn_code"], 1)
+        self.assertTrue(Position.objects.activated().filter(
+            person=self.student, org=self.organization).exists())
+        self.assertTrue(CourseParticipant.objects.filter(
+            course=self.course, person=self.student).exists())
+
+    def test_enrollment_overlaps_closing(self):
+        self.overlap(self.enroll, lambda: course_utils.change_course_status(
+            Course.Status.STAGE2, Course.Status.SELECT_END))
+        self.assertTrue(Position.objects.activated().filter(
+            person=self.student, org=self.organization).exists())
+
+    def second_course(self):
+        return Course.objects.create(
+            name="Second course", organization=self.organization,
+            type=Course.CourseType.INTELLECTUAL, status=Course.Status.STAGE2,
+            capacity=20)
+
+    def test_student_lock_preserves_six_course_limit(self):
+        for _ in range(5):
+            CourseParticipant.objects.create(
+                course=self.second_course(), person=self.student,
+                status=CourseParticipant.Status.SUCCESS)
+        second_course = self.second_course()
+        results = self.overlap(self.enroll, lambda: course_utils.registration_status_change(
+            second_course.pk, self.student, "select"), table="app_naturalperson")
+        self.assertEqual(results["second"]["warn_code"], 1)
+        self.assertEqual(Course.objects.selected(self.student, unfailed=True).count(), 6)
+
+    def test_student_lock_preserves_timetable_check(self):
+        second_course = self.second_course()
+        CourseTime.objects.create(
+            course=second_course, start=self.course_time.start, end=self.course_time.end)
+        results = self.overlap(self.enroll, lambda: course_utils.registration_status_change(
+            second_course.pk, self.student, "select"), table="app_naturalperson")
+        self.assertEqual(results["second"]["warn_code"], 1)
+        self.assertEqual(Course.objects.selected(self.student, unfailed=True).count(), 1)

--- a/app/test/test_course_concurrency.py
+++ b/app/test/test_course_concurrency.py
@@ -5,6 +5,7 @@ from django.db import close_old_connections, connection
 from django.test import TransactionTestCase
 
 from app import course_utils, course_views
+from app.activity_utils import ActivityException, withdraw_activity_for_person
 from app.models import Activity, Course, CourseParticipant, CourseTime, Participation, Position
 from app.test.course_fixtures import CourseFixtures
 
@@ -80,6 +81,25 @@ class CourseConcurrencyTests(CourseFixtures, TransactionTestCase):
         self.enroll()
         results = self.overlap(self.single, self.withdraw)
         self.assertEqual(results["second"]["warn_code"], 2)
+        self.assert_withdrawn()
+
+    def test_activity_withdrawal_overlaps_course_withdrawal(self):
+        activity = self.activity()
+        self.enroll()
+        self.overlap(
+            lambda: withdraw_activity_for_person(self.student, activity),
+            self.withdraw, table="app_activity")
+        self.assert_withdrawn()
+
+    def test_course_withdrawal_overlaps_activity_withdrawal(self):
+        activity = self.activity()
+        self.enroll()
+
+        def withdraw_activity():
+            with self.assertRaises(ActivityException):
+                withdraw_activity_for_person(self.student, activity)
+
+        self.overlap(self.withdraw, withdraw_activity, table="app_activity")
         self.assert_withdrawn()
 
     def test_weekly_creation_overlaps_withdrawal(self):

--- a/app/test/test_course_late_enrollment.py
+++ b/app/test/test_course_late_enrollment.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from app.course_utils import change_course_status, registration_status_change
+from app.activity_utils import withdraw_activity_for_person
 from app.models import (
     Activity,
     Course,
@@ -111,6 +112,55 @@ class CourseLateEnrollmentTestCase(TestCase):
         self.assertEqual(activity.current_participants, 4)
         self.assertEqual(activity.capacity, 4)
 
+    @patch("app.course_utils.unlock_achievement")
+    def test_stage2_cancellation_removes_future_activity_participation(
+            self, _unlock_achievement):
+        activity = self.create_activity()
+        registration_status_change(self.course.id, self.student, "select")
+
+        result = registration_status_change(
+            self.course.id, self.student, "unselect")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertFalse(CourseParticipant.objects.filter(
+            course=self.course, person=self.student).exists())
+        self.assertFalse(Participation.objects.filter(
+            activity=activity, person=self.student).exists())
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 3)
+        self.assertEqual(activity.capacity, 3)
+
+    @patch("app.course_utils.unlock_achievement")
+    def test_reselection_restores_manually_canceled_course_activity(
+            self, _unlock_achievement):
+        activity = self.create_activity()
+        registration_status_change(self.course.id, self.student, "select")
+        activity.refresh_from_db()
+        with self.captureOnCommitCallbacks(execute=True):
+            withdraw_activity_for_person(self.student, activity)
+
+        result = registration_status_change(
+            self.course.id, self.student, "unselect")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertFalse(Participation.objects.filter(
+            activity=activity, person=self.student).exists())
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 3)
+        self.assertEqual(activity.capacity, 3)
+
+        result = registration_status_change(
+            self.course.id, self.student, "select")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        participation = Participation.objects.get(
+            activity=activity, person=self.student)
+        self.assertEqual(
+            participation.status, Participation.AttendStatus.APPLYSUCCESS)
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 4)
+        self.assertEqual(activity.capacity, 4)
+
     @patch("app.course_utils.publish_notification")
     @patch("app.course_utils.unlock_achievement")
     def test_stage2_selection_only_notifies_nearest_new_activity(
@@ -140,6 +190,36 @@ class CourseLateEnrollmentTestCase(TestCase):
         self.assertEqual(notification.title, nearest_activity.title)
         self.assertFalse(Notification.objects.filter(
             relate_instance=farther_activity).exists())
+        publish_notification.assert_called_once_with(
+            notification.id, app=WechatApp.TO_PARTICIPANT)
+
+    @patch("app.course_utils.publish_notification")
+    @patch("app.course_utils.unlock_achievement")
+    def test_stage2_selection_defers_unpublished_activity_notification(
+            self, _unlock_achievement, publish_notification):
+        unpublished = self.create_activity(
+            title="Unpublished activity",
+            status=Activity.Status.UNPUBLISHED,
+            start=datetime.now() + timedelta(hours=2),
+            end=datetime.now() + timedelta(hours=4),
+            publish_time=datetime.now() + timedelta(hours=1),
+        )
+        published = self.create_activity(
+            title="Published activity",
+            start=datetime.now() + timedelta(days=1),
+            end=datetime.now() + timedelta(days=1, hours=2),
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = registration_status_change(
+                self.course.id, self.student, "select")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertTrue(Participation.objects.filter(
+            activity=unpublished, person=self.student).exists())
+        notification = Notification.objects.get(
+            receiver=self.student.get_user())
+        self.assertEqual(notification.relate_instance_id, published.pk)
         publish_notification.assert_called_once_with(
             notification.id, app=WechatApp.TO_PARTICIPANT)
 

--- a/app/test/test_course_late_enrollment.py
+++ b/app/test/test_course_late_enrollment.py
@@ -1,0 +1,328 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from app.course_utils import change_course_status, registration_status_change
+from app.models import (
+    Activity,
+    Course,
+    CourseParticipant,
+    NaturalPerson,
+    ModifyPosition,
+    Notification,
+    Organization,
+    OrganizationType,
+    Participation,
+    Position,
+    User,
+)
+from app.org_utils import update_pos_application
+from app.extern.wechat import WechatApp
+
+
+class CourseLateEnrollmentTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        teacher_user = User.objects.create_user(
+            "late_enrol_teacher",
+            "Late enrol teacher",
+            User.Type.TEACHER,
+            password="pw",
+        )
+        cls.teacher = NaturalPerson.objects.create(
+            teacher_user,
+            name="Teacher",
+            identity=NaturalPerson.Identity.TEACHER,
+        )
+        student_user = User.objects.create_user(
+            "late_enrol_student",
+            "Late enrol student",
+            User.Type.STUDENT,
+            password="pw",
+        )
+        cls.student = NaturalPerson.objects.create(
+            student_user,
+            name="Student",
+            identity=NaturalPerson.Identity.STUDENT,
+        )
+        org_type = OrganizationType.objects.create(
+            otype_id=9101,
+            otype_name="Late enrol test type",
+            incharge=cls.teacher,
+            job_name_list=["负责人", "副负责人", "成员", "干事"],
+        )
+        org_user = User.objects.create_user(
+            "late_enrol_org",
+            "Late enrol org",
+            User.Type.ORG,
+            password="pw",
+        )
+        cls.organization = Organization.objects.create(
+            organization_id=org_user,
+            oname="Late enrol org",
+            otype=org_type,
+        )
+        cls.course = Course.objects.create(
+            name="Late enrol course",
+            organization=cls.organization,
+            type=Course.CourseType.INTELLECTUAL,
+            status=Course.Status.STAGE2,
+            capacity=20,
+        )
+
+    def create_activity(self, **overrides):
+        now = datetime.now()
+        fields = {
+            "title": "Late enrol activity",
+            "organization_id": self.organization,
+            "start": now + timedelta(days=1),
+            "end": now + timedelta(days=1, hours=2),
+            "location": "Test room",
+            "examine_teacher": self.teacher,
+            "category": Activity.ActivityCategory.COURSE,
+            "need_apply": False,
+            "status": Activity.Status.WAITING,
+            "current_participants": 3,
+            "capacity": 3,
+        }
+        fields.update(overrides)
+        return Activity.objects.create(**fields)
+
+    @patch("app.course_utils.unlock_achievement")
+    def test_stage2_selection_adds_student_to_future_auto_enrol_activity(
+            self, _unlock_achievement):
+        activity = self.create_activity()
+
+        result = registration_status_change(
+            self.course.id, self.student, "select")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertTrue(CourseParticipant.objects.filter(
+            course=self.course,
+            person=self.student,
+            status=CourseParticipant.Status.SUCCESS,
+        ).exists())
+        participation = Participation.objects.get(
+            activity=activity, person=self.student)
+        self.assertEqual(
+            participation.status, Participation.AttendStatus.APPLYSUCCESS)
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 4)
+        self.assertEqual(activity.capacity, 4)
+
+    @patch("app.course_utils.publish_notification")
+    @patch("app.course_utils.unlock_achievement")
+    def test_stage2_selection_only_notifies_nearest_new_activity(
+            self, _unlock_achievement, publish_notification):
+        farther_activity = self.create_activity(
+            title="Farther activity",
+            start=datetime.now() + timedelta(days=2),
+            end=datetime.now() + timedelta(days=2, hours=2),
+        )
+        nearest_activity = self.create_activity(
+            title="Nearest activity",
+            start=datetime.now() + timedelta(hours=2),
+            end=datetime.now() + timedelta(hours=4),
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = registration_status_change(
+                self.course.id, self.student, "select")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        notification = Notification.objects.get(
+            receiver=self.student.get_user())
+        self.assertEqual(
+            notification.relate_instance_id, nearest_activity.pk)
+        self.assertEqual(
+            notification.URL, f"/viewActivity/{nearest_activity.id}")
+        self.assertEqual(notification.title, nearest_activity.title)
+        self.assertFalse(Notification.objects.filter(
+            relate_instance=farther_activity).exists())
+        publish_notification.assert_called_once_with(
+            notification.id, app=WechatApp.TO_PARTICIPANT)
+
+    @patch("app.course_utils.unlock_achievement")
+    def test_stage2_selection_does_not_add_ineligible_activities(
+            self, _unlock_achievement):
+        now = datetime.now()
+        self.create_activity(
+            title="Requires application",
+            need_apply=True,
+        )
+        self.create_activity(
+            title="Already started",
+            start=now - timedelta(hours=2),
+            end=now - timedelta(hours=1),
+            status=Activity.Status.END,
+        )
+        self.create_activity(
+            title="Future but progressing",
+            status=Activity.Status.PROGRESSING,
+        )
+        self.create_activity(
+            title="Ordinary activity",
+            category=Activity.ActivityCategory.NORMAL,
+        )
+
+        result = registration_status_change(
+            self.course.id, self.student, "select")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertFalse(Participation.objects.filter(
+            person=self.student).exists())
+
+    @patch("app.course_utils.unlock_achievement")
+    def test_existing_participation_is_not_duplicated(
+            self, _unlock_achievement):
+        activity = self.create_activity()
+        Participation.objects.create(
+            activity=activity,
+            person=self.student,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        )
+
+        result = registration_status_change(
+            self.course.id, self.student, "select")
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertEqual(Participation.objects.filter(
+            activity=activity, person=self.student).count(), 1)
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 3)
+        self.assertEqual(activity.capacity, 3)
+        _unlock_achievement.assert_called_once_with(
+            self.student, "首次报名书院课程")
+
+    @patch("app.course_utils.unlock_achievement")
+    def test_full_course_rejects_selection_without_updating_activity(
+            self, _unlock_achievement):
+        self.course.current_participants = self.course.capacity
+        self.course.save(update_fields=["current_participants"])
+        activity = self.create_activity()
+
+        result = registration_status_change(
+            self.course.id, self.student, "select")
+
+        self.assertEqual(result["warn_code"], 1, result)
+        self.assertEqual(result["warn_message"], "选课人数已满！")
+        self.assertFalse(CourseParticipant.objects.filter(
+            course=self.course, person=self.student).exists())
+        self.assertFalse(Participation.objects.filter(
+            activity=activity, person=self.student).exists())
+        self.course.refresh_from_db()
+        activity.refresh_from_db()
+        self.assertEqual(
+            self.course.current_participants, self.course.capacity)
+        self.assertEqual(activity.current_participants, 3)
+        self.assertEqual(activity.capacity, 3)
+        _unlock_achievement.assert_not_called()
+
+    def test_accepting_course_org_member_adds_future_activity_participation(
+            self):
+        self.course.status = Course.Status.SELECT_END
+        self.course.save(update_fields=["status"])
+        activity = self.create_activity()
+        application = ModifyPosition.objects.create(
+            person=self.student,
+            org=self.organization,
+            pos=10,
+            apply_type=ModifyPosition.ApplyType.JOIN,
+        )
+
+        result = update_pos_application(
+            application,
+            self.organization,
+            self.organization,
+            {"post_type": "accept_submit"},
+        )
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertTrue(Participation.objects.filter(
+            activity=activity,
+            person=self.student,
+            status=Participation.AttendStatus.APPLYSUCCESS,
+        ).exists())
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 4)
+        self.assertEqual(activity.capacity, 4)
+
+    @patch("app.course_utils.publish_notification")
+    def test_accepting_course_org_member_only_notifies_nearest_activity(
+            self, publish_notification):
+        self.course.status = Course.Status.SELECT_END
+        self.course.save(update_fields=["status"])
+        farther_activity = self.create_activity(
+            title="Farther member activity",
+            start=datetime.now() + timedelta(days=2),
+            end=datetime.now() + timedelta(days=2, hours=2),
+        )
+        nearest_activity = self.create_activity(
+            title="Nearest member activity",
+            start=datetime.now() + timedelta(hours=2),
+            end=datetime.now() + timedelta(hours=4),
+        )
+        application = ModifyPosition.objects.create(
+            person=self.student,
+            org=self.organization,
+            pos=10,
+            apply_type=ModifyPosition.ApplyType.JOIN,
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = update_pos_application(
+                application,
+                self.organization,
+                self.organization,
+                {"post_type": "accept_submit"},
+            )
+
+        self.assertEqual(result["warn_code"], 2, result)
+        notification = Notification.objects.get(
+            receiver=self.student.get_user())
+        self.assertEqual(
+            notification.relate_instance_id, nearest_activity.pk)
+        self.assertFalse(Notification.objects.filter(
+            relate_instance=farther_activity).exists())
+        publish_notification.assert_called_once_with(
+            notification.id, app=WechatApp.TO_PARTICIPANT)
+
+    def test_accepting_member_during_stage2_does_not_sync_activity(self):
+        activity = self.create_activity()
+        application = ModifyPosition.objects.create(
+            person=self.student,
+            org=self.organization,
+            pos=10,
+            apply_type=ModifyPosition.ApplyType.JOIN,
+        )
+
+        result = update_pos_application(
+            application,
+            self.organization,
+            self.organization,
+            {"post_type": "accept_submit"},
+        )
+
+        self.assertEqual(result["warn_code"], 2, result)
+        self.assertFalse(Participation.objects.filter(
+            activity=activity, person=self.student).exists())
+        self.assertFalse(Notification.objects.filter(
+            receiver=self.student.get_user()).exists())
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 3)
+        self.assertEqual(activity.capacity, 3)
+
+    def test_stage2_end_creates_position_before_updating_course_status(self):
+        CourseParticipant.objects.create(
+            course=self.course,
+            person=self.student,
+            status=CourseParticipant.Status.SUCCESS,
+        )
+
+        change_course_status(Course.Status.STAGE2, Course.Status.SELECT_END)
+
+        self.course.refresh_from_db()
+        self.assertEqual(self.course.status, Course.Status.SELECT_END)
+        self.assertTrue(Position.objects.activated().filter(
+            org=self.organization, person=self.student).exists())

--- a/app/test/test_course_lock_boundaries.py
+++ b/app/test/test_course_lock_boundaries.py
@@ -1,0 +1,35 @@
+"""Regression coverage for transaction boundaries and deferred side effects."""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from app import course_utils
+from app.models import Course, CourseParticipant, Participation
+from app.test.course_fixtures import CourseFixtures
+
+
+class CourseLockBoundaryTests(CourseFixtures, TestCase):
+    def test_selection_failure_rolls_back_all_writes_and_callbacks(self):
+        activity = self.activity()
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            with patch.object(course_utils, "unlock_achievement", side_effect=RuntimeError("failure")):
+                with self.assertRaises(RuntimeError):
+                    self.enroll()
+        self.assertEqual(callbacks, [])
+        self.course.refresh_from_db()
+        activity.refresh_from_db()
+        self.assertEqual(self.course.current_participants, 0)
+        self.assertEqual(activity.current_participants, 0)
+        self.assertFalse(CourseParticipant.objects.filter(person=self.student).exists())
+        self.assertFalse(Participation.objects.filter(person=self.student).exists())
+
+    def test_selection_does_not_overwrite_other_course_fields(self):
+        def update_classroom(*args):
+            Course.objects.filter(pk=self.course.pk).update(classroom="Changed inside transaction")
+            return False, ""
+
+        with patch.object(course_utils, "check_course_time_conflict", side_effect=update_classroom):
+            self.enroll()
+        self.course.refresh_from_db()
+        self.assertEqual(self.course.classroom, "Changed inside transaction")
+        self.assertEqual(self.course.current_participants, 1)

--- a/app/test/test_course_lock_boundaries.py
+++ b/app/test/test_course_lock_boundaries.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from app import course_utils
+from app.activity_utils import ActivityException, withdraw_activity_for_person
 from app.models import Course, CourseParticipant, Participation
 from app.test.course_fixtures import CourseFixtures
 
@@ -33,3 +34,15 @@ class CourseLockBoundaryTests(CourseFixtures, TestCase):
         self.course.refresh_from_db()
         self.assertEqual(self.course.classroom, "Changed inside transaction")
         self.assertEqual(self.course.current_participants, 1)
+
+    def test_withdraw_uses_locked_activity_and_rejects_duplicate(self):
+        activity = self.activity()
+        self.enroll()
+        # Neither the write nor the caller's response may use a stale count.
+        activity.current_participants = 42
+        withdraw_activity_for_person(self.student, activity)
+        self.assertEqual(activity.current_participants, 0)
+        with self.assertRaises(ActivityException):
+            withdraw_activity_for_person(self.student, activity)
+        activity.refresh_from_db()
+        self.assertEqual(activity.current_participants, 0)

--- a/app/test/test_course_lock_boundaries.py
+++ b/app/test/test_course_lock_boundaries.py
@@ -1,11 +1,12 @@
 """Regression coverage for transaction boundaries and deferred side effects."""
 from unittest.mock import patch
 
+from django.db import transaction
 from django.test import TestCase
 
-from app import course_utils
+from app import course_utils, course_views
 from app.activity_utils import ActivityException, withdraw_activity_for_person
-from app.models import Course, CourseParticipant, Participation
+from app.models import Activity, Course, CourseParticipant, Participation
 from app.test.course_fixtures import CourseFixtures
 
 
@@ -46,3 +47,41 @@ class CourseLockBoundaryTests(CourseFixtures, TestCase):
             withdraw_activity_for_person(self.student, activity)
         activity.refresh_from_db()
         self.assertEqual(activity.current_participants, 0)
+
+    def test_creation_defers_external_effects(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            course_utils.create_single_course_activity(self.request())
+            course_utils.ScheduleAdder.assert_not_called()
+            course_utils.publish_notification.assert_not_called()
+        self.assertTrue(course_utils.ScheduleAdder.called)
+        course_utils.publish_notification.assert_called_once()
+
+    def test_edit_and_cancel_discard_external_effects_on_rollback(self):
+        for operation in (course_utils.modify_course_activity, course_utils.cancel_course_activity):
+            with self.subTest(operation=operation.__name__):
+                activity = self.activity()
+                with self.captureOnCommitCallbacks(execute=True) as callbacks:
+                    with self.assertRaises(RuntimeError):
+                        with transaction.atomic():
+                            locked = course_views._lock_course_activity(activity, self.organization)
+                            operation(self.request(activity), locked)
+                            raise RuntimeError("rollback")
+                self.assertEqual(callbacks, [])
+                course_utils.ScheduleAdder.assert_not_called()
+                course_utils.remove_job.assert_not_called()
+                course_utils.notifyActivity.assert_not_called()
+                activity.refresh_from_db()
+                self.assertEqual(activity.status, Activity.Status.UNPUBLISHED)
+
+    def test_edit_and_cancel_run_external_effects_after_commit(self):
+        activity = self.activity()
+        with self.captureOnCommitCallbacks(execute=True):
+            course_utils.modify_course_activity(self.request(activity), activity)
+            course_utils.ScheduleAdder.assert_not_called()
+        self.assertTrue(course_utils.ScheduleAdder.called)
+        with self.captureOnCommitCallbacks(execute=True):
+            course_utils.cancel_course_activity(self.request(activity), activity)
+            course_utils.notifyActivity.assert_not_called()
+            course_utils.remove_job.assert_not_called()
+        course_utils.notifyActivity.assert_called_once()
+        self.assertTrue(course_utils.remove_job.called)

--- a/app/test/test_course_locking.py
+++ b/app/test/test_course_locking.py
@@ -1,0 +1,47 @@
+"""Lottery regressions for authoritative reads under the Course lock."""
+from django.db import connection
+from django.test import TestCase
+
+from app import course_utils
+from app.models import Course, CourseParticipant
+from app.test.course_fixtures import CourseFixtures
+
+
+class CourseLockingTests(CourseFixtures, TestCase):
+    def prepare_lottery(self):
+        self.course.status = Course.Status.DRAWING
+        self.course.capacity = 0
+        self.course.save(update_fields=["status", "capacity"])
+        return CourseParticipant.objects.create(
+            course=self.course, person=self.student, status=CourseParticipant.Status.SELECT)
+
+    def change_before_course_lock(self, **changes):
+        changed = False
+
+        def wrapper(execute, sql, params, many, context):
+            nonlocal changed
+            if not changed and "FOR UPDATE" in sql and "FROM `app_course`" in sql:
+                changed = True
+                Course.objects.filter(pk=self.course.pk).update(**changes)
+            return execute(sql, params, many, context)
+        return connection.execute_wrapper(wrapper)
+
+    def test_lottery_uses_locked_capacity_and_does_not_repeat(self):
+        participant = self.prepare_lottery()
+        with self.change_before_course_lock(capacity=1):
+            course_utils.draw_lots()
+        participant.refresh_from_db()
+        self.assertEqual(participant.status, CourseParticipant.Status.SUCCESS)
+        notifications = course_utils.bulk_notification_create.call_count
+        course_utils.draw_lots()
+        self.assertEqual(course_utils.bulk_notification_create.call_count, notifications)
+        self.course.refresh_from_db()
+        self.assertEqual(self.course.current_participants, 1)
+
+    def test_lottery_skips_course_that_changed_stage(self):
+        participant = self.prepare_lottery()
+        with self.change_before_course_lock(status=Course.Status.STAGE2):
+            course_utils.draw_lots()
+        participant.refresh_from_db()
+        self.assertEqual(participant.status, CourseParticipant.Status.SELECT)
+        course_utils.bulk_notification_create.assert_not_called()

--- a/templates/course/lesson_add.html
+++ b/templates/course/lesson_add.html
@@ -56,6 +56,7 @@
                     </div>
                     <div class="widget-content widget-content-area">
                         <form method="POST" onsubmit="return checkInputs()">
+                            {% csrf_token %}
                             <div id="basic-info">
                                 <p>
                                     <b>基本信息</b>

--- a/templates/course/show_course_activity.html
+++ b/templates/course/show_course_activity.html
@@ -145,6 +145,7 @@
                                                                         </div>
                                                                         {% if act.course_time %}
                                                                         <form method="POST" id="cancel-details">
+                                                                            {% csrf_token %}
                                                                         <div class="modal-body">
 
                                                                             <input type="radio" id="cancel_only" name="post_type" value="cancel_only" checked="checked"/>
@@ -167,6 +168,7 @@
                                                                         <div class="modal-footer">
                                                                             <button type="button" class="btn btn-secondary" data-dismiss="modal">再想想</button>
                                                                             <form method="POST" id="cancel-details">
+                                                                                {% csrf_token %}
                                                                                 <input type="hidden" name="cancel-action" value="{{act.id}}">
                                                                                 <button type="button" class="btn btn-primary" onclick="this.form.submit()" data-dismiss="modal">确认</button>
                                                                             </form>


### PR DESCRIPTION
  - 补退选成功后，将学生加入已创建且尚未开始的免报名课程活动
  - 成员加入课程组织获批后，同步其未来课程活动参与记录
  - 补发最近一场未开始活动的通知
  - 更新活动参与人数及容量，确保学生可以正常签到
  - 增加幂等处理、并发锁及相关回归测试