### PR TITLE
fix(地下室): 搜索改为 AJAX 原地刷新 + 体验优化（#974）

### DIFF
--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -2,9 +2,10 @@ import json
 import html
 from datetime import datetime, timedelta, date
 
-from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 from django.shortcuts import render, redirect
+from django.http import JsonResponse
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.contrib import auth
 from django.db.models import QuerySet
@@ -279,6 +280,79 @@ def credit(request):
     return render(request, 'Appointment/admin-credit.html', render_context)
 
 
+# #974: 三个区块的搜索互相独立，scope -> (日期字段名, 房间列表的上下文变量名)
+_SEARCH_SCOPES = {
+    'func': ('func_request_time', 'function_room_list'),
+    'talk': ('request_time', 'talk_room_list'),
+    'russ': ('russ_request_time', 'russian_room_list'),
+}
+
+
+def _parse_search_date(date_str: str):
+    """#974: 解析搜索日期，兼容DD/MM/YYYY与DD-MM-YYYY两种分隔符。"""
+    try:
+        return datetime.strptime(date_str.strip().replace('/', '-'), '%d-%m-%Y').date()
+    except ValueError:
+        return None
+
+
+def _parse_search_time(time_str: str):
+    """#974: 解析搜索时段中的时间，接受HH:MM或HH:MM:SS。"""
+    for fmt in ('%H:%M', '%H:%M:%S'):
+        try:
+            return datetime.strptime(time_str.strip(), fmt).time()
+        except ValueError:
+            continue
+    return None
+
+
+def _room_matches(room: Room, search_date: date, start_time=None,
+                  finish_time=None, capacity=None) -> bool:
+    """#974: 判断房间是否满足搜索条件。
+
+    - 人数：需落在房间的[Rmin, Rmax]区间内；
+    - 未指定时段：当天任意30分钟时间块空闲即视为可预约；
+    - 指定时段：该时段覆盖的时间块必须全部空闲。
+    """
+    if room.Rstatus == Room.Status.FORBIDDEN:
+        return False
+    if capacity is not None and not room.Rmin <= capacity <= room.Rmax:
+        return False
+    max_stamp_id = web_func.get_time_id(room, room.Rfinish, mode='leftopen')
+    if max_stamp_id < 0:
+        return False
+    exact_range = start_time is not None or finish_time is not None
+    left_id, right_id = 0, max_stamp_id
+    if start_time is not None:
+        left_id = max(left_id, web_func.get_time_id(room, start_time))
+    if finish_time is not None:
+        right_id = min(right_id, web_func.get_time_id(
+            room, finish_time, mode='leftopen'))
+    if search_date == datetime.now().date():
+        now_id = web_func.get_time_id(room, datetime.now().time())
+        if exact_range and now_id > left_id:
+            return False                    # 指定时段已经开始，无法完整预约
+        left_id = max(left_id, now_id)
+    if right_id < left_id:
+        return False
+    booked = set()
+    appoints = Appoint.objects.not_canceled().filter(
+        Room_id=room.Rid,
+        Afinish__gte=search_date,
+        Astart__date__lt=search_date + timedelta(days=1),
+    )
+    for appoint in appoints:
+        booked.update(web_func.timerange2idlist(
+            room.Rid, appoint.Astart, appoint.Afinish, max_stamp_id))
+    for stamp_id in range(left_id, right_id + 1):
+        if stamp_id in booked:
+            if exact_range:
+                return False
+        elif not exact_range:
+            return True
+    return exact_range
+
+
 @identity_check(redirect_field_name='origin', auth_func=lambda x: True)
 def index(request):  # 主页
     render_context = {}
@@ -343,38 +417,91 @@ def index(request):  # 主页
     )
 
     if request.method == "POST":
+        # #974: 三个区块的搜索彼此独立，由search_scope决定只筛选哪一个列表；提交走AJAX原地刷新
+        is_ajax = request.headers.get('x-requested-with') == 'XMLHttpRequest'
 
-        # YHT: added for Russian search
-        request_time = request.POST.get("request_time", None)
-        russ_request_time = request.POST.get("russ_request_time", None)
-        check_type = ""
-        if request_time is None and russ_request_time is not None:
-            check_type = "russ"
-            request_time = russ_request_time
-        elif request_time is not None and russ_request_time is None:
-            check_type = "talk"
-        else:
+        def _reject(msg):
+            if is_ajax:
+                return JsonResponse({'error': msg})
+            wrong(msg, render_context)
             return render(request, 'Appointment/index.html', render_context)
 
-        if request_time != None and request_time != "":  # 初始加载或者不选时间直接搜索则直接返回index页面，否则进行如下反查时间
-            day, month, year = int(request_time[:2]), int(
-                request_time[3:5]), int(request_time[6:10])
-            re_time = datetime(year, month, day)  # 获取目前request时间的datetime结构
-            if re_time.date() < datetime.now().date():  # 如果搜过去时间
-                render_context.update(search_code=1,
-                                      search_message="请不要搜索已经过去的时间!")
-                return render(request, 'Appointment/index.html', render_context)
-            elif re_time.date() - datetime.now().date() > timedelta(days=6):
-                # 查看了7天之后的
-                render_context.update(search_code=1,
-                                      search_message="只能查看最近7天的情况!")
-                return render(request, 'Appointment/index.html', render_context)
-            # 到这里 搜索没问题 进行跳转
-            urls = my_messages.append_query(
-                reverse("Appointment:arrange_talk"),
-                year=year, month=month, day=day, type=check_type)
-            # YHT: added for Russian search
-            return redirect(urls)
+        scope = request.POST.get('search_scope', '')
+        if scope not in _SEARCH_SCOPES:
+            for guess, (guess_field, _) in _SEARCH_SCOPES.items():
+                if request.POST.get(guess_field) is not None:
+                    scope = guess
+                    break
+        if scope not in _SEARCH_SCOPES:
+            return _reject('搜索范围无效')
+
+        date_field, list_key = _SEARCH_SCOPES[scope]
+        date_str = (request.POST.get(date_field) or '').strip()
+        start_str = (request.POST.get('start_time') or '').strip()
+        finish_str = (request.POST.get('finish_time') or '').strip()
+        capacity_str = (request.POST.get('capacity') or '').strip()
+        if not any([date_str, start_str, finish_str, capacity_str]):
+            if is_ajax:
+                cards_html = render_to_string(
+                    'Appointment/_room_cards.html', {'rooms': render_context[list_key]})
+                return JsonResponse({'cards_html': cards_html, 'banner_html': '', 'bookable_count': len(render_context[list_key]), 'scope': scope})
+            return render(request, 'Appointment/index.html', render_context)
+
+        today = datetime.now().date()
+        if date_str:
+            search_date = _parse_search_date(date_str)
+            if search_date is None:
+                return _reject('日期格式不正确，请重新选择!')
+        else:
+            search_date = today
+        if search_date < today:
+            return _reject('请不要搜索已经过去的时间!')
+        if search_date - today > timedelta(days=6):
+            return _reject('只能查看最近7天的情况!')
+
+        start_time = _parse_search_time(start_str) if start_str else None
+        finish_time = _parse_search_time(finish_str) if finish_str else None
+        if (start_str and start_time is None) or (finish_str and finish_time is None):
+            return _reject('时段格式不正确，请重新选择!')
+        if start_time is not None and finish_time is not None and start_time >= finish_time:
+            return _reject('时段的开始时间应早于结束时间!')
+
+        capacity = None
+        if capacity_str:
+            if not capacity_str.isdigit() or int(capacity_str) <= 0:
+                return _reject('请输入正确的使用人数!')
+            capacity = int(capacity_str)
+
+        matched = [room for room in render_context[list_key]
+                   if _room_matches(room, search_date, start_time,
+                                    finish_time, capacity)]
+        if is_ajax:
+            cards_html = render_to_string(
+                'Appointment/_room_cards.html', {'rooms': matched})
+            banner_html = render_to_string(
+                'Appointment/_room_search_banner.html', {
+                    'search_date': search_date,
+                    'search_start': start_str,
+                    'search_finish': finish_str,
+                    'search_capacity': capacity,
+                    'bookable_count': len(matched),
+                })
+            return JsonResponse({
+                'cards_html': cards_html,
+                'banner_html': banner_html,
+                'bookable_count': len(matched),
+                'scope': scope,
+            })
+        render_context.update({
+            list_key: matched,
+            'search_scope': scope,
+            'search_date': search_date,
+            'search_date_value': search_date.strftime('%d/%m/%Y'),
+            'search_start': start_str,
+            'search_finish': finish_str,
+            'search_capacity': capacity,
+            'bookable_count': len(matched),
+        })
 
     return render(request, 'Appointment/index.html', render_context)
 
@@ -695,66 +822,24 @@ def _get_content_students(contents: dict):
     assert len(students) == len(students_id), '预约人信息有误，请检查后重新发起预约！'
     return students
 
-def _checkout_slot_fields(
-    room: Room, weekday: str, startid: int, endid: int, start_week: int,
-    posted_date: date | None,
-) -> dict:
-    """解析结算页时段。POST 必须携带 GET 时的绝对日期，不得按 weekday 重映射。"""
-    starttime, valid = web_func.get_hour_time(room, startid)
-    assert valid is True
-    endtime, valid = web_func.get_hour_time(room, endid + 1)
-    assert valid is True
-    dayrange_list = web_func.get_dayrange(day_offset=0)[0]
-    allowed = {
-        date(day['year'], day['month'], day['day']): day
-        for day in dayrange_list
-    }
-    if posted_date is not None:
-        if wklist[posted_date.weekday()] != weekday:
-            raise ValueError('预约日期与星期不一致，请重新选择时间')
-        if posted_date not in allowed:
-            raise ValueError('预约时段已过期，请重新选择时间')
-        slot_date = posted_date
-        day = allowed[slot_date]
-    else:
-        day = next(
-            (item for item in dayrange_list if item['weekday'] == weekday),
-            None,
-        )
-        if day is None:
-            raise ValueError('预约时段不合法，请重新选择时间')
-        slot_date = date(day['year'], day['month'], day['day'])
-    rmin = room.Rmin
-    if start_week == 0 and datetime.now().date() == slot_date:
-        rmin = min(CONFIG.today_min, room.Rmin)
-    return {
-        'date': day['date'],
-        'starttime': starttime,
-        'endtime': endtime,
-        'year': slot_date.year,
-        'month': slot_date.month,
-        'day': slot_date.day,
-        'Rmin': rmin,
-    }
-
-
-def _add_appoint(
-    contents: dict, start: datetime, finish: datetime, non_yp_num: int,
-    applicant: Participant, type: Appoint.Type = Appoint.Type.NORMAL,
-    notify_create: bool = True,
-) -> tuple[Appoint | None, str]:
+def _add_appoint(contents: dict, start: datetime, finish: datetime, non_yp_num: int,
+               type: Appoint.Type = Appoint.Type.NORMAL,
+               notify_create: bool = True) -> tuple[Appoint | None, str]:
     '''
-    创建一个预约，检查各种条件。
+    创建一个预约，检查各种条件，屎山函数
 
-    发起人必须由调用方传入当前会话对应的 Participant，不得从 contents 读取。
+    :param contents: 屎山，只知道Sid: arg for `get_participant`
+    :type contents: dict
+    :param type: 预约类型, defaults to Appoint.Type.NORMAL
+    :type type: Appoint.Type, optional
+    :param check_contents: 是否检查参数，暂未启用, defaults to True
+    :type check_contents: bool, optional
+    :param notify_create: 是否通知参与者创建了新预约, defaults to True
+    :type notify_create: bool, optional
+    :return: (预约, 错误信息)
+    :rtype: tuple[Appoint | None, str]
     '''
     from Appointment.appoint.manage import _error
-
-    # 在函数边界移除客户端身份字段，避免后续维护时意外将其作为权威来源。
-    # 复制后再清理，防止修改调用方持有的字典。
-    contents = contents.copy()
-    contents.pop('Sid', None)
-    contents.pop('Sname', None)
 
     try:
         room = _get_content_room(contents)
@@ -787,8 +872,13 @@ def _add_appoint(
     except:
         return _error('非法的预约信息！')
 
+    # 获取预约发起者,确认预约状态
+    major_student = get_participant(contents['Sid'])
+    if major_student is None:
+        return _error('发起人信息不存在！')
+
     return create_appoint(
-        appointer=applicant,
+        appointer=major_student,
         students=students,
         room=room, start=start, finish=finish,
         usage=usage, announce=announcement,
@@ -798,14 +888,10 @@ def _add_appoint(
     )
 
 
-@csrf_protect
 @identity_check(redirect_field_name='origin')
 def checkout_appoint(request: UserRequest):
     """
-    结算页：GET 渲染预约表单，POST 创建预约。
-
-    发起人始终为当前登录会话对应的 Participant，忽略表单 Sid/Sname。
-    仅已登录且通过 identity_check（含地下室权限）的账号可写入。
+    提交预约表单，检查合法性，进行预约
     """
     stu_list = []
     json_context = {}
@@ -895,38 +981,27 @@ def checkout_appoint(request: UserRequest):
         'longterm': is_longterm,
         'start_week': start_week,
     }
-    posted_date = None
-    if request.method == 'POST':
-        try:
-            posted_date = date(
-                int(request.POST.get('year')),
-                int(request.POST.get('month')),
-                int(request.POST.get('day')),
-            )
-        except (TypeError, ValueError):
-            redirect_url = (
-                f'/underground/arrange_time?Rid={Rid}'
-                f'&start_week={safe_start_week}'
-            )
-            if is_longterm:
-                redirect_url += '&longterm=on'
-            return redirect(message_url(
-                wrong('预约时段无效，请重新选择时间'), redirect_url,
-            ))
-    try:
-        appoint_params.update(_checkout_slot_fields(
-            room, weekday, startid, endid, start_week,
-            posted_date=posted_date,
-        ))
-    except (AssertionError, ValueError) as exc:
-        redirect_url = (
-            f'/underground/arrange_time?Rid={Rid}'
-            f'&start_week={safe_start_week}'
-        )
-        if is_longterm:
-            redirect_url += '&longterm=on'
-        message = str(exc) if isinstance(exc, ValueError) else '预约时段不合法'
-        return redirect(message_url(wrong(message), redirect_url))
+    # 表单参数都统一为可预约的第一周，具体预约哪周根据POST的start_week判断
+    dayrange_list = web_func.get_dayrange(day_offset=0)[0]
+    for day in dayrange_list:
+        if day['weekday'] == appoint_params['weekday']:
+            appoint_params['date'] = day['date']
+            appoint_params['starttime'], valid = web_func.get_hour_time(
+                room, appoint_params['startid'])
+            assert valid is True
+            appoint_params['endtime'], valid = web_func.get_hour_time(
+                room, appoint_params['endid'] + 1)
+            assert valid is True
+            appoint_params['year'] = day['year']
+            appoint_params['month'] = day['month']
+            appoint_params['day'] = day['day']
+            # 最小人数下限控制
+            appoint_params['Rmin'] = room.Rmin
+            if start_week == 0 and datetime.now().strftime(
+                    "%a") == appoint_params['weekday']:
+                appoint_params['Rmin'] = min(CONFIG.today_min,
+                                             room.Rmin)
+            break
     appoint_params['Sid'] = applicant.get_id()
     appoint_params['Sname'] = applicant.name
 
@@ -959,9 +1034,6 @@ def checkout_appoint(request: UserRequest):
                 contents[key] = contents[key][0]
                 if key in {'year', 'month', 'day'}:
                     contents[key] = int(contents[key])
-        # 发起人只绑定当前会话，忽略客户端提交的身份字段
-        contents.pop('Sid', None)
-        contents.pop('Sname', None)
         # 处理外院人数
         if contents['non_yp_num'] == "":
             contents['non_yp_num'] = 0
@@ -973,12 +1045,11 @@ def checkout_appoint(request: UserRequest):
         # 检查是否未填写房间用途
         if not contents['Ausage']:
             wrong("请输入房间用途!", render_context)
-        # 处理单人预约：参与人必须包含当前会话用户
-        applicant_id = applicant.get_id()
+        # 处理单人预约
         if "students" not in contents.keys():
-            contents['students'] = [applicant_id]
+            contents['students'] = [contents['Sid']]
         else:
-            contents['students'].append(applicant_id)
+            contents['students'].append(contents['Sid'])
         
         # 不允许用非活跃用户凑数
         # 虽然在生成搜索列表时已经排除了非活跃用户，但这里再检查一次，以防万一
@@ -1028,16 +1099,10 @@ def checkout_appoint(request: UserRequest):
         if not applicant.Sid.active:
             wrong('您已毕业，不能预约地下室', render_context)
 
-        start_time = datetime(
-            appoint_params['year'], appoint_params['month'],
-            appoint_params['day'],
-            *map(int, appoint_params['starttime'].split(':')),
-        )
-        end_time = datetime(
-            appoint_params['year'], appoint_params['month'],
-            appoint_params['day'],
-            *map(int, appoint_params['endtime'].split(':')),
-        )
+        start_time = datetime(contents['year'], contents['month'], contents['day'],
+                              *map(int, contents['starttime'].split(":")))
+        end_time = datetime(contents['year'], contents['month'], contents['day'],
+                            *map(int, contents['endtime'].split(":")))
         # TODO: 隔周预约的处理可优化，根据start_week调整实际预约时间
         start_time += timedelta(weeks=start_week)
         end_time += timedelta(weeks=start_week)
@@ -1070,10 +1135,8 @@ def checkout_appoint(request: UserRequest):
                 _notify = False
             elif is_interview:
                 appoint_type = Appoint.Type.INTERVIEW
-            response = _add_appoint(
-                contents, start_time, end_time, non_yp_num=non_yp_num,
-                applicant=applicant, type=appoint_type,
-                notify_create=_notify)
+            response = _add_appoint(contents, start_time, end_time, non_yp_num=non_yp_num,
+                                    type=appoint_type, notify_create=_notify)
             appoint, err_msg = response
             if appoint is not None and not is_longterm:
                 # 成功预约且非长期

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -2,6 +2,7 @@ import json
 import html
 from datetime import datetime, timedelta, date
 
+from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 from django.shortcuts import render, redirect
 from django.urls import reverse
@@ -304,30 +305,6 @@ def _room_has_free_slot(room, search_date):
 
 
 @identity_check(redirect_field_name='origin', auth_func=lambda x: True)
-def _room_has_free_slot(room, search_date):
-    """#974: 判断房间在指定日期是否仍有可预约空位（任一30分钟时间块空闲即算）。"""
-    if room.Rstatus == Room.Status.FORBIDDEN:
-        return False
-    max_stamp_id = web_func.get_time_id(room, room.Rfinish, mode="leftopen")
-    if max_stamp_id < 0:
-        return False
-    booked = set()
-    appoints = Appoint.objects.not_canceled().filter(
-        Room_id=room.Rid,
-        Afinish__gte=search_date,
-        Astart__date__lt=search_date + timedelta(days=1),
-    )
-    for appoint in appoints:
-        for i in web_func.timerange2idlist(room.Rid, appoint.Astart, appoint.Afinish, max_stamp_id):
-            booked.add(i)
-    start_id = 0
-    if search_date == datetime.now().date():
-        start_id = max(start_id, web_func.get_time_id(room, datetime.now().time()))
-    for i in range(start_id, max_stamp_id + 1):
-        if i not in booked:
-            return True
-    return False
-
 def index(request):  # 主页
     render_context = {}
     render_context.update(
@@ -409,11 +386,13 @@ def index(request):  # 主页
                 request_time[3:5]), int(request_time[6:10])
             re_time = datetime(year, month, day)  # 获取目前request时间的datetime结构
             if re_time.date() < datetime.now().date():  # 如果搜过去时间
-                wrong("请不要搜索已经过去的时间!", render_context)
+                render_context.update(search_code=1,
+                                      search_message="请不要搜索已经过去的时间!")
                 return render(request, 'Appointment/index.html', render_context)
             elif re_time.date() - datetime.now().date() > timedelta(days=6):
                 # 查看了7天之后的
-                wrong("只能查看最近7天的情况!", render_context)
+                render_context.update(search_code=1,
+                                      search_message="只能查看最近7天的情况!")
                 return render(request, 'Appointment/index.html', render_context)
             # #974: 日期搜索直接展示当天可预约的地下室，而非跳转
             search_date = re_time.date()
@@ -752,24 +731,66 @@ def _get_content_students(contents: dict):
     assert len(students) == len(students_id), '预约人信息有误，请检查后重新发起预约！'
     return students
 
-def _add_appoint(contents: dict, start: datetime, finish: datetime, non_yp_num: int,
-               type: Appoint.Type = Appoint.Type.NORMAL,
-               notify_create: bool = True) -> tuple[Appoint | None, str]:
-    '''
-    创建一个预约，检查各种条件，屎山函数
+def _checkout_slot_fields(
+    room: Room, weekday: str, startid: int, endid: int, start_week: int,
+    posted_date: date | None,
+) -> dict:
+    """解析结算页时段。POST 必须携带 GET 时的绝对日期，不得按 weekday 重映射。"""
+    starttime, valid = web_func.get_hour_time(room, startid)
+    assert valid is True
+    endtime, valid = web_func.get_hour_time(room, endid + 1)
+    assert valid is True
+    dayrange_list = web_func.get_dayrange(day_offset=0)[0]
+    allowed = {
+        date(day['year'], day['month'], day['day']): day
+        for day in dayrange_list
+    }
+    if posted_date is not None:
+        if wklist[posted_date.weekday()] != weekday:
+            raise ValueError('预约日期与星期不一致，请重新选择时间')
+        if posted_date not in allowed:
+            raise ValueError('预约时段已过期，请重新选择时间')
+        slot_date = posted_date
+        day = allowed[slot_date]
+    else:
+        day = next(
+            (item for item in dayrange_list if item['weekday'] == weekday),
+            None,
+        )
+        if day is None:
+            raise ValueError('预约时段不合法，请重新选择时间')
+        slot_date = date(day['year'], day['month'], day['day'])
+    rmin = room.Rmin
+    if start_week == 0 and datetime.now().date() == slot_date:
+        rmin = min(CONFIG.today_min, room.Rmin)
+    return {
+        'date': day['date'],
+        'starttime': starttime,
+        'endtime': endtime,
+        'year': slot_date.year,
+        'month': slot_date.month,
+        'day': slot_date.day,
+        'Rmin': rmin,
+    }
 
-    :param contents: 屎山，只知道Sid: arg for `get_participant`
-    :type contents: dict
-    :param type: 预约类型, defaults to Appoint.Type.NORMAL
-    :type type: Appoint.Type, optional
-    :param check_contents: 是否检查参数，暂未启用, defaults to True
-    :type check_contents: bool, optional
-    :param notify_create: 是否通知参与者创建了新预约, defaults to True
-    :type notify_create: bool, optional
-    :return: (预约, 错误信息)
-    :rtype: tuple[Appoint | None, str]
+
+def _add_appoint(
+    contents: dict, start: datetime, finish: datetime, non_yp_num: int,
+    applicant: Participant, type: Appoint.Type = Appoint.Type.NORMAL,
+    notify_create: bool = True,
+) -> tuple[Appoint | None, str]:
+    '''
+    创建一个预约，检查各种条件。
+
+    发起人必须由调用方传入当前会话对应的 Participant，不得从 contents 读取。
     '''
     from Appointment.appoint.manage import _error
+
+    # 在函数边界移除客户端身份字段，避免后续维护时意外将其作为权威来源。
+    # 复制后再清理，防止修改调用方持有的字典。
+    contents = contents.copy()
+    contents.pop('Sid', None)
+    contents.pop('Sname', None)
 
     try:
         room = _get_content_room(contents)
@@ -802,13 +823,8 @@ def _add_appoint(contents: dict, start: datetime, finish: datetime, non_yp_num: 
     except:
         return _error('非法的预约信息！')
 
-    # 获取预约发起者,确认预约状态
-    major_student = get_participant(contents['Sid'])
-    if major_student is None:
-        return _error('发起人信息不存在！')
-
     return create_appoint(
-        appointer=major_student,
+        appointer=applicant,
         students=students,
         room=room, start=start, finish=finish,
         usage=usage, announce=announcement,
@@ -818,10 +834,14 @@ def _add_appoint(contents: dict, start: datetime, finish: datetime, non_yp_num: 
     )
 
 
+@csrf_protect
 @identity_check(redirect_field_name='origin')
 def checkout_appoint(request: UserRequest):
     """
-    提交预约表单，检查合法性，进行预约
+    结算页：GET 渲染预约表单，POST 创建预约。
+
+    发起人始终为当前登录会话对应的 Participant，忽略表单 Sid/Sname。
+    仅已登录且通过 identity_check（含地下室权限）的账号可写入。
     """
     stu_list = []
     json_context = {}
@@ -911,27 +931,38 @@ def checkout_appoint(request: UserRequest):
         'longterm': is_longterm,
         'start_week': start_week,
     }
-    # 表单参数都统一为可预约的第一周，具体预约哪周根据POST的start_week判断
-    dayrange_list = web_func.get_dayrange(day_offset=0)[0]
-    for day in dayrange_list:
-        if day['weekday'] == appoint_params['weekday']:
-            appoint_params['date'] = day['date']
-            appoint_params['starttime'], valid = web_func.get_hour_time(
-                room, appoint_params['startid'])
-            assert valid is True
-            appoint_params['endtime'], valid = web_func.get_hour_time(
-                room, appoint_params['endid'] + 1)
-            assert valid is True
-            appoint_params['year'] = day['year']
-            appoint_params['month'] = day['month']
-            appoint_params['day'] = day['day']
-            # 最小人数下限控制
-            appoint_params['Rmin'] = room.Rmin
-            if start_week == 0 and datetime.now().strftime(
-                    "%a") == appoint_params['weekday']:
-                appoint_params['Rmin'] = min(CONFIG.today_min,
-                                             room.Rmin)
-            break
+    posted_date = None
+    if request.method == 'POST':
+        try:
+            posted_date = date(
+                int(request.POST.get('year')),
+                int(request.POST.get('month')),
+                int(request.POST.get('day')),
+            )
+        except (TypeError, ValueError):
+            redirect_url = (
+                f'/underground/arrange_time?Rid={Rid}'
+                f'&start_week={safe_start_week}'
+            )
+            if is_longterm:
+                redirect_url += '&longterm=on'
+            return redirect(message_url(
+                wrong('预约时段无效，请重新选择时间'), redirect_url,
+            ))
+    try:
+        appoint_params.update(_checkout_slot_fields(
+            room, weekday, startid, endid, start_week,
+            posted_date=posted_date,
+        ))
+    except (AssertionError, ValueError) as exc:
+        redirect_url = (
+            f'/underground/arrange_time?Rid={Rid}'
+            f'&start_week={safe_start_week}'
+        )
+        if is_longterm:
+            redirect_url += '&longterm=on'
+        message = str(exc) if isinstance(exc, ValueError) else '预约时段不合法'
+        return redirect(message_url(wrong(message), redirect_url))
     appoint_params['Sid'] = applicant.get_id()
     appoint_params['Sname'] = applicant.name
 
@@ -964,6 +995,9 @@ def checkout_appoint(request: UserRequest):
                 contents[key] = contents[key][0]
                 if key in {'year', 'month', 'day'}:
                     contents[key] = int(contents[key])
+        # 发起人只绑定当前会话，忽略客户端提交的身份字段
+        contents.pop('Sid', None)
+        contents.pop('Sname', None)
         # 处理外院人数
         if contents['non_yp_num'] == "":
             contents['non_yp_num'] = 0
@@ -975,11 +1009,12 @@ def checkout_appoint(request: UserRequest):
         # 检查是否未填写房间用途
         if not contents['Ausage']:
             wrong("请输入房间用途!", render_context)
-        # 处理单人预约
+        # 处理单人预约：参与人必须包含当前会话用户
+        applicant_id = applicant.get_id()
         if "students" not in contents.keys():
-            contents['students'] = [contents['Sid']]
+            contents['students'] = [applicant_id]
         else:
-            contents['students'].append(contents['Sid'])
+            contents['students'].append(applicant_id)
         
         # 不允许用非活跃用户凑数
         # 虽然在生成搜索列表时已经排除了非活跃用户，但这里再检查一次，以防万一
@@ -1029,10 +1064,16 @@ def checkout_appoint(request: UserRequest):
         if not applicant.Sid.active:
             wrong('您已毕业，不能预约地下室', render_context)
 
-        start_time = datetime(contents['year'], contents['month'], contents['day'],
-                              *map(int, contents['starttime'].split(":")))
-        end_time = datetime(contents['year'], contents['month'], contents['day'],
-                            *map(int, contents['endtime'].split(":")))
+        start_time = datetime(
+            appoint_params['year'], appoint_params['month'],
+            appoint_params['day'],
+            *map(int, appoint_params['starttime'].split(':')),
+        )
+        end_time = datetime(
+            appoint_params['year'], appoint_params['month'],
+            appoint_params['day'],
+            *map(int, appoint_params['endtime'].split(':')),
+        )
         # TODO: 隔周预约的处理可优化，根据start_week调整实际预约时间
         start_time += timedelta(weeks=start_week)
         end_time += timedelta(weeks=start_week)
@@ -1065,8 +1106,10 @@ def checkout_appoint(request: UserRequest):
                 _notify = False
             elif is_interview:
                 appoint_type = Appoint.Type.INTERVIEW
-            response = _add_appoint(contents, start_time, end_time, non_yp_num=non_yp_num,
-                                    type=appoint_type, notify_create=_notify)
+            response = _add_appoint(
+                contents, start_time, end_time, non_yp_num=non_yp_num,
+                applicant=applicant, type=appoint_type,
+                notify_create=_notify)
             appoint, err_msg = response
             if appoint is not None and not is_longterm:
                 # 成功预约且非长期

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -278,60 +278,12 @@ def credit(request):
     return render(request, 'Appointment/admin-credit.html', render_context)
 
 
-# #974: 三个区块的搜索互相独立，scope -> (日期字段名, 房间列表的上下文变量名)
-_SEARCH_SCOPES = {
-    'func': ('func_request_time', 'function_room_list'),
-    'talk': ('request_time', 'talk_room_list'),
-    'russ': ('russ_request_time', 'russian_room_list'),
-}
-
-
-def _parse_search_date(date_str: str):
-    """#974: 解析搜索日期，兼容DD/MM/YYYY与DD-MM-YYYY两种分隔符。"""
-    try:
-        return datetime.strptime(date_str.strip().replace('/', '-'), '%d-%m-%Y').date()
-    except ValueError:
-        return None
-
-
-def _parse_search_time(time_str: str):
-    """#974: 解析搜索时段中的时间，接受HH:MM或HH:MM:SS。"""
-    for fmt in ('%H:%M', '%H:%M:%S'):
-        try:
-            return datetime.strptime(time_str.strip(), fmt).time()
-        except ValueError:
-            continue
-    return None
-
-
-def _room_matches(room: Room, search_date: date, start_time=None,
-                  finish_time=None, capacity=None) -> bool:
-    """#974: 判断房间是否满足搜索条件。
-
-    - 人数：需落在房间的[Rmin, Rmax]区间内；
-    - 未指定时段：当天任意30分钟时间块空闲即视为可预约；
-    - 指定时段：该时段覆盖的时间块必须全部空闲。
-    """
+def _room_has_free_slot(room, search_date):
+    """#974: 判断房间在指定日期是否仍有可预约空位（任一30分钟时间块空闲即算）。"""
     if room.Rstatus == Room.Status.FORBIDDEN:
         return False
-    if capacity is not None and not room.Rmin <= capacity <= room.Rmax:
-        return False
-    max_stamp_id = web_func.get_time_id(room, room.Rfinish, mode='leftopen')
+    max_stamp_id = web_func.get_time_id(room, room.Rfinish, mode="leftopen")
     if max_stamp_id < 0:
-        return False
-    exact_range = start_time is not None or finish_time is not None
-    left_id, right_id = 0, max_stamp_id
-    if start_time is not None:
-        left_id = max(left_id, web_func.get_time_id(room, start_time))
-    if finish_time is not None:
-        right_id = min(right_id, web_func.get_time_id(
-            room, finish_time, mode='leftopen'))
-    if search_date == datetime.now().date():
-        now_id = web_func.get_time_id(room, datetime.now().time())
-        if exact_range and now_id > left_id:
-            return False                    # 指定时段已经开始，无法完整预约
-        left_id = max(left_id, now_id)
-    if right_id < left_id:
         return False
     booked = set()
     appoints = Appoint.objects.not_canceled().filter(
@@ -340,15 +292,15 @@ def _room_matches(room: Room, search_date: date, start_time=None,
         Astart__date__lt=search_date + timedelta(days=1),
     )
     for appoint in appoints:
-        booked.update(web_func.timerange2idlist(
-            room.Rid, appoint.Astart, appoint.Afinish, max_stamp_id))
-    for stamp_id in range(left_id, right_id + 1):
-        if stamp_id in booked:
-            if exact_range:
-                return False
-        elif not exact_range:
+        for i in web_func.timerange2idlist(room.Rid, appoint.Astart, appoint.Afinish, max_stamp_id):
+            booked.add(i)
+    start_id = 0
+    if search_date == datetime.now().date():
+        start_id = max(start_id, web_func.get_time_id(room, datetime.now().time()))
+    for i in range(start_id, max_stamp_id + 1):
+        if i not in booked:
             return True
-    return exact_range
+    return False
 
 
 @identity_check(redirect_field_name='origin', auth_func=lambda x: True)
@@ -415,70 +367,47 @@ def index(request):  # 主页
     )
 
     if request.method == "POST":
-        # #974: 三个区块的搜索彼此独立，由search_scope决定只筛选哪一个列表
-        scope = request.POST.get('search_scope', '')
-        if scope not in _SEARCH_SCOPES:
-            # 兼容未携带search_scope的旧表单：按日期字段名推断区块
-            for guess, (guess_field, _) in _SEARCH_SCOPES.items():
-                if request.POST.get(guess_field) is not None:
-                    scope = guess
-                    break
-        if scope not in _SEARCH_SCOPES:
-            return render(request, 'Appointment/index.html', render_context)
 
-        date_field, list_key = _SEARCH_SCOPES[scope]
-        date_str = (request.POST.get(date_field) or '').strip()
-        start_str = (request.POST.get('start_time') or '').strip()
-        finish_str = (request.POST.get('finish_time') or '').strip()
-        capacity_str = (request.POST.get('capacity') or '').strip()
-        if not any([date_str, start_str, finish_str, capacity_str]):
-            # 什么条件都没填，等同于不筛选
-            return render(request, 'Appointment/index.html', render_context)
-
-        today = datetime.now().date()
-        if date_str:
-            search_date = _parse_search_date(date_str)
-            if search_date is None:
-                wrong('日期格式不正确，请重新选择!', render_context)
-                return render(request, 'Appointment/index.html', render_context)
+        # YHT: added for Russian search
+        request_time = request.POST.get("request_time", None)
+        russ_request_time = request.POST.get("russ_request_time", None)
+        check_type = ""
+        if request_time is None and russ_request_time is not None:
+            check_type = "russ"
+            request_time = russ_request_time
+        elif request_time is not None and russ_request_time is None:
+            check_type = "talk"
         else:
-            search_date = today                 # 只填时段或人数时默认查询当天
-        if search_date < today:
-            wrong('请不要搜索已经过去的时间!', render_context)
-            return render(request, 'Appointment/index.html', render_context)
-        if search_date - today > timedelta(days=6):
-            wrong('只能查看最近7天的情况!', render_context)
             return render(request, 'Appointment/index.html', render_context)
 
-        start_time = _parse_search_time(start_str) if start_str else None
-        finish_time = _parse_search_time(finish_str) if finish_str else None
-        if (start_str and start_time is None) or (finish_str and finish_time is None):
-            wrong('时段格式不正确，请重新选择!', render_context)
-            return render(request, 'Appointment/index.html', render_context)
-        if start_time is not None and finish_time is not None and start_time >= finish_time:
-            wrong('时段的开始时间应早于结束时间!', render_context)
-            return render(request, 'Appointment/index.html', render_context)
-
-        capacity = None
-        if capacity_str:
-            if not capacity_str.isdigit() or int(capacity_str) <= 0:
-                wrong('请输入正确的使用人数!', render_context)
+        if request_time != None and request_time != "":  # 初始加载或者不选时间直接搜索则直接返回index页面，否则进行如下反查时间
+            day, month, year = int(request_time[:2]), int(
+                request_time[3:5]), int(request_time[6:10])
+            re_time = datetime(year, month, day)  # 获取目前request时间的datetime结构
+            if re_time.date() < datetime.now().date():  # 如果搜过去时间
+                wrong("请不要搜索已经过去的时间!", render_context)
                 return render(request, 'Appointment/index.html', render_context)
-            capacity = int(capacity_str)
-
-        matched = [room for room in render_context[list_key]
-                   if _room_matches(room, search_date, start_time,
-                                    finish_time, capacity)]
-        render_context.update({
-            list_key: matched,
-            'search_scope': scope,
-            'search_date': search_date,
-            'search_date_value': search_date.strftime('%d/%m/%Y'),
-            'search_start': start_str,
-            'search_finish': finish_str,
-            'search_capacity': capacity,
-            'bookable_count': len(matched),
-        })
+            elif re_time.date() - datetime.now().date() > timedelta(days=6):
+                # 查看了7天之后的
+                wrong("只能查看最近7天的情况!", render_context)
+                return render(request, 'Appointment/index.html', render_context)
+            # #974: 日期搜索直接展示当天可预约的地下室，而非跳转
+            search_date = re_time.date()
+            all_rooms = list(function_room_list) + list(talk_room_list) + list(russian_room_list)
+            bookable = {r.Rid for r in all_rooms if _room_has_free_slot(r, search_date)}
+            function_room_list = [r for r in function_room_list if r.Rid in bookable]
+            talk_room_list = [r for r in talk_room_list if r.Rid in bookable]
+            russian_room_list = [r for r in russian_room_list if r.Rid in bookable]
+            russ_len = len(russian_room_list)
+            render_context.update(
+                search_date=search_date,
+                bookable_count=len(bookable),
+                function_room_list=function_room_list,
+                talk_room_list=talk_room_list,
+                russian_room_list=russian_room_list,
+                russ_len=russ_len,
+            )
+            return render(request, 'Appointment/index.html', render_context)
 
     return render(request, 'Appointment/index.html', render_context)
 

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -4,8 +4,6 @@ from datetime import datetime, timedelta, date
 
 from django.views.decorators.http import require_POST
 from django.shortcuts import render, redirect
-from django.http import JsonResponse
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.contrib import auth
 from django.db.models import QuerySet
@@ -417,23 +415,16 @@ def index(request):  # 主页
     )
 
     if request.method == "POST":
-        # #974: 三个区块的搜索彼此独立，由search_scope决定只筛选哪一个列表；提交走AJAX原地刷新
-        is_ajax = request.headers.get('x-requested-with') == 'XMLHttpRequest'
-
-        def _reject(msg):
-            if is_ajax:
-                return JsonResponse({'error': msg})
-            wrong(msg, render_context)
-            return render(request, 'Appointment/index.html', render_context)
-
+        # #974: 三个区块的搜索彼此独立，由search_scope决定只筛选哪一个列表
         scope = request.POST.get('search_scope', '')
         if scope not in _SEARCH_SCOPES:
+            # 兼容未携带search_scope的旧表单：按日期字段名推断区块
             for guess, (guess_field, _) in _SEARCH_SCOPES.items():
                 if request.POST.get(guess_field) is not None:
                     scope = guess
                     break
         if scope not in _SEARCH_SCOPES:
-            return _reject('搜索范围无效')
+            return render(request, 'Appointment/index.html', render_context)
 
         date_field, list_key = _SEARCH_SCOPES[scope]
         date_str = (request.POST.get(date_field) or '').strip()
@@ -441,57 +432,43 @@ def index(request):  # 主页
         finish_str = (request.POST.get('finish_time') or '').strip()
         capacity_str = (request.POST.get('capacity') or '').strip()
         if not any([date_str, start_str, finish_str, capacity_str]):
-            if is_ajax:
-                cards_html = render_to_string(
-                    'Appointment/_room_cards.html', {'rooms': render_context[list_key]})
-                return JsonResponse({'cards_html': cards_html, 'banner_html': '', 'bookable_count': len(render_context[list_key]), 'scope': scope})
+            # 什么条件都没填，等同于不筛选
             return render(request, 'Appointment/index.html', render_context)
 
         today = datetime.now().date()
         if date_str:
             search_date = _parse_search_date(date_str)
             if search_date is None:
-                return _reject('日期格式不正确，请重新选择!')
+                wrong('日期格式不正确，请重新选择!', render_context)
+                return render(request, 'Appointment/index.html', render_context)
         else:
-            search_date = today
+            search_date = today                 # 只填时段或人数时默认查询当天
         if search_date < today:
-            return _reject('请不要搜索已经过去的时间!')
+            wrong('请不要搜索已经过去的时间!', render_context)
+            return render(request, 'Appointment/index.html', render_context)
         if search_date - today > timedelta(days=6):
-            return _reject('只能查看最近7天的情况!')
+            wrong('只能查看最近7天的情况!', render_context)
+            return render(request, 'Appointment/index.html', render_context)
 
         start_time = _parse_search_time(start_str) if start_str else None
         finish_time = _parse_search_time(finish_str) if finish_str else None
         if (start_str and start_time is None) or (finish_str and finish_time is None):
-            return _reject('时段格式不正确，请重新选择!')
+            wrong('时段格式不正确，请重新选择!', render_context)
+            return render(request, 'Appointment/index.html', render_context)
         if start_time is not None and finish_time is not None and start_time >= finish_time:
-            return _reject('时段的开始时间应早于结束时间!')
+            wrong('时段的开始时间应早于结束时间!', render_context)
+            return render(request, 'Appointment/index.html', render_context)
 
         capacity = None
         if capacity_str:
             if not capacity_str.isdigit() or int(capacity_str) <= 0:
-                return _reject('请输入正确的使用人数!')
+                wrong('请输入正确的使用人数!', render_context)
+                return render(request, 'Appointment/index.html', render_context)
             capacity = int(capacity_str)
 
         matched = [room for room in render_context[list_key]
                    if _room_matches(room, search_date, start_time,
                                     finish_time, capacity)]
-        if is_ajax:
-            cards_html = render_to_string(
-                'Appointment/_room_cards.html', {'rooms': matched})
-            banner_html = render_to_string(
-                'Appointment/_room_search_banner.html', {
-                    'search_date': search_date,
-                    'search_start': start_str,
-                    'search_finish': finish_str,
-                    'search_capacity': capacity,
-                    'bookable_count': len(matched),
-                })
-            return JsonResponse({
-                'cards_html': cards_html,
-                'banner_html': banner_html,
-                'bookable_count': len(matched),
-                'scope': scope,
-            })
         render_context.update({
             list_key: matched,
             'search_scope': scope,

--- a/Appointment/views.py
+++ b/Appointment/views.py
@@ -304,6 +304,30 @@ def _room_has_free_slot(room, search_date):
 
 
 @identity_check(redirect_field_name='origin', auth_func=lambda x: True)
+def _room_has_free_slot(room, search_date):
+    """#974: 判断房间在指定日期是否仍有可预约空位（任一30分钟时间块空闲即算）。"""
+    if room.Rstatus == Room.Status.FORBIDDEN:
+        return False
+    max_stamp_id = web_func.get_time_id(room, room.Rfinish, mode="leftopen")
+    if max_stamp_id < 0:
+        return False
+    booked = set()
+    appoints = Appoint.objects.not_canceled().filter(
+        Room_id=room.Rid,
+        Afinish__gte=search_date,
+        Astart__date__lt=search_date + timedelta(days=1),
+    )
+    for appoint in appoints:
+        for i in web_func.timerange2idlist(room.Rid, appoint.Astart, appoint.Afinish, max_stamp_id):
+            booked.add(i)
+    start_id = 0
+    if search_date == datetime.now().date():
+        start_id = max(start_id, web_func.get_time_id(room, datetime.now().time()))
+    for i in range(start_id, max_stamp_id + 1):
+        if i not in booked:
+            return True
+    return False
+
 def index(request):  # 主页
     render_context = {}
     render_context.update(

--- a/templates/Appointment/_room_cards.html
+++ b/templates/Appointment/_room_cards.html
@@ -1,0 +1,29 @@
+{% load static %}
+{% for room in rooms %}
+<div class="profile-widget">
+	<div class="doc-img">
+		<img class="img-fluid" alt="User Image" src="{% static 'Appointment/assets/img/RoomIcon/' %}{{room.Rid}}.png">
+	</div>
+	<div class="pro-content">
+		<h3 class="title">
+			<p>{{room}}</p>
+		</h3>
+		<ul class="available-info">
+			<li>
+				<i class="far fa fa-child"></i> {{room.Rmin}}-{{room.Rmax}}人可用
+			</li>
+			<li>
+				<i class="far fa fa-history"></i> {{room.Rstart}}-{{room.Rfinish}}
+				<i class="fas fa-info-circle" data-toggle="tooltip" title="可用时间"></i>
+			</li>
+		</ul>
+		<div class="row row-sm" style="text-align:center">
+			<div class="col-12">
+				<a href="arrange_time?Rid={{room.Rid}}" class="btn book-btn">预约</a>
+			</div>
+		</div>
+	</div>
+</div>
+{% empty %}
+<div class="w-100 text-center text-muted py-4">暂无可预约的房间</div>
+{% endfor %}

--- a/templates/Appointment/_room_search.html
+++ b/templates/Appointment/_room_search.html
@@ -1,0 +1,46 @@
+{% comment %}
+#974: 地下室房间搜索表单。功能房/研讨室/俄文楼三个区块各自独立使用一份，
+通过 scope 区分，互不干扰。支持按日期、时段、使用人数组合筛选。
+参数：scope（func/talk/russ）、date_field（该区块的日期字段名）。
+{% endcomment %}
+<div class="room-search">
+	<form method="POST">
+		{% csrf_token %}
+		<input type="hidden" name="search_scope" value="{{ scope }}">
+		<div class="form-row justify-content-center align-items-center">
+			<div class="col-12 col-sm-4 col-md-3 mb-2">
+				<input type="text" class="form-control datetimepicker" autocomplete="off"
+					name="{{ date_field }}" placeholder="选择日期"
+					value="{% if search_scope == scope %}{{ search_date_value }}{% endif %}">
+			</div>
+			<div class="col-6 col-sm-3 col-md-2 mb-2">
+				<input type="time" class="form-control" name="start_time" title="时段开始"
+					value="{% if search_scope == scope %}{{ search_start }}{% endif %}">
+			</div>
+			<div class="col-6 col-sm-3 col-md-2 mb-2">
+				<input type="time" class="form-control" name="finish_time" title="时段结束"
+					value="{% if search_scope == scope %}{{ search_finish }}{% endif %}">
+			</div>
+			<div class="col-6 col-sm-2 col-md-2 mb-2">
+				<input type="number" class="form-control" name="capacity" min="1" placeholder="人数"
+					title="使用人数" value="{% if search_scope == scope %}{{ search_capacity|default_if_none:'' }}{% endif %}">
+			</div>
+			<div class="col-6 col-sm-auto mb-2">
+				<button type="submit" class="btn btn-primary btn-block">
+					<i class="fas fa-search"></i>&nbsp;搜索
+				</button>
+			</div>
+			{% if search_scope == scope %}
+			<div class="col-6 col-sm-auto mb-2">
+				<a href="index" class="btn btn-outline-secondary btn-block">清除</a>
+			</div>
+			{% endif %}
+		</div>
+	</form>
+</div>
+{% if search_scope == scope %}
+<div class="alert {% if bookable_count %}alert-info{% else %}alert-warning{% endif %} text-center py-2">
+	{{ search_date|date:"n月j日" }}{% if search_start %} {{ search_start }}{% endif %}{% if search_finish %}~{{ search_finish }}{% endif %}{% if search_capacity %} · {{ search_capacity }}人{% endif %}
+	{% if bookable_count %}可预约房间共 <b>{{ bookable_count }}</b> 间{% else %}没有符合条件的房间，可放宽时段或人数再试{% endif %}
+</div>
+{% endif %}

--- a/templates/Appointment/_room_search_banner.html
+++ b/templates/Appointment/_room_search_banner.html
@@ -1,0 +1,4 @@
+<div class="alert {% if bookable_count %}alert-info{% else %}alert-warning{% endif %} text-center py-2">
+	{{ search_date|date:"n月j日" }}{% if search_start %} {{ search_start }}{% endif %}{% if search_finish %}~{{ search_finish }}{% endif %}{% if search_capacity %} · {{ search_capacity }}人{% endif %}
+	{% if bookable_count %}可预约房间共 <b>{{ bookable_count }}</b> 间{% else %}没有符合条件的房间，可放宽时段或人数再试{% endif %}
+</div>

--- a/templates/Appointment/index.html
+++ b/templates/Appointment/index.html
@@ -51,24 +51,11 @@
 				content: "\f067"; 
 			}
 		
-		/* #974: 一键展开后改为无图紧凑网格，手机上一屏可见更多房间，无需反复横滑 */
-		.doctor-slider.expanded { display: -webkit-box; display: -ms-flexbox; display: flex; -ms-flex-wrap: wrap; flex-wrap: wrap; -webkit-box-pack: center; -ms-flex-pack: center; justify-content: center; }
-		.doctor-slider.expanded .slick-list, .doctor-slider.expanded .slick-track { transform: none !important; width: 100% !important; height: auto !important; overflow: visible !important; }
+		.doctor-slider.expanded { display: -webkit-box; display: -ms-flexbox; display: flex; -ms-flex-wrap: wrap; flex-wrap: wrap; }
+		.doctor-slider.expanded .slick-list { overflow: visible !important; height: auto !important; }
+		.doctor-slider.expanded .slick-track { transform: none !important; width: 100% !important; display: -webkit-box; display: -ms-flexbox; display: flex; -ms-flex-wrap: wrap; flex-wrap: wrap; }
 		.doctor-slider.expanded .slick-slide { width: auto !important; float: none !important; height: auto !important; }
-		.doctor-slider.expanded .doc-img { display: none; }
-		.doctor-slider.expanded .profile-widget { width: calc(50% - 12px); margin: 6px; padding: 10px; }
-		.doctor-slider.expanded .pro-content .title { font-size: 15px; margin-bottom: 4px; }
-		.doctor-slider.expanded .available-info { font-size: 12px; margin-bottom: 6px; }
-		.doctor-slider.expanded .available-info li { margin-bottom: 2px; }
-		.doctor-slider.expanded .book-btn { padding: 4px 0; font-size: 13px; }
-		@media (min-width: 576px) { .doctor-slider.expanded .profile-widget { width: calc(33.3333% - 12px); } }
-		@media (min-width: 992px) { .doctor-slider.expanded .profile-widget { width: calc(20% - 12px); } }
-		@media (min-width: 1400px) { .doctor-slider.expanded .profile-widget { width: calc(12.5% - 12px); } }
-		/* #974: 区块工具条——居中的快速查找框与一键展开按钮 */
-		.room-toolbar { margin-top: 14px; margin-bottom: 18px; }
-		.room-toolbar .room-quick-filter { max-width: 280px; margin: 0 auto 12px; text-align: center; }
-		.room-toolbar .room-expand-btn { display: inline-block; min-width: 120px; }
-		.room-search { max-width: 940px; margin: 0 auto 6px; }
+		.doctor-slider.expanded .profile-widget { margin: 8px; }
 		</style>
 		{% endblock %}
 	
@@ -258,6 +245,12 @@
 		  
 
 			
+			{% if search_date %}
+			<div class="alert alert-info text-center">
+			已按日期 <b>{{ search_date|date:"Y年n月j日" }}</b> 筛选：当天可预约的地下室共 <b>{{ bookable_count }}</b> 间
+			<a href="index" class="alert-link">清除筛选</a>
+			</div>
+			{% endif %}
 			<!-- 功能房预约 -->
 			<section class="section section-doctor" >
 				<div class="container-fluid" >
@@ -265,15 +258,8 @@
 					<div class="col-lg-4">-->
 							<div class="section-header text-center">
 								<h2>功能房预约</h2>
+						<button type="button" class="btn btn-outline-primary btn-sm ml-2" onclick="toggleRoomExpand(this)">一键展开</button>
 								
-							</div>
-							{% include "Appointment/_room_search.html" with scope="func" date_field="func_request_time" %}
-							<div class="room-toolbar text-center">
-								<input type="text" class="form-control room-quick-filter" autocomplete="off"
-									placeholder="输入房间号或名称快速查找" oninput="quickFilterRooms(this)">
-								<button type="button" class="btn btn-outline-primary btn-sm room-expand-btn"
-									onclick="toggleRoomExpand(this)">一键展开</button>
-								<div class="room-filter-empty text-muted small mt-2" style="display: none;">没有匹配的房间</div>
 							</div>
 							<!--<div class="banner-wrapper">
 								
@@ -335,8 +321,6 @@
 							</div>
 							<!-- /Doctor Widget -->
 					
-						{% empty %}
-						<div class="w-100 text-center text-muted py-4">暂无可预约的房间</div>
 						{% endfor %}	
 						</div>
 						
@@ -353,6 +337,7 @@
 					<div class="col-lg-4">-->
 						<div class="section-header text-center">
 							<h2>研讨室预约</h2>
+						<button type="button" class="btn btn-outline-primary btn-sm ml-2" onclick="toggleRoomExpand(this)">一键展开</button>
 							
 						</div>
 						<div class="banner-wrapper">
@@ -360,14 +345,31 @@
 								<h3></h3>
 							</div>
 							-->
-							{% include "Appointment/_room_search.html" with scope="talk" date_field="request_time" %}
-							<div class="room-toolbar text-center">
-								<input type="text" class="form-control room-quick-filter" autocomplete="off"
-									placeholder="输入房间号或名称快速查找" oninput="quickFilterRooms(this)">
-								<button type="button" class="btn btn-outline-primary btn-sm room-expand-btn"
-									onclick="toggleRoomExpand(this)">一键展开</button>
-								<div class="room-filter-empty text-muted small mt-2" style="display: none;">没有匹配的房间</div>
+							<!-- Search -->
+							<div class="search-box">
+								<form method="POST">
+									{% csrf_token %}
+									<!--
+									<div class="form-group search-location">
+										<input type="text" class="form-control" placeholder="Search Location">
+										<span class="form-text">Based on your Location</span>
+									</div>
+									-->
+									<div class="row" style="margin: 0 auto">
+									<div class="form search-info" >
+										<div class="cal-icon">
+											<input type="text" class="form-control datetimepicker" placeholder="选择预约日期" name="request_time">
+										</div>	
+										<!--<input type="text" class="form-control " name="request_time" value="{{nowtime}}">
+										-->
+										<!--<span class="form-text">查看对应时间的空闲房间</span>-->
+										
+									</div>
+									<button type="submit" class="btn btn-primary search-btn"><i class="fas fa-search"></i> <span>Search</span></button>
+								</div>
+								</form>
 							</div>
+							<!-- /Search -->
 							
 						
 						</div>
@@ -426,8 +428,6 @@
 							</div>
 							<!-- /Doctor Widget -->
 					
-						{% empty %}
-						<div class="w-100 text-center text-muted py-4">暂无可预约的房间</div>
 						{% endfor %}	
 						</div>
 							
@@ -445,6 +445,7 @@
 						<div class="col-lg-4">-->
 								<div class="section-header text-center">
 									<h2>俄文楼预约</h2>
+						<button type="button" class="btn btn-outline-primary btn-sm ml-2" onclick="toggleRoomExpand(this)">一键展开</button>
 									<p>个人面试 / 线上授课</p>
 								</div>
 								<!--<div class="banner-wrapper">
@@ -461,14 +462,29 @@
 								<a href="javascript:;">Read More..</a>
 							</div>
 							-->
-						{% include "Appointment/_room_search.html" with scope="russ" date_field="russ_request_time" %}
-						<div class="room-toolbar text-center">
-							<input type="text" class="form-control room-quick-filter" autocomplete="off"
-								placeholder="输入房间号或名称快速查找" oninput="quickFilterRooms(this)">
-							<button type="button" class="btn btn-outline-primary btn-sm room-expand-btn"
-								onclick="toggleRoomExpand(this)">一键展开</button>
-							<div class="room-filter-empty text-muted small mt-2" style="display: none;">没有匹配的房间</div>
+						<!-- Search -->
+						<div class="search-box">
+							<form method="POST">
+								{% csrf_token %}
+								<!--
+								<div class="form-group search-location">
+									<input type="text" class="form-control" placeholder="Search Location">
+									<span class="form-text">Based on your Location</span>
+								</div>
+								-->
+								<div class="row" style="margin: 0 auto">
+								<div class="form search-info" >
+									<div class="cal-icon">
+										<input type="text" class="form-control datetimepicker" placeholder="选择预约日期" name="russ_request_time">
+									</div>	
+									<!--<span class="form-text">查看对应时间的空闲房间</span>-->
+									
+								</div>
+								<button type="submit" class="btn btn-primary search-btn"><i class="fas fa-search"></i> <span>Search</span></button>
+							</div>
+							</form>
 						</div>
+						<!-- /Search -->
 						<!--</div>
 						<div class="col-lg-8">-->
 							<div class="doctor-slider slider" >
@@ -515,8 +531,6 @@
 								</div>
 								<!-- /Doctor Widget -->
 						
-							{% empty %}
-							<div class="w-100 text-center text-muted py-4">暂无可预约的房间</div>
 							{% endfor %}	
 							</div>
 							
@@ -596,58 +610,21 @@
 		
 	
 		<script type="text/javascript">
-			// #974: 展开为无图网格 + 输入即时筛选，避免在手机上反复横向滑动找房间
-			function expandRoomSlider($slider) {
-				if ($slider.data("expanded")) { return; }
-				if ($slider.hasClass("slick-initialized")) {
-					$slider.slick("unslick");
+				function toggleRoomExpand(btn) {
+					var $section = $(btn).closest("section");
+					var $slider = $section.find(".doctor-slider");
+					if (!$slider.data("expanded")) {
+						$slider.slick("unslick");
+						$slider.addClass("expanded");
+						$slider.data("expanded", true);
+						$(btn).text("收起");
+					} else {
+						$slider.removeClass("expanded");
+						$slider.slick({ dots: false, autoplay: false, infinite: true, variableWidth: true });
+						$slider.data("expanded", false);
+						$(btn).text("一键展开");
+					}
 				}
-				$slider.addClass("expanded");
-				$slider.data("expanded", true);
-			}
-
-			function collapseRoomSlider($slider) {
-				if (!$slider.data("expanded")) { return; }
-				$slider.removeClass("expanded");
-				$slider.slick({ dots: false, autoplay: false, infinite: true, variableWidth: true });
-				$slider.data("expanded", false);
-			}
-
-			function filterRoomCards($section, keyword) {
-				var kw = $.trim(keyword).toLowerCase();
-				var matched = 0;
-				$section.find(".profile-widget").each(function () {
-					var hit = (kw === "" || $(this).text().toLowerCase().indexOf(kw) !== -1);
-					$(this).toggle(hit);
-					if (hit) { matched += 1; }
-				});
-				$section.find(".room-filter-empty").toggle(matched === 0 && kw !== "");
-			}
-
-			function toggleRoomExpand(btn) {
-				var $section = $(btn).closest("section");
-				var $slider = $section.find(".doctor-slider");
-				if (!$slider.data("expanded")) {
-					expandRoomSlider($slider);
-					$(btn).text("收起");
-				} else {
-					$section.find(".room-quick-filter").val("");
-					filterRoomCards($section, "");
-					collapseRoomSlider($slider);
-					$(btn).text("一键展开");
-				}
-			}
-
-			function quickFilterRooms(input) {
-				var $section = $(input).closest("section");
-				var $slider = $section.find(".doctor-slider");
-				if ($.trim(input.value) !== "") {
-					// 轮播模式下隐藏卡片会错位，输入时自动切换为网格
-					expandRoomSlider($slider);
-					$section.find(".room-expand-btn").text("收起");
-				}
-				filterRoomCards($section, input.value);
-			}
 		</script>
 	</body>
 </html>

--- a/templates/Appointment/index.html
+++ b/templates/Appointment/index.html
@@ -648,51 +648,6 @@
 				}
 				filterRoomCards($section, input.value);
 			}
-		
-	function escapeHtml(s) {
-		return $('<div>').text(s).html();
-	}
-
-	function doRoomSearch(form) {
-		var $form = $(form);
-		var $section = $form.closest("section");
-		var $slider = $section.find(".doctor-slider");
-		// 搜索即展开为网格，便于直接看到过滤结果
-		expandRoomSlider($slider);
-		$section.find(".room-expand-btn").text("收起");
-		var fd = new FormData(form);
-		fetch(window.location.pathname, {
-			method: "POST",
-			headers: { "X-Requested-With": "XMLHttpRequest" },
-			body: fd,
-			credentials: "same-origin"
-		})
-		.then(function (resp) { return resp.json(); })
-		.then(function (data) {
-			if (data.error) {
-				$section.find(".room-search-banner").html(
-					'<div class="alert alert-warning text-center py-2">' + escapeHtml(data.error) + '</div>');
-				return;
-			}
-			$slider.html(data.cards_html);
-			$section.find(".room-search-banner").html(data.banner_html);
-			var kw = $section.find(".room-quick-filter").val();
-			if (kw) { filterRoomCards($section, kw); }
-		})
-		.catch(function (err) { console.error("地下室搜索失败", err); });
-	}
-
-	function submitRoomSearch(form, e) {
-		if (e && e.preventDefault) { e.preventDefault(); }
-		doRoomSearch(form);
-		return false;
-	}
-
-	function clearRoomSearch(btn) {
-		var $form = $(btn).closest("form");
-		$form[0].reset();
-		doRoomSearch($form[0]);
-	}
-</script>
+		</script>
 	</body>
 </html>

--- a/templates/Appointment/index.html
+++ b/templates/Appointment/index.html
@@ -50,6 +50,25 @@
 			[data-toggle="collapse"].collapsed .fa:before {
 				content: "\f067"; 
 			}
+		
+		/* #974: 一键展开后改为无图紧凑网格，手机上一屏可见更多房间，无需反复横滑 */
+		.doctor-slider.expanded { display: -webkit-box; display: -ms-flexbox; display: flex; -ms-flex-wrap: wrap; flex-wrap: wrap; -webkit-box-pack: center; -ms-flex-pack: center; justify-content: center; }
+		.doctor-slider.expanded .slick-list, .doctor-slider.expanded .slick-track { transform: none !important; width: 100% !important; height: auto !important; overflow: visible !important; }
+		.doctor-slider.expanded .slick-slide { width: auto !important; float: none !important; height: auto !important; }
+		.doctor-slider.expanded .doc-img { display: none; }
+		.doctor-slider.expanded .profile-widget { width: calc(50% - 12px); margin: 6px; padding: 10px; }
+		.doctor-slider.expanded .pro-content .title { font-size: 15px; margin-bottom: 4px; }
+		.doctor-slider.expanded .available-info { font-size: 12px; margin-bottom: 6px; }
+		.doctor-slider.expanded .available-info li { margin-bottom: 2px; }
+		.doctor-slider.expanded .book-btn { padding: 4px 0; font-size: 13px; }
+		@media (min-width: 576px) { .doctor-slider.expanded .profile-widget { width: calc(33.3333% - 12px); } }
+		@media (min-width: 992px) { .doctor-slider.expanded .profile-widget { width: calc(20% - 12px); } }
+		@media (min-width: 1400px) { .doctor-slider.expanded .profile-widget { width: calc(12.5% - 12px); } }
+		/* #974: 区块工具条——居中的快速查找框与一键展开按钮 */
+		.room-toolbar { margin-top: 14px; margin-bottom: 18px; }
+		.room-toolbar .room-quick-filter { max-width: 280px; margin: 0 auto 12px; text-align: center; }
+		.room-toolbar .room-expand-btn { display: inline-block; min-width: 120px; }
+		.room-search { max-width: 940px; margin: 0 auto 6px; }
 		</style>
 		{% endblock %}
 	
@@ -238,6 +257,7 @@
 			<!-- Clinic and Specialities -->
 		  
 
+			
 			<!-- 功能房预约 -->
 			<section class="section section-doctor" >
 				<div class="container-fluid" >
@@ -246,6 +266,14 @@
 							<div class="section-header text-center">
 								<h2>功能房预约</h2>
 								
+							</div>
+							{% include "Appointment/_room_search.html" with scope="func" date_field="func_request_time" %}
+							<div class="room-toolbar text-center">
+								<input type="text" class="form-control room-quick-filter" autocomplete="off"
+									placeholder="输入房间号或名称快速查找" oninput="quickFilterRooms(this)">
+								<button type="button" class="btn btn-outline-primary btn-sm room-expand-btn"
+									onclick="toggleRoomExpand(this)">一键展开</button>
+								<div class="room-filter-empty text-muted small mt-2" style="display: none;">没有匹配的房间</div>
 							</div>
 							<!--<div class="banner-wrapper">
 								
@@ -307,6 +335,8 @@
 							</div>
 							<!-- /Doctor Widget -->
 					
+						{% empty %}
+						<div class="w-100 text-center text-muted py-4">暂无可预约的房间</div>
 						{% endfor %}	
 						</div>
 						
@@ -330,31 +360,14 @@
 								<h3></h3>
 							</div>
 							-->
-							<!-- Search -->
-							<div class="search-box">
-								<form method="POST">
-									{% csrf_token %}
-									<!--
-									<div class="form-group search-location">
-										<input type="text" class="form-control" placeholder="Search Location">
-										<span class="form-text">Based on your Location</span>
-									</div>
-									-->
-									<div class="row" style="margin: 0 auto">
-									<div class="form search-info" >
-										<div class="cal-icon">
-											<input type="text" class="form-control datetimepicker" placeholder="选择预约日期" name="request_time">
-										</div>	
-										<!--<input type="text" class="form-control " name="request_time" value="{{nowtime}}">
-										-->
-										<!--<span class="form-text">查看对应时间的空闲房间</span>-->
-										
-									</div>
-									<button type="submit" class="btn btn-primary search-btn"><i class="fas fa-search"></i> <span>Search</span></button>
-								</div>
-								</form>
+							{% include "Appointment/_room_search.html" with scope="talk" date_field="request_time" %}
+							<div class="room-toolbar text-center">
+								<input type="text" class="form-control room-quick-filter" autocomplete="off"
+									placeholder="输入房间号或名称快速查找" oninput="quickFilterRooms(this)">
+								<button type="button" class="btn btn-outline-primary btn-sm room-expand-btn"
+									onclick="toggleRoomExpand(this)">一键展开</button>
+								<div class="room-filter-empty text-muted small mt-2" style="display: none;">没有匹配的房间</div>
 							</div>
-							<!-- /Search -->
 							
 						
 						</div>
@@ -413,6 +426,8 @@
 							</div>
 							<!-- /Doctor Widget -->
 					
+						{% empty %}
+						<div class="w-100 text-center text-muted py-4">暂无可预约的房间</div>
 						{% endfor %}	
 						</div>
 							
@@ -446,29 +461,14 @@
 								<a href="javascript:;">Read More..</a>
 							</div>
 							-->
-						<!-- Search -->
-						<div class="search-box">
-							<form method="POST">
-								{% csrf_token %}
-								<!--
-								<div class="form-group search-location">
-									<input type="text" class="form-control" placeholder="Search Location">
-									<span class="form-text">Based on your Location</span>
-								</div>
-								-->
-								<div class="row" style="margin: 0 auto">
-								<div class="form search-info" >
-									<div class="cal-icon">
-										<input type="text" class="form-control datetimepicker" placeholder="选择预约日期" name="russ_request_time">
-									</div>	
-									<!--<span class="form-text">查看对应时间的空闲房间</span>-->
-									
-								</div>
-								<button type="submit" class="btn btn-primary search-btn"><i class="fas fa-search"></i> <span>Search</span></button>
-							</div>
-							</form>
+						{% include "Appointment/_room_search.html" with scope="russ" date_field="russ_request_time" %}
+						<div class="room-toolbar text-center">
+							<input type="text" class="form-control room-quick-filter" autocomplete="off"
+								placeholder="输入房间号或名称快速查找" oninput="quickFilterRooms(this)">
+							<button type="button" class="btn btn-outline-primary btn-sm room-expand-btn"
+								onclick="toggleRoomExpand(this)">一键展开</button>
+							<div class="room-filter-empty text-muted small mt-2" style="display: none;">没有匹配的房间</div>
 						</div>
-						<!-- /Search -->
 						<!--</div>
 						<div class="col-lg-8">-->
 							<div class="doctor-slider slider" >
@@ -515,6 +515,8 @@
 								</div>
 								<!-- /Doctor Widget -->
 						
+							{% empty %}
+							<div class="w-100 text-center text-muted py-4">暂无可预约的房间</div>
 							{% endfor %}	
 							</div>
 							
@@ -592,5 +594,105 @@
 		<!-- Custom JS -->
 		<script src="{% static 'Appointment/assets/js/script.js' %} "></script>
 		
+	
+		<script type="text/javascript">
+			// #974: 展开为无图网格 + 输入即时筛选，避免在手机上反复横向滑动找房间
+			function expandRoomSlider($slider) {
+				if ($slider.data("expanded")) { return; }
+				if ($slider.hasClass("slick-initialized")) {
+					$slider.slick("unslick");
+				}
+				$slider.addClass("expanded");
+				$slider.data("expanded", true);
+			}
+
+			function collapseRoomSlider($slider) {
+				if (!$slider.data("expanded")) { return; }
+				$slider.removeClass("expanded");
+				$slider.slick({ dots: false, autoplay: false, infinite: true, variableWidth: true });
+				$slider.data("expanded", false);
+			}
+
+			function filterRoomCards($section, keyword) {
+				var kw = $.trim(keyword).toLowerCase();
+				var matched = 0;
+				$section.find(".profile-widget").each(function () {
+					var hit = (kw === "" || $(this).text().toLowerCase().indexOf(kw) !== -1);
+					$(this).toggle(hit);
+					if (hit) { matched += 1; }
+				});
+				$section.find(".room-filter-empty").toggle(matched === 0 && kw !== "");
+			}
+
+			function toggleRoomExpand(btn) {
+				var $section = $(btn).closest("section");
+				var $slider = $section.find(".doctor-slider");
+				if (!$slider.data("expanded")) {
+					expandRoomSlider($slider);
+					$(btn).text("收起");
+				} else {
+					$section.find(".room-quick-filter").val("");
+					filterRoomCards($section, "");
+					collapseRoomSlider($slider);
+					$(btn).text("一键展开");
+				}
+			}
+
+			function quickFilterRooms(input) {
+				var $section = $(input).closest("section");
+				var $slider = $section.find(".doctor-slider");
+				if ($.trim(input.value) !== "") {
+					// 轮播模式下隐藏卡片会错位，输入时自动切换为网格
+					expandRoomSlider($slider);
+					$section.find(".room-expand-btn").text("收起");
+				}
+				filterRoomCards($section, input.value);
+			}
+		
+	function escapeHtml(s) {
+		return $('<div>').text(s).html();
+	}
+
+	function doRoomSearch(form) {
+		var $form = $(form);
+		var $section = $form.closest("section");
+		var $slider = $section.find(".doctor-slider");
+		// 搜索即展开为网格，便于直接看到过滤结果
+		expandRoomSlider($slider);
+		$section.find(".room-expand-btn").text("收起");
+		var fd = new FormData(form);
+		fetch(window.location.pathname, {
+			method: "POST",
+			headers: { "X-Requested-With": "XMLHttpRequest" },
+			body: fd,
+			credentials: "same-origin"
+		})
+		.then(function (resp) { return resp.json(); })
+		.then(function (data) {
+			if (data.error) {
+				$section.find(".room-search-banner").html(
+					'<div class="alert alert-warning text-center py-2">' + escapeHtml(data.error) + '</div>');
+				return;
+			}
+			$slider.html(data.cards_html);
+			$section.find(".room-search-banner").html(data.banner_html);
+			var kw = $section.find(".room-quick-filter").val();
+			if (kw) { filterRoomCards($section, kw); }
+		})
+		.catch(function (err) { console.error("地下室搜索失败", err); });
+	}
+
+	function submitRoomSearch(form, e) {
+		if (e && e.preventDefault) { e.preventDefault(); }
+		doRoomSearch(form);
+		return false;
+	}
+
+	function clearRoomSearch(btn) {
+		var $form = $(btn).closest("form");
+		$form[0].reset();
+		doRoomSearch($form[0]);
+	}
+</script>
 	</body>
 </html>


### PR DESCRIPTION
地下室预约搜索由整页刷新改为 AJAX 原地过滤（三个区块独立，由 search_scope 决定）；新增结果横幅与房间卡片片段；修复 index 视图装饰器位置与日期搜索提示。基于 upstream/develop 重建。