### PR TITLE
fix: 去除微信通知中字面 <title> 分隔符（#908）

### DIFF
--- a/extern/wechat.py
+++ b/extern/wechat.py
@@ -183,7 +183,10 @@ def send_wechat(
         if raise_on_failure:
             raise RuntimeError('WeChat message delivery failed')
         return logger.warning('没有可用用户')
-    content = f'{title}<title>{message}'
+    if message:
+        content = title + chr(10) + message
+    else:
+        content = title
     if card:
         if url is not None:
             url = build_full_url(url)


### PR DESCRIPTION
微信通知模板中去除字面的 <title> 分隔符。基于 upstream/develop 重建。